### PR TITLE
Clarify LLVM 21+ restriction is also for ROCm>6.3

### DIFF
--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -556,7 +556,7 @@ def _validate_rocm_llvm_version_impl(gpu: gpu_type):
                 and int(chpl_llvm.get_llvm_version()) < 21
             ):
                 error(
-                    "Cannot target AMD GPUs with ROCm 6.3 without CHPL_LLVM=bundled or LLVM 21+"
+                    "Cannot target AMD GPUs with ROCm 6.3+ without CHPL_LLVM=bundled or LLVM 21+"
                 )
     elif major_version == "7":
         # requires LLVM 21+


### PR DESCRIPTION
Clarify error message for wrong LLVM dependency for ROCm 6.3+ is for >=6.3 and not just ==6.3.

In https://github.com/chapel-lang/chapel/pull/28220 the use of un-officially-supported ROCm versions became a warning rather than an error. https://github.com/chapel-lang/chapel/pull/28421 changed the restrictions on the LLVM dependence requirement for ROCm 6.3 or any subsequent minor version. Together this means it's possible for a user to build with ROCm 6.4 and see a warning that says they have things set up wrong for 6.3, as occurred in https://github.com/spack/spack-packages/pull/3836#discussion_r2963356673.

[reviewer info placeholder]