### PR TITLE
Improve nested coforalls lint warning

### DIFF
--- a/test/chplcheck/NestedCoforalls.chpl
+++ b/test/chplcheck/NestedCoforalls.chpl
@@ -19,5 +19,11 @@ module Nested {
         }
       }
     }
+
+    coforall loc in Locales do on loc {
+      coforall tid in 0..#loc.maxTaskPar {
+        writeln(loc, " ", tid);
+      }
+    }
   }
 }

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -763,6 +763,10 @@ def rules(driver: LintDriver):
 
         parent = node.parent()
         while parent is not None:
+            if isinstance(parent, On):
+                # if at any point there is an on-statement, we are fine since
+                # the second coforall will be on another node
+                return True
             if isinstance(parent, Coforall):
                 return False
             parent = parent.parent()


### PR DESCRIPTION
Improves the nested coforall lint warning to not fire when there are nested coforalls but there is an `on` block between them, as this is a common pattern and should be allowed

[Reviewed by @DanilaFe]