### PR TITLE
Include username in nightly's mysystemerrs tmp files

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -461,7 +461,7 @@ if (exists($ENV{'CHPL_NIGHTLY_TEST_CONFIG_NAME'})) {
 # Include username in the tmp file's name, so we don't get conflicting files
 # between different users running this script.
 $username = $ENV{LOGNAME} || $ENV{USER} || getpwuid($<);
-$mysystemlog = "$basetmpdir/$username-mysystemerrs-$config_name.txt";
+$mysystemlog = "$basetmpdir/mysystemerrs-$username-$config_name.txt";
 $emailOnError = $mysystemlog;
 unlink($mysystemlog); # the file gets appended to, so clear it first.
 unlink("$mysystemlog.clean"); # the file gets appended to, so clear it first.


### PR DESCRIPTION
Include the username of the user running the `util/cron/nightly` script in the names of the `/tmp/mysystemerrs-*.txt` files it creates, to avoid creating conflicting files between runs by different users.

The `$prevmysystemlog` variable is left unchanged because:
1. This lives in `$cronlogdir` (from env var `CHPL_NIGHTLY_CRON_LOGDIR` or a default) which so far we haven't set to a shared dir, and I don't expect we would, so it wouldn't be subject to the same issue.
2. Changing the name of this variable would result in some discontinuity in our test data, because we'd have one night where the previous results were not at the (newly) expected location.

[reviewer info placeholder]