### PR TITLE
Give the static and shared runtime libraries different names

### DIFF
--- a/util/chplenv/compile_link_args_utils.py
+++ b/util/chplenv/compile_link_args_utils.py
@@ -115,9 +115,8 @@ def shared_runtime_lib_base_name():
 
 
 def shared_runtime_lib_name():
-    ret = ""
-    ret += "lib" + shared_runtime_lib_base_name()
-    ret += "." + shared_runtime_lib_ext()
+    ret = "lib" + shared_runtime_lib_base_name() + "."
+    ret += shared_runtime_lib_ext()
     return ret
 
 

--- a/util/chplenv/printchplbuilds.py
+++ b/util/chplenv/printchplbuilds.py
@@ -15,6 +15,7 @@ import datetime
 from enum import Enum, unique
 from collections import defaultdict
 import chpl_home_utils
+from compile_link_args_utils import static_runtime_lib_name
 
 # Parsing the build directory path is implemented as a state machine. Some
 # of the components start with a prefix, some do not. The state machine
@@ -440,10 +441,11 @@ def main(argv):
         # gather the paths for all builds
         base = chpl_home_utils.get_chpl_runtime_lib()
 
-        # "targets" is a list of all paths that contain a "libchpl.a" file
+        # "targets" is a list of all paths that contain the runtime static lib
         targets = []
+        rt_static_lib = static_runtime_lib_name()
         for root, dirs, files in os.walk(base):
-            for target in filter(lambda x: x == "libchpl.a", files):
+            for target in filter(lambda x: x == rt_static_lib, files):
                 targets.append(os.path.join(root, target))
 
         if args.sort == Sort.OLDEST:


### PR DESCRIPTION
This PR names the runtime static archive `libchpl-static.a` and the shared library `libchpl.so` (unchanged). The motivations for doing this are explored in #28585. This PR should also hopefully fix broken Python interop tests and a broken GPU test.

TESTING

- [x] `COMM=none` `COMPILER=llvm`
- [x] `COMM=gasnet` `COMPILER=llvm`
- [x] `COMM=gasnet` `COMPILER=clang`
- [x] `COMM=none`, `PIC=pic`, `interop/python` w/ deps
- [x] `test/gpu/native/interop/gpuLibrary/...` w/ deps

Reviewed by @jabraham17. Thanks!