### PR TITLE
Print 'time' for each 'make' invocation in nightly

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -438,6 +438,7 @@ if (exists($ENV{'CHPL_NIGHTLY_MAKE'})) {
     $make = `$utildir/chplenv/chpl_make.py`;
     chomp($make);
 }
+$make = "time $make";
 print "Using make: $make\n";
 
 


### PR DESCRIPTION
Prepend the `make` command string to be used in `util/cron/nightly` with `time`, to get some information on how long compilation is taking.

[trivial, not reviewed]

Testing:
- [x] manual run of a nightly test job succeeded and printed `time` output