### PR TITLE
Pin archlinux portability testing to LLVM 21

### DIFF
--- a/util/devel/test/portability/apptainer/current/arch/image.def
+++ b/util/devel/test/portability/apptainer/current/arch/image.def
@@ -6,7 +6,7 @@ From: archlinux:base-devel
 
 %post
     /provision-scripts/pacman-deps.sh
-    /provision-scripts/pacman-llvm.sh
+    /provision-scripts/pacman-llvm21.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/portability/provision-scripts/pacman-llvm.sh
+++ b/util/devel/test/portability/provision-scripts/pacman-llvm.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# and LLVM stuff, this installs LLVM 21 as of {2025.10.01} version
-pacman --noconfirm -S llvm clang

--- a/util/devel/test/portability/provision-scripts/pacman-llvm21.sh
+++ b/util/devel/test/portability/provision-scripts/pacman-llvm21.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pacman --noconfirm -S llvm21 clang21


### PR DESCRIPTION
Pin portability testing on archlinux to install the `{llvm,clang}21` packages instead of latest version, which [as of 3/7 is now 22](https://gitlab.archlinux.org/archlinux/packaging/packages/llvm/-/commit/15bd912b183998d2373cffe1ff4d9397a4888296), which we don't yet support.

Since Archlinux updates so frequently, switch from having both a pinned and unpinned script to just a pinned script. This should reduce churn with adding and removing the pinned version as in https://github.com/chapel-lang/chapel/pull/27955/changes/f92cf9df032602da9f606962b6edc05478e0ca97 and https://github.com/chapel-lang/chapel/pull/28002/changes/ce2d96d63a9397f1f996b711220fbaf4b46c2bce.

[trivial, not reviewed]