### PR TITLE
Remove makefile dependency

### DIFF
--- a/tools/mason/Makefile
+++ b/tools/mason/Makefile
@@ -46,7 +46,7 @@ $(outputFile): $(MASON_SOURCES) buildMason
 	@echo "Building Mason..."
 	@CHPL_COMPILER=$(CHPL_COMPILER) outputFile=$(outputFile) DEBUG=$(DEBUG) ./buildMason
 
-deps: pullMasonDeps ThirdParty/masonDeps.txt
+deps: pullMasonDeps
 	@echo "Pulling Mason dependencies..."
 	@./pullMasonDeps
 


### PR DESCRIPTION
Removes a dependency in a makefile rule, since the file may or may not exist

[Not reviewed - trivial]