### PR TITLE
Make chpl_home_utils.py executable with proper shebang

### DIFF
--- a/util/chplenv/chpl_home_utils.py
+++ b/util/chplenv/chpl_home_utils.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Access to home variables"""
 
 import optparse


### PR DESCRIPTION
Makes chpl_home_utils.py excutable, matching what we do for other chplenv scripts. This allows someone to invoke the script as `$CHPL_HOME/util/chplenv/chpl_home_utils.py`without needing `python3` explicitly.

[Not reviewed - trivial]