### PR TITLE
Allow using findUndocumentedSymbols without CHPL_HOME being set

### DIFF
--- a/tools/chpldoc/findUndocumentedSymbols
+++ b/tools/chpldoc/findUndocumentedSymbols
@@ -21,8 +21,14 @@
 #
 
 if [ -z "$CHPL_HOME" ]; then
-  echo "Error: CHPL_HOME is not set"
-  exit 1
+  # We need CHPL_HOME to find run-in-venv.bash. Try falling back to a
+  # compiler in PATH.
+  if output=$(chpl --print-bootstrap-commands); then
+    eval "$output"
+  else
+    echo "Error: CHPL_HOME is not set" 1>&2
+    exit 1
+  fi
 fi
 
 python=$($CHPL_HOME/util/config/find-python.sh)


### PR DESCRIPTION
Improves `findUndocumentedSymbols` to work without CHPL_HOME being set

[Reviewed by @DanilaFe]