### PR TITLE
Nightly test failure cleanups

### DIFF
--- a/test/library/packages/UnitTest/Filtering/testFiltering-noregex.chpl
+++ b/test/library/packages/UnitTest/Filtering/testFiltering-noregex.chpl
@@ -1,16 +1,1 @@
-use UnitTest;
-
-proc testA(test: borrowed Test) throws {
-  test.assertTrue(true);
-}
-
-proc testB(test: borrowed Test) throws {
-  test.assertFalse(false);
-}
-
-proc failingTest(test: borrowed Test) throws {
-  test.assertFalse(true);
-}
-
-
-UnitTest.main();
+testFiltering.chpl

--- a/test/library/packages/UnitTest/PRETEST
+++ b/test/library/packages/UnitTest/PRETEST
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$CHPL_HOME/test/mason/PRETEST $@

--- a/test/library/packages/UnitTest/doc-examples/PRETEST
+++ b/test/library/packages/UnitTest/doc-examples/PRETEST
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+$CHPL_HOME/test/mason/PRETEST $@

--- a/test/mason/mason-prereq/prereq-errors.good
+++ b/test/mason/mason-prereq/prereq-errors.good
@@ -1,2 +1,2 @@
-Command failed: 'make MASON_PACKAGE_HOME=/chapel/home/abrahaja/chapel/test/mason/mason-prereq/prereq3'
-mason utils   : hello.c:6:27: error: expected ';' before '}' token
+Command failed: 'make MASON_PACKAGE_HOME=/Users/jade/Development/chapel-lang/chapel/test/mason/mason-prereq/prereq3'
+mason utils   : hello.c:6:27: error: expected

--- a/test/mason/mason-prereq/prereq-errors.masontest
+++ b/test/mason/mason-prereq/prereq-errors.masontest
@@ -4,4 +4,5 @@ set -eo pipefail
 
 cd prereq3
 
-MASON_LOG_LEVEL=info mason build | grep 'error:'
+
+MASON_LOG_LEVEL=info mason build | grep 'error:' | sed -E 's/^(.*expected).*$/\1/'


### PR DESCRIPTION
Fixes a few more things broken in nightly tests

* A UnitTest for regex was relying on the output of another test, which changed. Updated to use the same file
* Some tests were missing mason dependencies, they need to clone those dependencies with a PRETEST
* prereq-errors.masontest could have system-dependent errors

[Not reviewed - trivial]