### PR TITLE
CLS: Add a manually-triggerable action to test the language server

### DIFF
--- a/.github/workflows/test-language-server.yml
+++ b/.github/workflows/test-language-server.yml
@@ -1,7 +1,11 @@
-name: Test Chapel Language Server
+name: Test chpl-language-server
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'tools/chapel-py/**'
+      - 'tools/chpl-language-server/**'
 
 jobs:
   test_chpl_language_server:


### PR DESCRIPTION
This adds a manual workflow to run the language server tests.

It's manual because testing the language server is rather niche, and I don't think we necessarily even want to do this on every commit that touches Dyno. Instead, provide the ability to trigger it manually as a convenience, which is an improvement over the previous state of things.

Reviewed by @jabraham17 -- thanks!