### PR TITLE
Remove internal IO helper types

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -11409,9 +11409,11 @@ proc fileReader.readf(fmtStr:?t, ref args ...?k): bool throws
               if ! ok {
                 err = qio_format_error_arg_mismatch(i);
               } else {
-                var tmp : int;
-                try readCodepoint(tmp);
-                chr = tmp.safeCast(int(32));
+                const err = qio_channel_read_char(false, _channel_internal, chr);
+                if err != 0 {
+                  const msg = _constructIoErrorMsg(chr);
+                  try _ch_ioerror(err, msg);
+                }
               }
 
               if ! err {


### PR DESCRIPTION
This PR removes the ``chpl_ioLiteral``, ``_internalIoChar``, and ``_internalIoBits`` types. These types were once used in the old readThis/writeThis implementatino, but for expediency were made internal types when we switched to serializers. This PR replaces the uses of these types with calls to the relevant methods or external functions.

Testing:
- [x] local paratest