### PR TITLE
CLS: Fix CLS tests that relied on old format of domain/array printing.

### DIFF
--- a/tools/chpl-language-server/test/show_generic.py
+++ b/tools/chpl-language-server/test/show_generic.py
@@ -195,7 +195,7 @@ async def test_lenses_default_rect(client: LanguageClient):
         (pos((2, 14)), ": int(64)", None),
         (
             pos((3, 17)),
-            'param value is "[domain(1,int(64),one)] int(64)"',
+            'param value is "[domain(1, int(64), strideKind.one)] int(64)"',
             None,
         ),
         (pos((3, 17)), ": string", None),
@@ -236,7 +236,7 @@ async def test_lenses_default_rect_rank1(client: LanguageClient):
         (pos((2, 14)), ": int(64)", None),
         (
             pos((3, 17)),
-            'param value is "[domain(1,int(64),one)] int(64)"',
+            'param value is "[domain(1, int(64), strideKind.one)] int(64)"',
             None,
         ),
         (pos((3, 17)), ": string", None),
@@ -277,7 +277,7 @@ async def test_lenses_default_rect_rank2(client: LanguageClient):
         (pos((2, 14)), ": int(64)", None),
         (
             pos((3, 17)),
-            'param value is "[domain(2,int(64),one)] int(64)"',
+            'param value is "[domain(2, int(64), strideKind.one)] int(64)"',
             None,
         ),
         (pos((3, 17)), ": string", None),
@@ -319,7 +319,7 @@ async def test_lenses_default_rect_where_1(client: LanguageClient):
         (pos((2, 14)), ": int(64)", None),
         (
             pos((3, 17)),
-            'param value is "[domain(1,int(64),one)] int(64)"',
+            'param value is "[domain(1, int(64), strideKind.one)] int(64)"',
             None,
         ),
         (pos((3, 17)), ": string", None),
@@ -385,7 +385,7 @@ async def test_lenses_default_rect_twoargs(client: LanguageClient):
         (pos((2, 14)), ": (int(64), int(64))", None),
         (
             pos((3, 17)),
-            'param value is "[domain(1,int(64),one)] int(64)"',
+            'param value is "[domain(1, int(64), strideKind.one)] int(64)"',
             None,
         ),
         (pos((3, 17)), ": string", None),
@@ -427,7 +427,7 @@ async def test_lenses_default_rect_other_args(client: LanguageClient):
         (pos((2, 14)), ": int(64)", None),
         (
             pos((3, 17)),
-            'param value is "[domain(1,int(64),one)] int(64)"',
+            'param value is "[domain(1, int(64), strideKind.one)] int(64)"',
             None,
         ),
         (pos((3, 17)), ": string", None),
@@ -470,7 +470,7 @@ async def test_lenses_default_rect_with_calls(client: LanguageClient):
         (pos((2, 14)), ": int(64)", None),
         (
             pos((3, 17)),
-            'param value is "[domain(1,int(64),one)] int(64)"',
+            'param value is "[domain(1, int(64), strideKind.one)] int(64)"',
             None,
         ),
         (pos((3, 17)), ": string", None),


### PR DESCRIPTION
https://github.com/chapel-lang/chapel/pull/28484, in an effort to un-xfail some tests, fixed the printing format of arrays and domains to include spaces and to qualify enum params. However, tests I've written on a different branch (https://github.com/chapel-lang/chapel/pull/28502) were not updated to match. This didn't show up when testing the branch itself, since it did not incorporate the changes. However, once merged, this breaks the tests.

This PR adjusts the tests' format to match the new output style.

Reviewed by @jabraham17 -- thanks!