### PR TITLE
Add support for LLVM 22

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -3104,8 +3104,13 @@ static GenRet codegenCallExprInner(GenRet function,
           }
 
           case clang::CodeGen::ABIArgInfo::Kind::Expand:
-            INT_FATAL("not implemented");
+            INT_FATAL("Expand ABI argument not implemented");
             break;
+#if LLVM_VERSION_MAJOR >= 22
+            case clang::CodeGen::ABIArgInfo::Kind::TargetSpecific:
+              INT_FATAL("TargetSpecific ABI argument not implemented");
+              break;
+#endif
         }
       } else {
 
@@ -4744,9 +4749,13 @@ DEFINE_PRIM(RETURN) {
         }
 
         case clang::CodeGen::ABIArgInfo::Kind::Expand:
-          INT_FATAL("not implemented yet");
+          INT_FATAL("Expand ABI return not implemented yet");
           break;
-
+#if LLVM_VERSION_MAJOR >= 22
+        case clang::CodeGen::ABIArgInfo::Kind::TargetSpecific:
+          INT_FATAL("TargetSpecific ABI argument not implemented");
+          break;
+#endif
         // No default -> compiler warning if more added
       }
 

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2134,7 +2134,11 @@ llvmAttachReturnInfo(llvm::LLVMContext& ctx,
     case clang::CodeGen::ABIArgInfo::Kind::Expand: {
       INT_FATAL("Invalid ABI kind for return argument");
     } break;
-
+#if LLVM_VERSION_MAJOR >= 22
+    case clang::CodeGen::ABIArgInfo::Kind::TargetSpecific: {
+      INT_FATAL("TargetSpecific ABI argument not implemented");
+    } break;
+#endif
     //
     // No default -> compiler warning if more added
     //
@@ -2422,6 +2426,12 @@ codegenFunctionTypeLLVMImpl(
                                         formalInfo->type());
           pushAllFieldTypesRecursively(cname, t, argTys, outArgNames);
         } break;
