### PR TITLE
Use 2 threads for make in test-docker

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -24,7 +24,7 @@ set -exuo pipefail
 # Use this many `make` threads in parallel within the Docker image build.
 # Note that for multi-arch builds, the build for each arch occurs
 # simultaneously, and each build will use this many threads.
-export DOCKER_BUILD_MAKE_THREADS=1
+export DOCKER_BUILD_MAKE_THREADS=2
 
 # BEGIN FUNCTIONS
 


### PR DESCRIPTION
Bump number of threads to `make -j` argument in `util/cron/test-docker.bash` from 1 to 2.

I think we can get away with this level of parallelism. If it works and doesn't cause system stability issues, pushing further to 3 or even 4 could be worth trying.

[trivial, not reviewed]