### PR TITLE
Increase homebrew upgrade retries 3->10

### DIFF
--- a/util/cron/test-homebrew.bash
+++ b/util/cron/test-homebrew.bash
@@ -69,7 +69,7 @@ cat chapel.rb
 # we retry to install in case of either network issues or the error
 # "Error: File exists", this happens somewhat frequently and just
 # rerunning the command seems to fix it.
-RETRIES=3
+RETRIES=10
 until brew upgrade --force --overwrite; do
   if [ $RETRIES -le 0 ]; then
     log_error "Failed to update Homebrew after multiple attempts."


### PR DESCRIPTION
Increase the max number of `brew upgrade` retries from 3 to 10.

We are still hitting the "file exists" issue, however I think more retries would fix it as each iteration gets past a single stuck package.

Follow up to https://github.com/chapel-lang/chapel/pull/28547.

[reviewer info placeholder]