### PR TITLE
Skip trying to invoce .location() on comments.

### DIFF
--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -1097,6 +1097,9 @@ def rules(driver: LintDriver):
                     at_node = True
                 continue
 
+            if isinstance(sibling, Comment):
+                continue
+
             if sibling.location().start()[1] != last_loc.start()[1]:
                 break
 


### PR DESCRIPTION
This was an oversight in my implementation that I didn't catch because I was building in release mode (and thus, didn't have asserts).

Trivial, will not be reviewed.

## Testing
- [x] new `MisleadingIndentation` fixit no longer asserts in debug mode :)