+
+#if LLVM_VERSION_MAJOR >= 22
+        case clang::CodeGen::ABIArgInfo::Kind::TargetSpecific:
+          INT_FATAL("TargetSpecific ABI argument not implemented");
+          break;
+#endif
       }
 
     } else {

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -2343,6 +2343,15 @@ codegenFunctionTypeLLVMImpl(
           clang::CharUnits align = argInfo->getIndirectAlign();
           if (argInfo->getIndirectByVal()) {
             b.addAlignmentAttr(align.getQuantity());
+          } else {
+#if LLVM_VERSION_MAJOR >= 22
+            // mark dead on return for records only for non-sret indirect
+            auto isMaybeStructLike = isPrimitiveType(formalInfo->type()) &&
+                                     formalInfo->type()->symbol->hasFlag(FLAG_EXTERN);
+            if ((isRecord(formalInfo->type()) || isMaybeStructLike) &&
+                !outAttrs.hasParamAttr(i, llvm::Attribute::StructRet))
+              b.addAttribute(llvm::Attribute::DeadOnReturn);
+#endif
           }
 
           llvmAddAttr(ctx, outAttrs, argTys.size(), b);

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2880,8 +2880,11 @@ static void codegenGpuGlobals() {
 struct ChapelRemarkSerializer : public llvm::remarks::RemarkSerializer {
   ChapelRemarkSerializer(llvm::raw_ostream& OS)
       : llvm::remarks::RemarkSerializer(
-            llvm::remarks::Format::Unknown, OS,
-            llvm::remarks::SerializerMode::Standalone) {}
+            llvm::remarks::Format::Unknown, OS
+#if LLVM_VERSION_MAJOR < 22
+            , llvm::remarks::SerializerMode::Standalone
+#endif
+          ) {}
 
   void emit(const llvm::remarks::Remark& Remark) override {
 
@@ -2929,6 +2932,15 @@ struct ChapelRemarkSerializer : public llvm::remarks::RemarkSerializer {
     OS << " for '" << Remark.PassName << "'";
     OS << " - " << Remark.getArgsAsMsg() << "\n";
   }
+#if LLVM_VERSION_MAJOR >= 22
+  // just use the YAML (default) meta serializer, which gets encoded in the asm
+  std::unique_ptr<llvm::remarks::MetaSerializer> metaSerializer(
+      llvm::raw_ostream& OS,
+      llvm::StringRef ExternalFilename) override {
+    return std::make_unique<llvm::remarks::YAMLMetaSerializer>(
+        OS, ExternalFilename);
+  }
+#else
   // just use the YAML (default) meta serializer, which gets encoded in the asm
   std::unique_ptr<llvm::remarks::MetaSerializer> metaSerializer(
       llvm::raw_ostream& OS,
@@ -2936,6 +2948,7 @@ struct ChapelRemarkSerializer : public llvm::remarks::RemarkSerializer {
     return std::make_unique<llvm::remarks::YAMLMetaSerializer>(
         OS, ExternalFilename);
   }
+#endif
   private:
   std::string typeToString(llvm::remarks::Type t) {
     switch (t) {

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -40,6 +40,9 @@ namespace llvm {
   class Function;
   class Type;
   class Value;
+#if HAVE_LLVM_VER >= 220
+  enum class VectorLibrary;
+#endif
 }
 namespace clang {
   class Decl;
@@ -144,6 +147,10 @@ llvm::FunctionType*
 codegenFunctionTypeLLVM(FunctionType* ft,
                         llvm::AttributeList& outAttrs,
                         std::vector<const char*>& outArgNames);
+
+#if HAVE_LLVM_VER >= 220
+extern llvm::VectorLibrary fVectorLibLLVM;
+#endif
 
 #endif // HAVE_LLVM
 

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -148,6 +148,22 @@ codegenFunctionTypeLLVM(FunctionType* ft,
                         llvm::AttributeList& outAttrs,
                         std::vector<const char*>& outArgNames);
 
+template <typename Ty,
+          std::enable_if_t<std::is_pointer_v<Ty> &&
+                           std::is_base_of_v<clang::TypeDecl, std::remove_pointer_t<Ty>>, bool> = true>
+const clang::Type* getClangASTType(ASTContext& ctx, Ty decl) {
+#if LLVM_VERSION_MAJOR >= 22
+  if constexpr (std::is_same_v<Ty, clang::TagDecl*>) {
+    return ctx.getCanonicalTagType(decl)->getTypePtr();
+  } else {
+    return ctx.getCanonicalTypeDeclType(decl)->getTypePtr();
+  }
+#else
+  std::ignore = ctx;
+  return decl->getTypeForDecl();
+#endif
+}
+
 #if HAVE_LLVM_VER >= 220
 extern llvm::VectorLibrary fVectorLibLLVM;
 #endif

--- a/compiler/include/clangUtil.h
+++ b/compiler/include/clangUtil.h
@@ -34,6 +34,7 @@
 #if HAVE_LLVM_VER >= 160
 #include "clang/Basic/AddressSpaces.h"
 #endif
+#include "clang/AST/ASTContext.h"
 
 // forward declare some llvm and clang things
 namespace llvm {
@@ -151,7 +152,7 @@ codegenFunctionTypeLLVM(FunctionType* ft,
 template <typename Ty,
           std::enable_if_t<std::is_pointer_v<Ty> &&
                            std::is_base_of_v<clang::TypeDecl, std::remove_pointer_t<Ty>>, bool> = true>
-const clang::Type* getClangASTType(ASTContext& ctx, Ty decl) {
+const clang::Type* getClangASTType(clang::ASTContext& ctx, Ty decl) {
 #if LLVM_VERSION_MAJOR >= 22
   if constexpr (std::is_same_v<Ty, clang::TagDecl*>) {
     return ctx.getCanonicalTagType(decl)->getTypePtr();

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1615,24 +1615,24 @@ CCodeGenAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
 };
 
 static void finishClang(ClangInfo* clangInfo){
-  if( clangInfo->cCodeGen ) {
+  if (clangInfo->cCodeGen) {
     // This should call Builder->Release()
     clangInfo->cCodeGen->HandleTranslationUnit(*clangInfo->Ctx);
   }
 }
 
 static void deleteClang(ClangInfo* clangInfo){
-  if( clangInfo->cCodeGen ) {
+  if (clangInfo->cCodeGen) {
     delete clangInfo->cCodeGen;
-    clangInfo->cCodeGen = NULL;
+    clangInfo->cCodeGen = nullptr;
   }
-  if ( clangInfo->Clang ) {
+  if (clangInfo->Clang) {
     delete clangInfo->Clang;
-    clangInfo->Clang = NULL;
+    clangInfo->Clang = nullptr;
   }
-  if ( clangInfo->cCodeGenAction ) {
+  if (clangInfo->cCodeGenAction) {
     delete clangInfo->cCodeGenAction;
-    clangInfo->cCodeGenAction = NULL;
+    clangInfo->cCodeGenAction = nullptr;
   }
 }
 
@@ -1645,7 +1645,7 @@ static void cleanupClang(ClangInfo* clangInfo)
 // Initialize LLVM targets if needed
 static void initializeLlvmTargets() {
   static bool targetsInited = false;
-  if (targetsInited == false) {
+  if (!targetsInited) {
     llvm::InitializeAllTargets();
     llvm::InitializeAllTargetMCs();
     llvm::InitializeAllAsmPrinters();

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1687,7 +1687,7 @@ static std::string getConfiguredTargetTripleString() {
 static std::string getConfiguredTargetTriple() {
   return llvm::sys::getDefaultTargetTriple();
 }
-static std:string getConfiguredTargetTripleString() {
+static std::string getConfiguredTargetTripleString() {
   return getConfiguredTargetTriple();
 }
 #endif

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -209,7 +209,11 @@ struct ClangInfo {
   // Once we get to code generation....
   clang::ASTContext *Ctx;
 
+#if LLVM_VERSION_MAJOR >= 22
+  std::unique_ptr<clang::CodeGenerator> cCodeGen;
+#else
   clang::CodeGenerator *cCodeGen;
+#endif
   CCodeGenAction *cCodeGenAction;
 
   // We stash the layout that Clang would like to use here.
@@ -1347,11 +1351,7 @@ class CCodeGenConsumer final : public ASTConsumer {
   private:
     GenInfo* info;
     clang::DiagnosticsEngine* Diags;
-#if LLVM_VERSION_MAJOR >= 22
-    std::unique_ptr<clang::CodeGenerator> Builder;
-#else
     clang::CodeGenerator* Builder;
-#endif
     bool parseOnly;
     ASTContext* savedCtx;
 
@@ -1382,7 +1382,7 @@ class CCodeGenConsumer final : public ASTConsumer {
     {
 
       if (!parseOnly) {
-        Builder = CreateLLVMCodeGen(
+        info->clangInfo->cCodeGen = CreateLLVMCodeGen(
           *Diags,
           LLVM_MODULE_NAME,
 #if HAVE_LLVM_VER >= 150
@@ -1393,13 +1393,17 @@ class CCodeGenConsumer final : public ASTConsumer {
           info->clangInfo->codegenOptions,
           gContext->llvmContext());
 
-        INT_ASSERT(Builder);
-        INT_ASSERT(!info->module);
-        info->module = Builder->GetModule();
 #if LLVM_VERSION_MAJOR >= 22
-        info->clangInfo->cCodeGen = Builder.get();
+        INT_ASSERT(info->clangInfo->cCodeGen.get());
 #else
-        info->clangInfo->cCodeGen = Builder;
+        INT_ASSERT(info->clangInfo->cCodeGen);
+#endif
+        INT_ASSERT(!info->module);
+        info->module = info->clangInfo->cCodeGen->GetModule();
+#if LLVM_VERSION_MAJOR >= 22
+        Builder = info->clangInfo->cCodeGen.get();
+#else
+        Builder = info->clangInfo->cCodeGen;
 #endif
 
         // compute target triple, data layout
@@ -1623,8 +1627,13 @@ static void finishClang(ClangInfo* clangInfo){
 
 static void deleteClang(ClangInfo* clangInfo){
   if (clangInfo->cCodeGen) {
+#if LLVM_VERSION_MAJOR >= 22
+    delete clangInfo->cCodeGen.release();
+     clangInfo->cCodeGen = nullptr;
+#else
     delete clangInfo->cCodeGen;
     clangInfo->cCodeGen = nullptr;
+#endif
   }
   if (clangInfo->Clang) {
     delete clangInfo->Clang;
@@ -1855,8 +1864,7 @@ void setupClang(GenInfo* info, std::string mainFile)
   // Create the compilers actual diagnostics engine.
 #if LLVM_VERSION_MAJOR >= 20
 #if LLVM_VERSION_MAJOR >= 22
-  clangInfo->Clang->createDiagnostics(*llvm::vfs::getRealFileSystem(),
-                                     clangInfo->Clang->getDiagnosticOpts());
+  clangInfo->Clang->createDiagnostics();
 #else
   clangInfo->Clang->createDiagnostics(*llvm::vfs::getRealFileSystem());
 #endif
@@ -3536,13 +3544,16 @@ llvm::Type* getTypeLLVM(const char* name)
   return NULL;
 }
 // should support TypedefDecl,EnumDecl,RecordDecl
-llvm::Type* codegenCType(const TypeDecl* td)
-{
+llvm::Type* codegenCType(const TypeDecl* td) {
   GenInfo* info = gGenInfo;
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
+#if LLVM_VERSION_MAJOR >= 22
+  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
+#else
   clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
+#endif
   INT_ASSERT(cCodeGen);
 
   QualType qType;
@@ -3570,26 +3581,32 @@ llvm::Type* codegenCType(const TypeDecl* td)
   return clang::CodeGen::convertTypeForMemory(cCodeGen->CGM(), qType);
 }
 
-llvm::Type* codegenCType(const clang::QualType& qType)
-{
+llvm::Type* codegenCType(const clang::QualType& qType) {
   GenInfo* info = gGenInfo;
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
+#if LLVM_VERSION_MAJOR >= 22
+  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
+#else
   clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
+#endif
   INT_ASSERT(cCodeGen);
 
   return clang::CodeGen::convertTypeForMemory(cCodeGen->CGM(), qType);
 }
 
 // should support FunctionDecl,VarDecl,EnumConstantDecl
-GenRet codegenCValue(const ValueDecl *vd)
-{
+GenRet codegenCValue(const ValueDecl *vd) {
   GenInfo* info = gGenInfo;
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
+#if LLVM_VERSION_MAJOR >= 22
+  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
+#else
   clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
+#endif
   INT_ASSERT(cCodeGen);
 
   GenRet ret;
@@ -3982,13 +3999,16 @@ void LayeredValueTable::swap(LayeredValueTable* other)
 }
 
 int getCRecordMemberGEP(const char* typeName, const char* fieldName,
-                        bool& isCArrayField)
-{
+                        bool& isCArrayField) {
   GenInfo* info = gGenInfo;
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
+#if LLVM_VERSION_MAJOR >= 22
+  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
+#else
   clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
+#endif
   INT_ASSERT(cCodeGen);
 
   TypeDecl* d = NULL;
@@ -4126,13 +4146,16 @@ static clang::CanQualType getClangFormalType(ArgSymbol* formal) {
   return getClangFormalType(formal->intent, formal->type, isReceiver);
 }
 
-const clang::CodeGen::CGFunctionInfo& getClangABIInfoFD(clang::FunctionDecl* FD)
-{
+const clang::CodeGen::CGFunctionInfo& getClangABIInfoFD(clang::FunctionDecl* FD) {
   GenInfo* info = gGenInfo;
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
+#if LLVM_VERSION_MAJOR >= 22
+  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
+#else
   clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
+#endif
   INT_ASSERT(cCodeGen);
   clang::CodeGen::CodeGenModule& CGM = cCodeGen->CGM();
 
@@ -4152,7 +4175,11 @@ const clang::CodeGen::CGFunctionInfo& getClangABIInfoFD(clang::FunctionDecl* FD)
 const clang::CodeGen::CGFunctionInfo& getClangABIInfo(::FunctionType* ft) {
   auto info = gGenInfo;
   auto clangInfo = info->clangInfo;
-  auto cCodeGen = clangInfo->cCodeGen;
+#if LLVM_VERSION_MAJOR >= 22
+  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
+#else
+  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
+#endif
   INT_ASSERT(info && clangInfo && cCodeGen);
   auto& CGM = cCodeGen->CGM();
 
@@ -4194,7 +4221,11 @@ const clang::CodeGen::CGFunctionInfo& getClangABIInfo(FnSymbol* fn) {
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
+#if LLVM_VERSION_MAJOR >= 22
+  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
+#else
   clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
+#endif
   INT_ASSERT(cCodeGen);
   clang::CodeGen::CodeGenModule& CGM = cCodeGen->CGM();
 
@@ -4309,13 +4340,16 @@ bool useDarwinArmFix(::Type* type) {
 // TODO: Update `getClangABIInfo` to handle formal types and return types that
 // are not extern types.
 //
-const clang::CodeGen::ABIArgInfo*
-getSingleCGArgInfo(::Type* type) {
+const clang::CodeGen::ABIArgInfo* getSingleCGArgInfo(::Type* type) {
   GenInfo* info = gGenInfo;
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
+#if LLVM_VERSION_MAJOR >= 22
+  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
+#else
   clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
+#endif
   INT_ASSERT(cCodeGen);
   clang::CodeGen::CodeGenModule& CGM = cCodeGen->CGM();
 

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -99,6 +99,10 @@ using LlvmOptimizationLevel = llvm::OptimizationLevel;
 #include "llvm/Transforms/Instrumentation/AddressSanitizerOptions.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
 
+#if HAVE_LLVM_VER >= 220
+#include "llvm/IR/SystemLibraries.h"
+#endif
+
 
 #ifdef HAVE_LLVM_RV
 #include "rv/passes.h"
@@ -169,6 +173,10 @@ static void adjustLayoutForGlobalToWide();
 static void setupModule();
 
 fileinfo    gAllExternCode;
+
+#if HAVE_LLVM_VER >= 220
+llvm::VectorLibrary fVectorLibLLVM = llvm::VectorLibrary::NoLibrary;
+#endif
 
 // forward declare
 class CCodeGenConsumer;
@@ -1991,6 +1999,10 @@ static llvm::TargetOptions getTargetOptions(
           .Case("softfp", llvm::FloatABI::Soft)
           .Case("hard", llvm::FloatABI::Hard)
           .Default(llvm::FloatABI::Default);
+
+#if HAVE_LLVM_VER >= 220
+  Options.VecLib = fVectorLibLLVM;
+#endif
 
 
   // Set the floating point optimization level

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3107,7 +3107,7 @@ static void helpComputeClangArgs(std::string& clangCC,
     // these come from applying the format attribute to non-variadic functions,
     // which clang allows but gcc does not. we never compiler GPU code with gcc,
     // so this is fine
-    clangCCArgs.push_back("-Wno-gcc-compat ");
+    clangCCArgs.push_back("-Wno-gcc-compat");
     clangCCArgs.push_back("-DUSE_FORMAT_ATTR_FOR_NON_VARIADIC");
   }
 #endif

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -3101,6 +3101,17 @@ static void helpComputeClangArgs(std::string& clangCC,
   }
 #endif
 
+#if HAVE_LLVM_VER >= 220
+  if (usingGpuLocaleModel()) {
+    // silence warnings about gcc compat with clang 22
+    // these come from applying the format attribute to non-variadic functions,
+    // which clang allows but gcc does not. we never compiler GPU code with gcc,
+    // so this is fine
+    clangCCArgs.push_back("-Wno-gcc-compat ");
+    clangCCArgs.push_back("-DUSE_FORMAT_ATTR_FOR_NON_VARIADIC");
+  }
+#endif
+
   // Add debug flags
   if (fDebugSymbols) {
     clangCCArgs.push_back("-g");

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -246,6 +246,8 @@ struct ClangInfo {
     std::vector<std::string> clangOtherArgsIn,
     std::vector<std::string> clangLDArgsIn,
     bool parseOnlyIn);
+
+  clang::CodeGenerator* getCodeGenerator();
 };
 
 ClangInfo::ClangInfo(
@@ -274,6 +276,16 @@ ClangInfo::ClangInfo(
          ptrSizeInBits(0),
          wideCharSizeInBits(0)
 {
+}
+
+clang::CodeGenerator* ClangInfo::getCodeGenerator() {
+#if LLVM_VERSION_MAJOR >= 22
+  clang::CodeGenerator* cCodeGen = this->cCodeGen.get();
+#else
+  clang::CodeGenerator* cCodeGen = this->cCodeGen;
+#endif
+  INT_ASSERT(cCodeGen);
+  return cCodeGen;
 }
 
 static
@@ -1333,22 +1345,6 @@ void readMacrosClang(void) {
 };
 
 
-template <typename Ty,
-          std::enable_if_t<std::is_pointer_v<Ty> &&
-                           std::is_base_of_v<clang::TypeDecl, std::remove_pointer_t<Ty>>, bool> = true>
-const clang::Type* getClangASTType(ASTContext& ctx, Ty decl) {
-#if LLVM_VERSION_MAJOR >= 22
-  if constexpr (std::is_same_v<Ty, clang::TagDecl*>) {
-    return ctx.getCanonicalTagType(decl)->getTypePtr();
-  } else {
-    return ctx.getCanonicalTypeDeclType(decl)->getTypePtr();
-  }
-#else
-  std::ignore = ctx;
-  return decl->getTypeForDecl();
-#endif
-}
-
 // This ASTConsumer helps us to:
 // 1: parse code only in certain configurations
 // 2: Convert C code to LLVM IR in others
@@ -1637,7 +1633,7 @@ static void deleteClang(ClangInfo* clangInfo){
   if (clangInfo->cCodeGen) {
 #if LLVM_VERSION_MAJOR >= 22
     delete clangInfo->cCodeGen.release();
-     clangInfo->cCodeGen = nullptr;
+    clangInfo->cCodeGen = nullptr;
 #else
     delete clangInfo->cCodeGen;
     clangInfo->cCodeGen = nullptr;
@@ -1870,14 +1866,10 @@ void setupClang(GenInfo* info, std::string mainFile)
   }
 
   // Create the compilers actual diagnostics engine.
-#if LLVM_VERSION_MAJOR >= 20
-#if LLVM_VERSION_MAJOR >= 22
+#if LLVM_VERSION_MAJOR < 20 || LLVM_VERSION_MAJOR >= 22
   clangInfo->Clang->createDiagnostics();
 #else
   clangInfo->Clang->createDiagnostics(*llvm::vfs::getRealFileSystem());
-#endif
-#else
-  clangInfo->Clang->createDiagnostics();
 #endif
   if (!clangInfo->Clang->hasDiagnostics())
     INT_FATAL("Bad diagnostics from clang");
@@ -3572,12 +3564,7 @@ llvm::Type* codegenCType(const TypeDecl* td) {
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
-#if LLVM_VERSION_MAJOR >= 22
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
-#else
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
-#endif
-  INT_ASSERT(cCodeGen);
+  clang::CodeGenerator* cCodeGen = clangInfo->getCodeGenerator();
 
   QualType qType;
 
@@ -3609,12 +3596,7 @@ llvm::Type* codegenCType(const clang::QualType& qType) {
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
-#if LLVM_VERSION_MAJOR >= 22
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
-#else
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
-#endif
-  INT_ASSERT(cCodeGen);
+  clang::CodeGenerator* cCodeGen = clangInfo->getCodeGenerator();
 
   return clang::CodeGen::convertTypeForMemory(cCodeGen->CGM(), qType);
 }
@@ -3625,12 +3607,7 @@ GenRet codegenCValue(const ValueDecl *vd) {
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
-#if LLVM_VERSION_MAJOR >= 22
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
-#else
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
-#endif
-  INT_ASSERT(cCodeGen);
+  clang::CodeGenerator* cCodeGen = clangInfo->getCodeGenerator();
 
   GenRet ret;
 
@@ -4027,12 +4004,7 @@ int getCRecordMemberGEP(const char* typeName, const char* fieldName,
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
-#if LLVM_VERSION_MAJOR >= 22
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
-#else
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
-#endif
-  INT_ASSERT(cCodeGen);
+  clang::CodeGenerator* cCodeGen = clangInfo->getCodeGenerator();
 
   TypeDecl* d = NULL;
   int ret;
@@ -4174,12 +4146,7 @@ const clang::CodeGen::CGFunctionInfo& getClangABIInfoFD(clang::FunctionDecl* FD)
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
-#if LLVM_VERSION_MAJOR >= 22
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
-#else
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
-#endif
-  INT_ASSERT(cCodeGen);
+  clang::CodeGenerator* cCodeGen = clangInfo->getCodeGenerator();
   clang::CodeGen::CodeGenModule& CGM = cCodeGen->CGM();
 
   clang::CanQualType FTy = FD->getType()->getCanonicalTypeUnqualified();
@@ -4197,13 +4164,10 @@ const clang::CodeGen::CGFunctionInfo& getClangABIInfoFD(clang::FunctionDecl* FD)
 
 const clang::CodeGen::CGFunctionInfo& getClangABIInfo(::FunctionType* ft) {
   auto info = gGenInfo;
+  INT_ASSERT(info);
   auto clangInfo = info->clangInfo;
-#if LLVM_VERSION_MAJOR >= 22
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
-#else
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
-#endif
-  INT_ASSERT(info && clangInfo && cCodeGen);
+  INT_ASSERT(clangInfo);
+  clang::CodeGenerator* cCodeGen = clangInfo->getCodeGenerator();
   auto& CGM = cCodeGen->CGM();
 
   // Otherwise, we should call arrangeFreeFunctionCall
@@ -4244,12 +4208,7 @@ const clang::CodeGen::CGFunctionInfo& getClangABIInfo(FnSymbol* fn) {
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
-#if LLVM_VERSION_MAJOR >= 22
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
-#else
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
-#endif
-  INT_ASSERT(cCodeGen);
+  clang::CodeGenerator* cCodeGen = clangInfo->getCodeGenerator();
   clang::CodeGen::CodeGenModule& CGM = cCodeGen->CGM();
 
   // Lookup the clang AST for this function so we can
@@ -4368,12 +4327,7 @@ const clang::CodeGen::ABIArgInfo* getSingleCGArgInfo(::Type* type) {
   INT_ASSERT(info);
   ClangInfo* clangInfo = info->clangInfo;
   INT_ASSERT(clangInfo);
-#if LLVM_VERSION_MAJOR >= 22
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen.get();
-#else
-  clang::CodeGenerator* cCodeGen = clangInfo->cCodeGen;
-#endif
-  INT_ASSERT(cCodeGen);
+  clang::CodeGenerator* cCodeGen = clangInfo->getCodeGenerator();
   clang::CodeGen::CodeGenModule& CGM = cCodeGen->CGM();
 
   llvm::SmallVector<clang::CanQualType,4> argTypesC;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1320,6 +1320,23 @@ void readMacrosClang(void) {
   }
 };
 
+
+template <typename Ty,
+          std::enable_if_t<std::is_pointer_v<Ty> &&
+                           std::is_base_of_v<clang::TypeDecl, std::remove_pointer_t<Ty>>, bool> = true>
+const clang::Type* getClangASTType(ASTContext& ctx, Ty decl) {
+#if LLVM_VERSION_MAJOR >= 22
+  if constexpr (std::is_same_v<Ty, clang::TagDecl*>) {
+    return ctx.getCanonicalTagType(decl)->getTypePtr();
+  } else {
+    return ctx.getCanonicalTypeDeclType(decl)->getTypePtr();
+  }
+#else
+  std::ignore ctx;
+  return decl->getTypeForDecl();
+#endif
+}
+
 // This ASTConsumer helps us to:
 // 1: parse code only in certain configurations
 // 2: Convert C code to LLVM IR in others
@@ -1330,7 +1347,11 @@ class CCodeGenConsumer final : public ASTConsumer {
   private:
     GenInfo* info;
     clang::DiagnosticsEngine* Diags;
+#if LLVM_VERSION_MAJOR >= 22
+    std::unique_ptr<clang::CodeGenerator> Builder;
+#else
     clang::CodeGenerator* Builder;
+#endif
     bool parseOnly;
     ASTContext* savedCtx;
 
@@ -1355,9 +1376,9 @@ class CCodeGenConsumer final : public ASTConsumer {
       : ASTConsumer(),
         info(gGenInfo),
         Diags(&info->clangInfo->Clang->getDiagnostics()),
-        Builder(NULL),
+        Builder(nullptr),
         parseOnly(info->clangInfo->parseOnly),
-        savedCtx(NULL)
+        savedCtx(nullptr)
     {
 
       if (!parseOnly) {
@@ -1375,7 +1396,11 @@ class CCodeGenConsumer final : public ASTConsumer {
         INT_ASSERT(Builder);
         INT_ASSERT(!info->module);
         info->module = Builder->GetModule();
+#if LLVM_VERSION_MAJOR >= 22
+        info->clangInfo->cCodeGen = Builder.get();
+#else
         info->clangInfo->cCodeGen = Builder;
+#endif
 
         // compute target triple, data layout
         setupModule();
@@ -1486,7 +1511,7 @@ class CCodeGenConsumer final : public ASTConsumer {
            info->lvt->addGlobalCDecl(*e); // & goes away with newer clang
          }
       } else if(RecordDecl *rd = dyn_cast<RecordDecl>(D)) {
-         const clang::Type *ctype = rd->getTypeForDecl();
+         const clang::Type *ctype = getClangASTType(rd->getASTContext(), rd);
 
          if(ctype != NULL && rd->getDefinition() != NULL) {
            info->lvt->addGlobalCDecl(rd);
@@ -1632,11 +1657,23 @@ static void initializeLlvmTargets() {
 
 // Get a string corresponding to the LLVM target triple
 // for the current configuration
+// TODO: use a different triple when cross compiling
+// TODO: look at CHPL_TARGET_ARCH
+#if LLVM_VERSION_MAJOR >= 22
+static llvm::Triple getConfiguredTargetTriple() {
+  return llvm::Triple(llvm::sys::getDefaultTargetTriple());
+}
+static std::string getConfiguredTargetTripleString() {
+  return getConfiguredTargetTriple().str();
+}
+#else
 static std::string getConfiguredTargetTriple() {
-  // TODO: use a different triple when cross compiling
-  // TODO: look at CHPL_TARGET_ARCH
   return llvm::sys::getDefaultTargetTriple();
 }
+static std:string getConfiguredTargetTripleString() {
+  return getConfiguredTargetTriple();
+}
+#endif
 
 
 void setupClang(GenInfo* info, std::string mainFile)
@@ -1675,7 +1712,7 @@ void setupClang(GenInfo* info, std::string mainFile)
   // target CPU supports vectorization, avx, etc, etc
   // Also important for generating assembly from this program.
   initializeLlvmTargets();
-  std::string triple = getConfiguredTargetTriple();
+  std::string triple = getConfiguredTargetTripleString();
 
   for (auto & arg : clangInfo->driverArgs) {
     clangInfo->driverArgsCStrings.push_back(arg.c_str());
@@ -1817,7 +1854,12 @@ void setupClang(GenInfo* info, std::string mainFile)
 
   // Create the compilers actual diagnostics engine.
 #if LLVM_VERSION_MAJOR >= 20
+#if LLVM_VERSION_MAJOR >= 22
+  clangInfo->Clang->createDiagnostics(*llvm::vfs::getRealFileSystem(),
+                                     clangInfo->Clang->getDiagnosticOpts());
+#else
   clangInfo->Clang->createDiagnostics(*llvm::vfs::getRealFileSystem());
+#endif
 #else
   clangInfo->Clang->createDiagnostics();
 #endif
@@ -1949,12 +1991,19 @@ static llvm::TargetOptions getTargetOptions(
   if (ffloatOpt == 1) {
     // --no-ieee-float
     // Allow unsafe fast floating point optimization
+#if LLVM_VERSION_MAJOR < 22
+    // NOTE (Jade 3-18-26): its not clear why LLVM removed "UnsafeFPMath", and
+    // what the proper replacement is, if any.
+    // They may have removed it due to it being redudant and so
+    // everything may just work fine
     Options.UnsafeFPMath = 1; // e.g. FSIN instruction
+#endif
     Options.NoInfsFPMath = 1;
     Options.NoNaNsFPMath = 1;
     Options.NoTrappingFPMath = 1;
     Options.NoSignedZerosFPMath = 1;
     Options.AllowFPOpFusion = llvm::FPOpFusion::Fast;
+
   } else if (ffloatOpt == 0) {
     // Target default floating point optimization
     Options.AllowFPOpFusion = llvm::FPOpFusion::Standard;
@@ -2127,7 +2176,11 @@ static void setupModule()
 
   // Set the TargetMachine
   std::string Err;
+#if LLVM_VERSION_MAJOR >= 22
+  const llvm::Target* Target = TargetRegistry::lookupTarget(Triple, Err);
+#else
   const llvm::Target* Target = TargetRegistry::lookupTarget(Triple.str(), Err);
+#endif
   if (!Target)
     USR_FATAL("Could not find LLVM target for %s: %s",
               Triple.str().c_str(), Err.c_str());
@@ -2852,7 +2905,7 @@ static bool isTargetCpuValid(const char* targetCpu) {
     return true;
   } else {
     initializeLlvmTargets();
-    std::string triple = getConfiguredTargetTriple();
+    auto triple = getConfiguredTargetTriple();
     std::string err;
     const llvm::Target* tgt = llvm::TargetRegistry::lookupTarget(triple, err);
     if (tgt == nullptr || !err.empty()) {
@@ -3067,7 +3120,7 @@ static void helpComputeClangArgs(std::string& clangCC,
     if (!targetCpuValid) {
       USR_WARN("Unknown target CPU %s -- not specializing",
                CHPL_LLVM_TARGET_CPU);
-      std::string triple = getConfiguredTargetTriple();
+      std::string triple = getConfiguredTargetTripleString();
       USR_PRINT("To see available CPU types, run "
                 "%s --target=%s --print-supported-cpus",
                 clangCC.c_str(), triple.c_str());
@@ -3503,9 +3556,13 @@ llvm::Type* codegenCType(const TypeDecl* td)
     RecordDecl *def = rd->getDefinition();
     if (def == nullptr) {
       // it's an opaque type - definition of fields not available
-      qType=rd->getCanonicalDecl()->getTypeForDecl()->getCanonicalTypeInternal();
+      qType
+        = getClangASTType(rd->getASTContext(),
+                          rd->getCanonicalDecl())->getCanonicalTypeInternal();
     } else {
-      qType=def->getCanonicalDecl()->getTypeForDecl()->getCanonicalTypeInternal();
+      qType
+        = getClangASTType(def->getASTContext(),
+                          def->getCanonicalDecl())->getCanonicalTypeInternal();
     }
   } else {
     INT_FATAL("Unknown clang type declaration");
@@ -3803,7 +3860,9 @@ llvm::Type *LayeredValueTable::getType(StringRef name, bool *isUnsigned) {
 
       // Convert it to an LLVM type.
       store->u.type = codegenCType(store->u.cTypeDecl);
-      const clang::Type *type = store->u.cTypeDecl->getTypeForDecl();
+      const clang::Type *type =
+        getClangASTType(store->u.cTypeDecl->getASTContext(),
+                        store->u.cTypeDecl);
       if (type != NULL) {
         store->isUnsigned = type->isUnsignedIntegerOrEnumerationType();
       }
@@ -4306,8 +4365,9 @@ int getCTypeAlignment(::Type* type) {
       if (def == nullptr)
         // ex. opaque pointer in test/extern/records/OpaqueStructNoField.chpl
         return ALIGNMENT_DEFER;
-      qType=def->getCanonicalDecl()->getTypeForDecl()
-               ->getCanonicalTypeInternal();
+      qType =
+        getClangASTType(def->getASTContext(),
+                        def->getCanonicalDecl())->getCanonicalTypeInternal();
     } else {
       INT_FATAL(type, "Unhandled Clang type declaration");
     }

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -1344,7 +1344,7 @@ const clang::Type* getClangASTType(ASTContext& ctx, Ty decl) {
     return ctx.getCanonicalTypeDeclType(decl)->getTypePtr();
   }
 #else
-  std::ignore ctx;
+  std::ignore = ctx;
   return decl->getTypeForDecl();
 #endif
 }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -64,6 +64,9 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
+#if HAVE_LLVM_VER >= 220
+#include "llvm/IR/SystemLibraries.h"
+#endif
 #endif
 
 
@@ -2206,10 +2209,20 @@ struct VectorLibraryInfo {
     std::string llvmBackendName;
     std::string clangBackendName;
     std::string gccBackendName;
+#if HAVE_LLVM_VER >= 220
+    llvm::VectorLibrary llvmLib;
+    KnownVectorLib(std::string name, std::string llvmBackendName,
+                   std::string clangBackendName, std::string gccBackendName,
+                   llvm::VectorLibrary llvmLib)
+      : name(name), llvmBackendName(llvmBackendName),
+        clangBackendName(clangBackendName), gccBackendName(gccBackendName),
+        llvmLib(llvmLib) {}
+#else
     KnownVectorLib(std::string name, std::string llvmBackendName,
                    std::string clangBackendName, std::string gccBackendName)
       : name(name), llvmBackendName(llvmBackendName),
         clangBackendName(clangBackendName), gccBackendName(gccBackendName) {}
+#endif
     std::string getBackendName() {
       if (0 == strcmp(CHPL_TARGET_COMPILER, "llvm")) {
         return llvmBackendName;
@@ -2223,12 +2236,17 @@ struct VectorLibraryInfo {
     }
   };
 
+#if HAVE_LLVM_VER >= 220
+  static inline const auto libmvec = KnownVectorLib("libmvec", "LIBMVEC", "libmvec", "", llvm::VectorLibrary::LIBMVEC);
+  static inline const auto darwinLibSystemM = KnownVectorLib("darwinLibSystemM", "Darwin_libsystem_m", "Darwin_libsystem_m", "", llvm::VectorLibrary::DarwinLibSystemM);
+#else
 #if HAVE_LLVM_VER < 210
   static inline const auto libmvec = KnownVectorLib("libmvec", "LIBMVEC-X86", "libmvec", "");
 #else
   static inline const auto libmvec = KnownVectorLib("libmvec", "LIBMVEC", "libmvec", "");
 #endif
   static inline const auto darwinLibSystemM = KnownVectorLib("darwinLibSystemM", "Darwin_libsystem_m", "Darwin_libsystem_m", "");
+#endif
 
   static std::optional<KnownVectorLib> getKnownVectorLib(const std::string& vecLib) {
     static std::array<KnownVectorLib, 2> knownVectorLibs = {libmvec, darwinLibSystemM};
@@ -2241,10 +2259,10 @@ struct VectorLibraryInfo {
   }
   static std::optional<std::string> getBackendVectorLibFlag() {
     if (0 == strcmp(CHPL_TARGET_COMPILER, "llvm")) {
-#if HAVE_LLVM_VER < 220
-      return "-vector-library=";
+#if HAVE_LLVM_VER >= 220
+      return "DELAYED";
 #else
-      return "--vector-library=";
+      return "-vector-library=";
 #endif
     } else if (0 == strcmp(CHPL_TARGET_COMPILER, "clang")) {
       return "-fveclib=";
@@ -2275,20 +2293,26 @@ static void setVectorLib() {
              fVectorLib.c_str(), flagName.value().c_str(), flagValue.c_str());
   }
 
-
-  if (0 == strcmp(CHPL_TARGET_COMPILER, "llvm")) {
-    if (llvmFlags.length() > 0)
-      llvmFlags += ' ';
-    llvmFlags += flagName.value();
-    llvmFlags += flagValue;
+  if (flagName.value() != "DELAYED") {
+    if (0 == strcmp(CHPL_TARGET_COMPILER, "llvm")) {
+      if (llvmFlags.length() > 0)
+        llvmFlags += ' ';
+      llvmFlags += flagName.value();
+      llvmFlags += flagValue;
+    } else {
+      if (ccflags.length() > 0)
+        ccflags += ' ';
+      ccflags += flagName.value();
+      ccflags += flagValue;
+    }
   } else {
-    if (ccflags.length() > 0)
-      ccflags += ' ';
-    ccflags += flagName.value();
-    ccflags += flagValue;
+#if HAVE_LLVM_VER >= 220
+  if (knownLib.has_value()) {
+    fVectorLibLLVM = knownLib.value().llvmLib;
+  }
+#endif
   }
 }
-
 // Check for inconsistencies in compiler-driver control flags
 static void checkCompilerDriverFlags() {
   if (fDriverDoMonolithic) {

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -741,7 +741,10 @@ static void setLLVMFlags(const ArgumentDescription* desc, const char* arg) {
 
   llvmFlags += arg;
 
-  if (0 == strcmp(arg, "--help")) {
+  if (0 == strcmp(arg, "--help-hidden")) {
+    std::vector<const char*> Args = {"chpl --mllvm", "--help-hidden", nullptr};
+    llvm::cl::ParseCommandLineOptions(Args.size()-1, &Args[0]);
+  } else if (0 == strcmp(arg, "--help")) {
     std::vector<const char*> Args = {"chpl --mllvm", "--help", nullptr};
     llvm::cl::ParseCommandLineOptions(Args.size()-1, &Args[0]);
   }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2238,7 +2238,11 @@ struct VectorLibraryInfo {
   }
   static std::optional<std::string> getBackendVectorLibFlag() {
     if (0 == strcmp(CHPL_TARGET_COMPILER, "llvm")) {
+#if HAVE_LLVM_VER < 220
       return "-vector-library=";
+#else
+      return "--vector-library=";
+#endif
     } else if (0 == strcmp(CHPL_TARGET_COMPILER, "clang")) {
       return "-fveclib=";
     } else if (0 == strcmp(CHPL_TARGET_COMPILER, "gnu")) {

--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -35,6 +35,7 @@
 
 #ifdef HAVE_LLVM
 // clang headers
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Type.h"
 #include "llvm/ADT/SmallSet.h"
@@ -486,7 +487,12 @@ void convertDeclToChpl(ModuleSymbol* module,
   //struct
   if (clang::RecordDecl *rd =
       llvm::dyn_cast_or_null<clang::RecordDecl>(cType)) {
+#if LLVM_VERSION_MAJOR >= 22
+    auto& ctx = rd->getASTContext();
+    convertToChplType(module, ctx.getCanonicalTagType(rd)->getTypePtr());
+#else
     convertToChplType(module, rd->getTypeForDecl());
+#endif
   }
 
   //enum constant

--- a/compiler/passes/externCResolve.cpp
+++ b/compiler/passes/externCResolve.cpp
@@ -487,12 +487,8 @@ void convertDeclToChpl(ModuleSymbol* module,
   //struct
   if (clang::RecordDecl *rd =
       llvm::dyn_cast_or_null<clang::RecordDecl>(cType)) {
-#if LLVM_VERSION_MAJOR >= 22
     auto& ctx = rd->getASTContext();
-    convertToChplType(module, ctx.getCanonicalTagType(rd)->getTypePtr());
-#else
-    convertToChplType(module, rd->getTypeForDecl());
-#endif
+    convertToChplType(module, getClangASTType(ctx, rd));
   }
 
   //enum constant

--- a/frontend/lib/util/clang-integration.cpp
+++ b/frontend/lib/util/clang-integration.cpp
@@ -35,7 +35,9 @@
 #include "clang/Driver/Compilation.h"
 #include "clang/Driver/Driver.h"
 #include "clang/Driver/Job.h"
+#if LLVM_VERSION_MAJOR <= 21
 #include "clang/Driver/Options.h"
+#endif
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/FrontendActions.h"
@@ -530,7 +532,11 @@ static owned<clang::CompilerInstance> getCompilerInstanceForReadingPch(
     )
   );
   Clang->createFileManager();
+#if LLVM_VERSION_MAJOR >= 22
+  Clang->createSourceManager();
+#else
   Clang->createSourceManager(Clang->getFileManager());
+#endif
   Clang->createPreprocessor(clang::TU_Complete);
 
   return toOwned(Clang);

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -104,53 +104,52 @@ __device__ static inline void chpl_gen_comm_getput_unordered(
 
 MAYBE_GPU static inline void chpl_gpu_write(const char *str) { printf("%s", str); }
 
-__attribute__ ((format_arg (1)))
 MAYBE_GPU static inline void chpl_gpu_printf0(const char *fmt) {
   printf("%s", fmt);
 }
-__attribute__ ((format_arg (1)))
+[[gnu::format(printf, 1, 2)]]
 MAYBE_GPU static inline void chpl_gpu_printf1(const char *fmt,
  void *x1)
 {
   printf(fmt, x1);
 }
-__attribute__ ((format_arg (1)))
+[[gnu::format(printf, 1, 2)]]
 MAYBE_GPU static inline void chpl_gpu_printf2(const char *fmt,
   void *x1, void *x2)
 {
   printf(fmt, x1, x2);
 }
-__attribute__ ((format_arg (1)))
+[[gnu::format(printf, 1, 2)]]
 MAYBE_GPU static inline void chpl_gpu_printf3(const char *fmt,
   void *x1, void *x2, void *x3)
 {
   printf(fmt, x1, x2, x3);
 }
-__attribute__ ((format_arg (1)))
+[[gnu::format(printf, 1, 2)]]
 MAYBE_GPU static inline void chpl_gpu_printf4(const char *fmt,
   void *x1, void *x2, void *x3, void *x4)
 {
   printf(fmt, x1, x2, x3, x4);
 }
-__attribute__ ((format_arg (1)))
+[[gnu::format(printf, 1, 2)]]
 MAYBE_GPU static inline void chpl_gpu_printf5(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5)
 {
   printf(fmt, x1, x2, x3, x4, x5);
 }
-__attribute__ ((format_arg (1)))
+[[gnu::format(printf, 1, 2)]]
 MAYBE_GPU static inline void chpl_gpu_printf6(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6);
 }
-__attribute__ ((format_arg (1)))
+[[gnu::format(printf, 1, 2)]]
 MAYBE_GPU static inline void chpl_gpu_printf7(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6, x7);
 }
-__attribute__ ((format_arg (1)))
+[[gnu::format(printf, 1, 2)]]
 MAYBE_GPU static inline void chpl_gpu_printf8(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7,
   void *x8)

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -107,43 +107,36 @@ MAYBE_GPU static inline void chpl_gpu_write(const char *str) { printf("%s", str)
 MAYBE_GPU static inline void chpl_gpu_printf0(const char *fmt) {
   printf("%s", fmt);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf1(const char *fmt,
  void *x1)
 {
   printf(fmt, x1);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf2(const char *fmt,
   void *x1, void *x2)
 {
   printf(fmt, x1, x2);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf3(const char *fmt,
   void *x1, void *x2, void *x3)
 {
   printf(fmt, x1, x2, x3);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf4(const char *fmt,
   void *x1, void *x2, void *x3, void *x4)
 {
   printf(fmt, x1, x2, x3, x4);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf5(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5)
 {
   printf(fmt, x1, x2, x3, x4, x5);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf6(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf7(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7)
 {
@@ -152,7 +145,6 @@ MAYBE_GPU static inline void chpl_gpu_printf7(const char *fmt,
 MAYBE_GPU static inline void chpl_gpu_printf8(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7,
   void *x8)
-__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3, x4, x5, x6, x7, x8);
 }

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -104,44 +104,53 @@ __device__ static inline void chpl_gen_comm_getput_unordered(
 
 MAYBE_GPU static inline void chpl_gpu_write(const char *str) { printf("%s", str); }
 
+__attribute__ ((format_arg (1)))
 MAYBE_GPU static inline void chpl_gpu_printf0(const char *fmt) {
   printf("%s", fmt);
 }
+__attribute__ ((format_arg (1)))
 MAYBE_GPU static inline void chpl_gpu_printf1(const char *fmt,
  void *x1)
 {
   printf(fmt, x1);
 }
+__attribute__ ((format_arg (1)))
 MAYBE_GPU static inline void chpl_gpu_printf2(const char *fmt,
   void *x1, void *x2)
 {
   printf(fmt, x1, x2);
 }
+__attribute__ ((format_arg (1)))
 MAYBE_GPU static inline void chpl_gpu_printf3(const char *fmt,
   void *x1, void *x2, void *x3)
 {
   printf(fmt, x1, x2, x3);
 }
+__attribute__ ((format_arg (1)))
 MAYBE_GPU static inline void chpl_gpu_printf4(const char *fmt,
   void *x1, void *x2, void *x3, void *x4)
 {
   printf(fmt, x1, x2, x3, x4);
 }
+__attribute__ ((format_arg (1)))
 MAYBE_GPU static inline void chpl_gpu_printf5(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5)
 {
   printf(fmt, x1, x2, x3, x4, x5);
 }
+__attribute__ ((format_arg (1)))
 MAYBE_GPU static inline void chpl_gpu_printf6(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6);
 }
+__attribute__ ((format_arg (1)))
 MAYBE_GPU static inline void chpl_gpu_printf7(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6, x7);
 }
+__attribute__ ((format_arg (1)))
 MAYBE_GPU static inline void chpl_gpu_printf8(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7,
   void *x8)

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -102,54 +102,60 @@ __device__ static inline void chpl_gen_comm_getput_unordered(
   // TODO
 }
 
+#ifdef USE_FORMAT_ATTR_FOR_NON_VARIADIC
+#define GPU_PRINT_ATTR __attribute__ ((format (printf, 1, 2)))
+#else
+#define GPU_PRINT_ATTR
+#endif
+
 MAYBE_GPU static inline void chpl_gpu_write(const char *str) { printf("%s", str); }
 
 MAYBE_GPU static inline void chpl_gpu_printf0(const char *fmt) {
   printf("%s", fmt);
 }
-__attribute__ ((format (printf, 1, 2)))
+GPU_PRINT_ATTR
 MAYBE_GPU static inline void chpl_gpu_printf1(const char *fmt,
  void *x1)
 {
   printf(fmt, x1);
 }
-__attribute__ ((format (printf, 1, 2)))
+GPU_PRINT_ATTR
 MAYBE_GPU static inline void chpl_gpu_printf2(const char *fmt,
   void *x1, void *x2)
 {
   printf(fmt, x1, x2);
 }
-__attribute__ ((format (printf, 1, 2)))
+GPU_PRINT_ATTR
 MAYBE_GPU static inline void chpl_gpu_printf3(const char *fmt,
   void *x1, void *x2, void *x3)
 {
   printf(fmt, x1, x2, x3);
 }
-__attribute__ ((format (printf, 1, 2)))
+GPU_PRINT_ATTR
 MAYBE_GPU static inline void chpl_gpu_printf4(const char *fmt,
   void *x1, void *x2, void *x3, void *x4)
 {
   printf(fmt, x1, x2, x3, x4);
 }
-__attribute__ ((format (printf, 1, 2)))
+GPU_PRINT_ATTR
 MAYBE_GPU static inline void chpl_gpu_printf5(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5)
 {
   printf(fmt, x1, x2, x3, x4, x5);
 }
-__attribute__ ((format (printf, 1, 2)))
+GPU_PRINT_ATTR
 MAYBE_GPU static inline void chpl_gpu_printf6(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6);
 }
-__attribute__ ((format (printf, 1, 2)))
+GPU_PRINT_ATTR
 MAYBE_GPU static inline void chpl_gpu_printf7(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6, x7);
 }
-__attribute__ ((format (printf, 1, 2)))
+GPU_PRINT_ATTR
 MAYBE_GPU static inline void chpl_gpu_printf8(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7,
   void *x8)

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -107,49 +107,49 @@ MAYBE_GPU static inline void chpl_gpu_write(const char *str) { printf("%s", str)
 MAYBE_GPU static inline void chpl_gpu_printf0(const char *fmt) {
   printf("%s", fmt);
 }
-[[gnu::format(printf, 1, 2)]]
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf1(const char *fmt,
  void *x1)
 {
   printf(fmt, x1);
 }
-[[gnu::format(printf, 1, 2)]]
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf2(const char *fmt,
   void *x1, void *x2)
 {
   printf(fmt, x1, x2);
 }
-[[gnu::format(printf, 1, 2)]]
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf3(const char *fmt,
   void *x1, void *x2, void *x3)
 {
   printf(fmt, x1, x2, x3);
 }
-[[gnu::format(printf, 1, 2)]]
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf4(const char *fmt,
   void *x1, void *x2, void *x3, void *x4)
 {
   printf(fmt, x1, x2, x3, x4);
 }
-[[gnu::format(printf, 1, 2)]]
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf5(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5)
 {
   printf(fmt, x1, x2, x3, x4, x5);
 }
-[[gnu::format(printf, 1, 2)]]
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf6(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6);
 }
-[[gnu::format(printf, 1, 2)]]
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf7(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6, x7);
 }
-[[gnu::format(printf, 1, 2)]]
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf8(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7,
   void *x8)

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -114,37 +114,44 @@ MAYBE_GPU static inline void chpl_gpu_printf1(const char *fmt,
 }
 MAYBE_GPU static inline void chpl_gpu_printf2(const char *fmt,
   void *x1, void *x2)
+__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2);
 }
 MAYBE_GPU static inline void chpl_gpu_printf3(const char *fmt,
   void *x1, void *x2, void *x3)
+__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3);
 }
 MAYBE_GPU static inline void chpl_gpu_printf4(const char *fmt,
   void *x1, void *x2, void *x3, void *x4)
+__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3, x4);
 }
 MAYBE_GPU static inline void chpl_gpu_printf5(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5)
+__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3, x4, x5);
 }
 MAYBE_GPU static inline void chpl_gpu_printf6(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6)
+__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3, x4, x5, x6);
 }
 MAYBE_GPU static inline void chpl_gpu_printf7(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7)
+__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3, x4, x5, x6, x7);
 }
 MAYBE_GPU static inline void chpl_gpu_printf8(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7,
   void *x8)
+__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3, x4, x5, x6, x7, x8);
 }

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -107,41 +107,49 @@ MAYBE_GPU static inline void chpl_gpu_write(const char *str) { printf("%s", str)
 MAYBE_GPU static inline void chpl_gpu_printf0(const char *fmt) {
   printf("%s", fmt);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf1(const char *fmt,
  void *x1)
 {
   printf(fmt, x1);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf2(const char *fmt,
   void *x1, void *x2)
 {
   printf(fmt, x1, x2);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf3(const char *fmt,
   void *x1, void *x2, void *x3)
 {
   printf(fmt, x1, x2, x3);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf4(const char *fmt,
   void *x1, void *x2, void *x3, void *x4)
 {
   printf(fmt, x1, x2, x3, x4);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf5(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5)
 {
   printf(fmt, x1, x2, x3, x4, x5);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf6(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf7(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6, x7);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf8(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7,
   void *x8)

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -107,44 +107,45 @@ MAYBE_GPU static inline void chpl_gpu_write(const char *str) { printf("%s", str)
 MAYBE_GPU static inline void chpl_gpu_printf0(const char *fmt) {
   printf("%s", fmt);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf1(const char *fmt,
  void *x1)
 {
   printf(fmt, x1);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf2(const char *fmt,
   void *x1, void *x2)
-__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf3(const char *fmt,
   void *x1, void *x2, void *x3)
-__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf4(const char *fmt,
   void *x1, void *x2, void *x3, void *x4)
-__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3, x4);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf5(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5)
-__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3, x4, x5);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf6(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6)
-__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3, x4, x5, x6);
 }
+__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf7(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7)
-__attribute__ ((format (printf, 1, 2)))
 {
   printf(fmt, x1, x2, x3, x4, x5, x6, x7);
 }

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -107,49 +107,41 @@ MAYBE_GPU static inline void chpl_gpu_write(const char *str) { printf("%s", str)
 MAYBE_GPU static inline void chpl_gpu_printf0(const char *fmt) {
   printf("%s", fmt);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf1(const char *fmt,
  void *x1)
 {
   printf(fmt, x1);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf2(const char *fmt,
   void *x1, void *x2)
 {
   printf(fmt, x1, x2);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf3(const char *fmt,
   void *x1, void *x2, void *x3)
 {
   printf(fmt, x1, x2, x3);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf4(const char *fmt,
   void *x1, void *x2, void *x3, void *x4)
 {
   printf(fmt, x1, x2, x3, x4);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf5(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5)
 {
   printf(fmt, x1, x2, x3, x4, x5);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf6(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf7(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7)
 {
   printf(fmt, x1, x2, x3, x4, x5, x6, x7);
 }
-__attribute__ ((format (printf, 1, 2)))
 MAYBE_GPU static inline void chpl_gpu_printf8(const char *fmt,
   void *x1, void *x2, void *x3, void *x4, void *x5, void *x6, void *x7,
   void *x8)

--- a/runtime/src/gpu/amd/Makefile.share
+++ b/runtime/src/gpu/amd/Makefile.share
@@ -26,6 +26,14 @@ RUNTIME_CXXFLAGS += -x hip --offload-arch=$(CHPL_MAKE_GPU_ARCH)
 # Some ROCm headers have `foo()`, suppress warnings/errors from them
 RUNTIME_CFLAGS += -Wno-strict-prototypes
 
+# silence warnings about gcc compat with clang 22
+# these come from applying the format attribute to non-variadic functions,
+# which clang allows but gcc does not. we never compiler GPU code with gcc,
+# so this is fine
+ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -ge 22; echo "$$?"),0)
+	RUNTIME_CXXFLAGS += -Wno-error=gcc-compat -DUSE_FORMAT_ATTR_FOR_NON_VARIADIC
+endif
+
 $(RUNTIME_OBJ_DIR)/gpu-amd-cub.o: gpu-amd-cub.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)
 	PATH=$(PATH):$(CHPL_MAKE_ROCM_LLVM_PATH)/bin $(CXX) -c $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -std=c++17 -o $@ $<

--- a/runtime/src/gpu/cpu/Makefile.share
+++ b/runtime/src/gpu/cpu/Makefile.share
@@ -20,3 +20,11 @@ SRCS = gpu-cpu.c
 GPU_SRCS = gpu-cpu.c
 
 GPU_OBJS = $(GPU_SRCS:%.c=$(GPU_OBJDIR)/%.o)
+
+# silence warnings about gcc compat with clang 22
+# these come from applying the format attribute to non-variadic functions,
+# which clang allows but gcc does not. we never compiler GPU code with gcc,
+# so this is fine
+ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -ge 22; echo "$$?"),0)
+	RUNTIME_CXXFLAGS += -Wno-error=gcc-compat -DUSE_FORMAT_ATTR_FOR_NON_VARIADIC
+endif

--- a/runtime/src/gpu/nvidia/Makefile.share
+++ b/runtime/src/gpu/nvidia/Makefile.share
@@ -38,6 +38,14 @@ ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -ge 15; echo "$$?"),0)
 			    -Wno-error=unknown-pragmas
 endif
 
+# silence warnings about gcc compat with clang 22
+# these come from applying the format attribute to non-variadic functions,
+# which clang allows but gcc does not. we never compiler GPU code with gcc,
+# so this is fine
+ifeq ($(shell test $(CHPL_MAKE_LLVM_VERSION) -ge 22; echo "$$?"),0)
+	RUNTIME_CXXFLAGS += -Wno-error=gcc-compat -DUSE_FORMAT_ATTR_FOR_NON_VARIADIC
+endif
+
 $(RUNTIME_OBJ_DIR)/gpu-nvidia-cub.o: gpu-nvidia-cub.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)
 	$(CXX) -c $(CXX11_STD) $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -o $@ $<

--- a/test/gpu/native/deviceAttributes.hip.c
+++ b/test/gpu/native/deviceAttributes.hip.c
@@ -1,5 +1,8 @@
 #include "deviceAttributes.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #ifndef __HIP_PLATFORM_AMD__
 #define __HIP_PLATFORM_AMD__
 #endif

--- a/test/llvm/abi/aarch64-darwin/export-vs-c-llvm22.good
+++ b/test/llvm/abi/aarch64-darwin/export-vs-c-llvm22.good
@@ -1,0 +1,206 @@
+OUTPUT testing abistructfunc_c_____
+OUTPUT testing abistructfunc_c_____: e 0 f 1 s.a 2 s.b 3 s.d 12.250000 g 4 h -5 ld 66.000000 m 1.125000n 10000.000000 i 7 j 8 k -1
+OUTPUT testing abistructfunc_chapel
+OUTPUT testing abistructfunc_chapel: e 0 f 1 s.a 2 s.b 3 s.d 12.250000 g 4 h -5 ld 66.000000 m 1.125000n 10000.000000 i 7 j 8 k -1
+OUTPUT testing bool_..._c_____
+OUTPUT testing bool_..._c_____: arg 1
+OUTPUT testing bool_..._chapel
+OUTPUT testing bool_..._chapel: arg 1
+OUTPUT testing complexd_..._c_____
+OUTPUT testing complexd_..._c_____: arg 1.000000 0.000000
+OUTPUT testing complexd_..._chapel
+OUTPUT testing complexd_..._chapel: arg 1.000000 0.000000
+OUTPUT testing complexf_..._c_____
+OUTPUT testing complexf_..._c_____: arg 1.000000 0.000000
+OUTPUT testing complexf_..._chapel
+OUTPUT testing complexf_..._chapel: arg 1.000000 0.000000
+OUTPUT testing double_..._c_____
+OUTPUT testing double_..._c_____: arg 1.000000
+OUTPUT testing double_..._chapel
+OUTPUT testing double_..._chapel: arg 1.000000
+OUTPUT testing float_..._c_____
+OUTPUT testing float_..._c_____: arg 0.125000
+OUTPUT testing float_..._chapel
+OUTPUT testing float_..._chapel: arg 0.125000
+OUTPUT testing int16_..._c_____
+OUTPUT testing int16_..._c_____: arg -1
+OUTPUT testing int16_..._chapel
+OUTPUT testing int16_..._chapel: arg -1
+OUTPUT testing int32_..._c_____
+OUTPUT testing int32_..._c_____: arg -1
+OUTPUT testing int32_..._chapel
+OUTPUT testing int32_..._chapel: arg -1
+OUTPUT testing int64_..._c_____
+OUTPUT testing int64_..._c_____: arg -1
+OUTPUT testing int64_..._chapel
+OUTPUT testing int64_..._chapel: arg -1
+OUTPUT testing int8_..._c_____
+OUTPUT testing int8_..._c_____: arg -1
+OUTPUT testing int8_..._chapel
+OUTPUT testing int8_..._chapel: arg -1
+OUTPUT testing struct_aligned16test_..._c_____
+OUTPUT testing struct_aligned16test_..._c_____: arg.x 123456789 arg.a 987654321
+OUTPUT testing struct_aligned16test_..._chapel
+OUTPUT testing struct_aligned16test_..._chapel: arg.x 123456789 arg.a 987654321
+OUTPUT testing struct_one_double..._c_____
+OUTPUT testing struct_one_double..._c_____: arg.a 15.000000
+OUTPUT testing struct_one_double..._chapel
+OUTPUT testing struct_one_double..._chapel: arg.a 15.000000
+OUTPUT testing struct_one_float..._c_____
+OUTPUT testing struct_one_float..._c_____: arg.a 12.000000
+OUTPUT testing struct_one_float..._chapel
+OUTPUT testing struct_one_float..._chapel: arg.a 12.000000
+OUTPUT testing struct_one_int..._c_____
+OUTPUT testing struct_one_int..._c_____: arg.a -2
+OUTPUT testing struct_one_int..._chapel
+OUTPUT testing struct_one_int..._chapel: arg.a -2
+OUTPUT testing struct_one_long..._c_____
+OUTPUT testing struct_one_long..._c_____: arg.a -8
+OUTPUT testing struct_one_long..._chapel
+OUTPUT testing struct_one_long..._chapel: arg.a -8
+OUTPUT testing struct_paddingtest_..._c_____
+OUTPUT testing struct_paddingtest_..._c_____: arg.c1 1 arg.h2 2 arg.d3 3
+OUTPUT testing struct_paddingtest_..._chapel
+OUTPUT testing struct_paddingtest_..._chapel: arg.c1 1 arg.h2 2 arg.d3 3
+OUTPUT testing struct_pair_double..._c_____
+OUTPUT testing struct_pair_double..._c_____: arg.a 0.000000 arg.b 1.000000
+OUTPUT testing struct_pair_double..._chapel
+OUTPUT testing struct_pair_double..._chapel: arg.a 0.000000 arg.b 1.000000
+OUTPUT testing struct_pair_float..._c_____
+OUTPUT testing struct_pair_float..._c_____: arg.a 0.000000 arg.b 1.000000
+OUTPUT testing struct_pair_float..._chapel
+OUTPUT testing struct_pair_float..._chapel: arg.a 0.000000 arg.b 1.000000
+OUTPUT testing struct_pair_int..._c_____
+OUTPUT testing struct_pair_int..._c_____: arg.a 0 arg.b 1
+OUTPUT testing struct_pair_int..._chapel
+OUTPUT testing struct_pair_int..._chapel: arg.a 0 arg.b 1
+OUTPUT testing struct_pair_long..._c_____
+OUTPUT testing struct_pair_long..._c_____: arg.a 0 arg.b 1
+OUTPUT testing struct_pair_long..._chapel
+OUTPUT testing struct_pair_long..._chapel: arg.a 0 arg.b 1
+OUTPUT testing struct_triple_..._c_____
+OUTPUT testing struct_triple_..._c_____: arg.a 0 arg.b 1 arg.c 2
+OUTPUT testing struct_triple_..._chapel
+OUTPUT testing struct_triple_..._chapel: arg.a 0 arg.b 1 arg.c 2
+OUTPUT testing struct_twelve_..._c_____
+OUTPUT testing struct_twelve_..._c_____: arg.a 0 arg.b 1 arg.c 2 arg.d 3 arg.e 4 arg.f 5 arg.g 6 arg.h 7 arg.i 8 arg.j 9 arg.k 10 arg.l 11
+OUTPUT testing struct_twelve_..._chapel
+OUTPUT testing struct_twelve_..._chapel: arg.a 0 arg.b 1 arg.c 2 arg.d 3 arg.e 4 arg.f 5 arg.g 6 arg.h 7 arg.i 8 arg.j 9 arg.k 10 arg.l 11
+OUTPUT testing uint16_..._c_____
+OUTPUT testing uint16_..._c_____: arg 65535
+OUTPUT testing uint16_..._chapel
+OUTPUT testing uint16_..._chapel: arg 65535
+OUTPUT testing uint32_..._c_____
+OUTPUT testing uint32_..._c_____: arg 4294967295
+OUTPUT testing uint32_..._chapel
+OUTPUT testing uint32_..._chapel: arg 4294967295
+OUTPUT testing uint64_..._c_____
+OUTPUT testing uint64_..._c_____: arg 18446744073709551615
+OUTPUT testing uint64_..._chapel
+OUTPUT testing uint64_..._chapel: arg 18446744073709551615
+OUTPUT testing uint8_..._c_____
+OUTPUT testing uint8_..._c_____: arg 255
+OUTPUT testing uint8_..._chapel
+OUTPUT testing uint8_..._chapel: arg 255
+define %struct.c_one_double @struct_one_double_return_c_____()
+define %struct.c_one_double @struct_one_double_return_chapel()
+define %struct.c_one_float @struct_one_float_return_c_____()
+define %struct.c_one_float @struct_one_float_return_chapel()
+define %struct.c_pair_double @struct_pair_double_return_c_____()
+define %struct.c_pair_double @struct_pair_double_return_chapel()
+define %struct.c_pair_float @struct_pair_float_return_c_____()
+define %struct.c_pair_float @struct_pair_float_return_chapel()
+define [2 x i64] @struct_paddingtest_return_c_____()
+define [2 x i64] @struct_paddingtest_return_chapel()
+define [2 x i64] @struct_pair_long_return_c_____()
+define [2 x i64] @struct_pair_long_return_chapel()
+define double @double_return_c_____()
+define double @double_return_chapel()
+define float @float_return_c_____()
+define float @float_return_chapel()
+define i32 @int32_return_c_____()
+define i32 @int32_return_chapel()
+define i32 @struct_one_int_return_c_____()
+define i32 @struct_one_int_return_chapel()
+define i32 @uint32_return_c_____()
+define i32 @uint32_return_chapel()
+define i64 @int64_return_c_____()
+define i64 @int64_return_chapel()
+define i64 @struct_one_long_return_c_____()
+define i64 @struct_one_long_return_chapel()
+define i64 @struct_pair_int_return_c_____()
+define i64 @struct_pair_int_return_chapel()
+define i64 @uint64_return_c_____()
+define i64 @uint64_return_chapel()
+define signext i16 @int16_return_c_____()
+define signext i16 @int16_return_chapel()
+define signext i8 @int8_return_c_____()
+define signext i8 @int8_return_chapel()
+define void @abistructfunc_c_____(i32 noundef, i32 noundef, [2 x i64], i32 noundef, i32 noundef, double noundef, double noundef, double noundef, i32 noundef, i32 noundef, i32 noundef0)
+define void @abistructfunc_chapel(i32, i32, [2 x i64], i32, i32, double, double, double, i32, i32, i320)
+define void @bool_arg_c_____(i1 noundef zeroext)
+define void @bool_arg_chapel(i1 zeroext)
+define void @complexd_arg_c_____([2 x double] noundef)
+define void @complexd_arg_chapel([2 x double])
+define void @complexf_arg_c_____([2 x float] noundef)
+define void @complexf_arg_chapel([2 x float])
+define void @double_arg_c_____(double noundef)
+define void @double_arg_chapel(double)
+define void @float_arg_c_____(float noundef)
+define void @float_arg_chapel(float)
+define void @int16_arg_c_____(i16 noundef signext)
+define void @int16_arg_chapel(i16 signext)
+define void @int32_arg_c_____(i32 noundef)
+define void @int32_arg_chapel(i32)
+define void @int64_arg_c_____(i64 noundef)
+define void @int64_arg_chapel(i64)
+define void @int8_arg_c_____(i8 noundef signext)
+define void @int8_arg_chapel(i8 signext)
+define void @struct_aligned16test_arg_c_____(ptr dead_on_return noundef)
+define void @struct_aligned16test_arg_chapel(ptr dead_on_return)
+define void @struct_aligned16test_return_c_____(ptr dead_on_unwind noalias writable sret(%struct.aligned16test) align 16)
+define void @struct_aligned16test_return_chapel(ptr dead_on_unwind noalias writable sret(%struct.aligned16test) align 16)
+define void @struct_one_double_arg_c_____([1 x double])
+define void @struct_one_double_arg_chapel([1 x double])
+define void @struct_one_float_arg_c_____([1 x float])
+define void @struct_one_float_arg_chapel([1 x float])
+define void @struct_one_int_arg_c_____(i64)
+define void @struct_one_int_arg_chapel(i64)
+define void @struct_one_long_arg_c_____(i64)
+define void @struct_one_long_arg_chapel(i64)
+define void @struct_paddingtest_arg_c_____([2 x i64])
+define void @struct_paddingtest_arg_chapel([2 x i64])
+define void @struct_pair_double_arg_c_____([2 x double])
+define void @struct_pair_double_arg_chapel([2 x double])
+define void @struct_pair_float_arg_c_____([2 x float])
+define void @struct_pair_float_arg_chapel([2 x float])
+define void @struct_pair_int_arg_c_____(i64)
+define void @struct_pair_int_arg_chapel(i64)
+define void @struct_pair_long_arg_c_____([2 x i64])
+define void @struct_pair_long_arg_chapel([2 x i64])
+define void @struct_triple_arg_c_____(ptr dead_on_return noundef)
+define void @struct_triple_arg_chapel(ptr dead_on_return)
+define void @struct_triple_return_c_____(ptr dead_on_unwind noalias writable sret(%struct.c_triple) align 8)
+define void @struct_triple_return_chapel(ptr dead_on_unwind noalias writable sret(%struct.c_triple) align 8)
+define void @struct_twelve_arg_c_____(ptr dead_on_return noundef)
+define void @struct_twelve_arg_chapel(ptr dead_on_return)
+define void @struct_twelve_return_c_____(ptr dead_on_unwind noalias writable sret(%struct.c_twelve) align 8)
+define void @struct_twelve_return_chapel(ptr dead_on_unwind noalias writable sret(%struct.c_twelve) align 8)
+define void @uint16_arg_c_____(i16 noundef zeroext)
+define void @uint16_arg_chapel(i16 zeroext)
+define void @uint32_arg_c_____(i32 noundef)
+define void @uint32_arg_chapel(i32)
+define void @uint64_arg_c_____(i64 noundef)
+define void @uint64_arg_chapel(i64)
+define void @uint8_arg_c_____(i8 noundef zeroext)
+define void @uint8_arg_chapel(i8 zeroext)
+define zeroext i1 @bool_return_c_____()
+define zeroext i1 @bool_return_chapel()
+define zeroext i16 @uint16_return_c_____()
+define zeroext i16 @uint16_return_chapel()
+define zeroext i8 @uint8_return_c_____()
+define zeroext i8 @uint8_return_chapel()
+define { double, double } @complexd_return_c_____()
+define { double, double } @complexd_return_chapel()
+define { float, float } @complexf_return_c_____()
+define { float, float } @complexf_return_chapel()

--- a/test/llvm/abi/x86-64/export-vs-c-llvm22.good
+++ b/test/llvm/abi/x86-64/export-vs-c-llvm22.good
@@ -1,0 +1,1 @@
+export-vs-c-llvm18.good

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -560,7 +560,10 @@ def _validate_rocm_llvm_version_impl(gpu: gpu_type):
                 )
     elif major_version == "7":
         # requires LLVM 21+
-        if int(chpl_llvm.get_llvm_version()) < 21:
+        if (
+            int(chpl_llvm.get_llvm_version()) < 21
+            and chpl_llvm.get() != "bundled"
+        ):
             error("Cannot target AMD GPUs with ROCm 7.x without LLVM 21+")
     elif not validateLlvmBuiltForTgt(gpu.llvm_target):
         _reportMissingGpuReq(

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -894,7 +894,7 @@ def get_gcc_prefix_dir(clang_cfg_args):
 @memoize
 def is_gcc_install_dir_supported():
     llvm_version = get_llvm_version()
-    return llvm_version not in ("14", "15")
+    return int(llvm_version) >= 16
 
 
 @memoize
@@ -1534,20 +1534,20 @@ def compute_host_link_settings():
     if llvm_val == "system" or llvm_val == "bundled":
         llvm_version = get_llvm_version()
         # Starting with clang 15, clang needs additional libraries
-        if llvm_version not in ("14",):
+        if int(llvm_version) >= 15:
             clang_static_libs.append("-lclangSupport")
             llvm_components.append("windowsdriver")
         # Starting with clang 16, clang needs additional libraries
-        if llvm_version not in ("14", "15"):
+        if int(llvm_version) >= 16:
             llvm_components.append("frontendhlsl")
         # Starting with clang 18, clang needs additional libraries
-        if llvm_version not in ("14", "15", "16", "17"):
+        if int(llvm_version) >= 18:
             llvm_components.append("frontenddriver")
             # clangAPINotes must go immediately after clangSema
             idx = clang_static_libs.index("-lclangSema") + 1
             clang_static_libs.insert(idx, "-lclangAPINotes")
         # Starting with clang 22, clang needs additional libraries
-        if llvm_version not in ("14", "15", "16", "17", "18", "19", "20", "21"):
+        if int(llvm_version) >= 22:
             # goes after the driver
             idx = clang_static_libs.index("-lclangDriver") + 1
             clang_static_libs.insert(idx, "-lclangOptions")

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1546,6 +1546,12 @@ def compute_host_link_settings():
             # clangAPINotes must go immediately after clangSema
             idx = clang_static_libs.index("-lclangSema") + 1
             clang_static_libs.insert(idx, "-lclangAPINotes")
+        # Starting with clang 22, clang needs additional libraries
+        if llvm_version not in ("14", "15", "16", "17", "18", "19", "20", "21"):
+            idx = clang_static_libs.index("-lclangDriver") + 1
+            clang_static_libs.insert(idx, "-lclangOptions")
+            idx = clang_static_libs.index("-lclangSema") + 1
+            clang_static_libs.insert(idx, "-lclangAnalysisLifetimeSafety")
 
     # quit early if the llvm value is unset
     if llvm_val == "unset":

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1548,9 +1548,11 @@ def compute_host_link_settings():
             clang_static_libs.insert(idx, "-lclangAPINotes")
         # Starting with clang 22, clang needs additional libraries
         if llvm_version not in ("14", "15", "16", "17", "18", "19", "20", "21"):
+            # goes after the driver
             idx = clang_static_libs.index("-lclangDriver") + 1
             clang_static_libs.insert(idx, "-lclangOptions")
-            idx = clang_static_libs.index("-lclangSema") + 1
+            # goes after analysis
+            idx = clang_static_libs.index("-lclangAnalysis") + 1
             clang_static_libs.insert(idx, "-lclangAnalysisLifetimeSafety")
 
     # quit early if the llvm value is unset

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -24,16 +24,13 @@ from collections import defaultdict
 # Get a tuple of supported major LLVM versions as strings.
 # These will be tried in order.
 def llvm_versions():
-    return (
-        "21",
-        "20",
-        "19",
-        "18",
-        "17",
-        "16",
-        "15",
-        "14",
-    )
+    # Which major release - only need one number for that with current
+    # llvm (since LLVM 4.0).
+    # These will be tried in order.
+    min_version = 14
+    max_version = 22
+    versions = tuple(str(i) for i in range(max_version, min_version - 1, -1))
+    return versions
 
 
 @memoize


### PR DESCRIPTION
Adds support to Chapel for LLVM 22

- [x] paratest x86 linux64
- [x] paratest gasnet x86 linux64
- [x] `start_test test/llvm` arm mac
- [x] `start_test test/gpu/native` with AMD GPUs and COMM=none
- [x] `start_test test/gpu/native` with NVIDIA GPUs and COMM=ofi


[Reviewed by @arifthpe]