### PR TITLE
Make `mason run` less intrusive

### DIFF
--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -336,7 +336,7 @@ private proc runExampleBinary(projectHome: string, exampleName: string,
   }
 
   // TODO: do we need to expose the error code in some way?
-  const exampleResult = runWithStatus(command.toArray());
+  const exampleResult = runWithStatus(command.toArray(), capture=false);
 }
 
 private proc getExamples(toml: Toml, projectHome: string) {

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -119,7 +119,7 @@ proc runProjectBinary(show: bool, release: bool,
     // Build if not built, throwing error if Mason.toml doesnt exist
     if isFile(joinPath(projectHome, "Mason.lock")) && built {
       // TODO: do we need to expose the error code in some way?
-      const runResult = runWithStatus(command.toArray());
+      const runResult = runWithStatus(command.toArray(), capture=false);
     } else if isFile(joinPath(projectHome, "Mason.toml")) {
       const msg = "Mason could not find your Mason.lock.\n";
       const help = "To build and run your project use: mason run --build";

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -156,17 +156,20 @@ proc runCommand(cmd: string, quiet=false) : string throws {
 
 /* Same as runCommand but for situations where an
    exit status is needed */
-proc runWithStatus(command: string, quiet=false): int {
+proc runWithStatus(command: string, quiet=false, capture=true): int {
   var cmd = command.split();
-  return runWithStatus(cmd, quiet=quiet);
+  return runWithStatus(cmd, quiet=quiet, capture=capture);
 }
-proc runWithStatus(command: [] string, quiet=false): int {
+proc runWithStatus(command: [] string, quiet=false, capture=true): int {
   try {
     log.debugf("runWithStatus: %?\n", command);
-    var sub = spawn(command, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
+    var sub =
+      if capture
+        then spawn(command, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe)
+        else spawn(command);
 
     var line:string;
-    if !quiet {
+    if !quiet && capture {
       while sub.stdout.readLine(line) do write(line);
       while sub.stderr.readLine(line) do write(line);
     }


### PR DESCRIPTION
Makes `mason run` less intrusive by having it not run with the output captured. This means that the stdout/stderr streams are the real stdout/stderr streams, and Mason programs can change their behavior based on that.

For example, without this PR [this call in this mason example](https://github.com/jabraham17/TerminalColors/blob/753ebdf11c15cd6897fb9f74f268aca7d610dae1/example/truecolor.chpl#L77) does not work because stdout/stderr is faked

[Reviewed by @benharsh]