### PR TITLE
spec: update specification with variable declaration exceptions.

### DIFF
--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -433,10 +433,13 @@ is equivalent to
 
 for an arbitrary expression ``e``.
 
-As an exception, iterator expressions (such as calls to an ``iter`` procedure),
-promoted function calls (see :ref:`Promotion`), and loop expressions (e.g.,
-:ref:`For_Expressions`), are converted into arrays. For iterators in
-particular, see also :ref:`Iterators_as_Arrays`.
+A prominent exception to this behavior occurs when a variable's initialization
+expression involves iteration — for example, a call to an iterator,
+a promoted procedure call (see :ref:`Promotion`), or a loop expression (e.g.,
+:ref:`For_Expressions`). In such cases, the variable will be inferred to have
+an array type, and its elements will be initialized to store the results of the
+iteration. For more information about the iterator case, see also
+:ref:`Iterators_as_Arrays`.
 
    *Example (iter-promo-loop-as-arrays.chpl)*.
 


### PR DESCRIPTION
Variable types for `var x = e` are not always determined by `e.type`; in some cases (most notably iterator expressions), the final type can be different. This PR weakens the spec's claim that this is always the case, by introducing the word "usually" and explicitly listing the big exception. There may be other exceptions, but I can't think of them and suspect they'd be in unstable portions of the language anyway (and so wouldn't belong in the spec)

Reviewed by @bradcray -- thanks!

## Testing
- [x] make docs, looks good
- [x] paratest