### PR TITLE
Disable debug info generation in EX RPM

### DIFF
--- a/util/build_configs/cray-internal/chapel.spec.template
+++ b/util/build_configs/cray-internal/chapel.spec.template
@@ -45,9 +45,9 @@ Chapel language compiler and libraries
 # Anna, 2026-03-10
 %define __brp_mangle_shebangs %{nil}
 
-# Avoid generating debug info, for which we get symlinks that are broken outside
-# the build container.
-# Anna, 2026-03-23
+# Avoid generating build-id links, for which we get symlinks that are broken
+# outside the build container.
+# Anna, 2026-03-25
 %define _build_id_links none
 
 %prep


### PR DESCRIPTION
Disable generation of debug info in the `chapel.spec.template` for the EX RPM build.

Adds the directive `%define _build_id_links none` to `util/build_configs/cray-internal/chapel.spec.template`.

This works around an issue of broken symlinks on RHEL install, that I think are a consequence of us building containerized.

----------

### Problem

We observed the following when trying to install the RPM built without this workaround:
```
error: unpacking of archive failed on file /usr/lib/.build-id/01/ef40c6e19be12ff16ab56793a0457186b4ce83;69b1e3a1: cpio: symlink failed - No data available
```

The build logs contained many entries of the form:
```
warning: Missing build-id in /home/*****/chapel-2.9.0.20260311-hpe-cray-ex/chapel-2.9.0.20260311-20260311202453_2e6ef26.hpecrayex/BUILDROOT/opt/cray/chapel/2.9.0.20260311/hpe-cray-ex/third-party/{libunwind,hwloc}/install/[...]
```

We also observed these warnings in the successful build logs of SLES RPM builds; however, the resulting RPMs for SLES did not contain any files in `/usr/lib/.build-id`.

### Reasoning for approach

From https://stackoverflow.com/questions/60673229/fpm-v-1-11-0-vs-inclusion-of-usr-lib-build-id-files as well as https://gnu.wildebeest.org/blog/mjw/2017/06/30/fedora-rpm-debuginfo-improvements-for-rawhidef27/ which it links to, I gathered that these links are for the purposes of debuginfo. Since they appear not to be present on SLES already, I feel it is alright to go for the easy solution of leaving them out on RHEL.

I gathered which directives are relevant to `build_id`s via the above links as well as https://github.com/rpm-software-management/rpm/issues/367 and https://www.claudiokuenzler.com/blog/1450/rpm-build-error-no-build-id-note-found-binaries. I tried building with different subsets of {`%global debug_package %{nil}`,`%define _build_id_links none`,`%undefine _missing_build_ids_terminate_build`}. I also went through a few phrasings of each (`%global` or just `%define`, `%define` to `%{nil}` instead of `%undefine`, changing position relative to `%description`) as `rpmbuild` seems to be picky about order in opaque ways. Eventually I found one which build without warnings and did not generate `build-id`s, but it may not be the only one. I don't understand this well and there may be a better solution.

----------

[reviewer info placeholder]

Testing:
- [x] successful build of EX RPM off of this Chapel code does not contain build-ids