### PR TITLE
Add an option to ignore LineLength lint on docstrings

### DIFF
--- a/test/chplcheck/LineLength.chpl
+++ b/test/chplcheck/LineLength.chpl
@@ -7,4 +7,18 @@ module LineLength {
       writeln("This is a very long line of text that exceeds 80 characters. It will trigger the lint warning.");
     }
   }
+
+  // This is a comment with a line length over 20 characters
+  var thisIsMyVeryLongVariableName:
+                       /*this inline comment also triggers it*/
+  int = 0;
+
+  /*I am a really long docstring but I should still get warned about by default because its long*/
+  proc foo() {}
+  /*a normal docstring*/
+                                                                                /*why would someone write this?*/proc bar() {}
+                                                                  /*weird edge*/
+                                                                    /*just over*/
+  // whitespace doesn't count
+  var loremIpsumAndDolorSitAmetConsecteturAdipiscingElit: int = 123456789 + 222;           
 }

--- a/test/chplcheck/LineLength.chplcheckopts
+++ b/test/chplcheck/LineLength.chplcheckopts
@@ -1,0 +1,4 @@
+ # Base
+--setting LineLength.Max=20
+--setting LineLength.IgnoreDocStrings=true
+--setting LineLength.Max=20 --setting LineLength.IgnoreDocStrings=true

--- a/test/chplcheck/LineLength.good
+++ b/test/chplcheck/LineLength.good
@@ -1,4 +1,47 @@
+=== chplcheckopts 1 ===
 LineLength.chpl:3: node violates rule LineLength
 LineLength.chpl:5: node violates rule UnattachedCurly
 LineLength.chpl:6: node violates rule LineLength
 LineLength.chpl:7: node violates rule LineLength
+LineLength.chpl:16: node violates rule LineLength
+LineLength.chpl:19: node violates rule IncorrectIndentation
+LineLength.chpl:19: node violates rule LineLength
+LineLength.chpl:21: node violates rule LineLength
+=== chplcheckopts 2 ===
+LineLength.chpl:2: node violates rule LineLength
+LineLength.chpl:3: node violates rule LineLength
+LineLength.chpl:5: node violates rule UnattachedCurly
+LineLength.chpl:5: node violates rule LineLength
+LineLength.chpl:6: node violates rule LineLength
+LineLength.chpl:7: node violates rule LineLength
+LineLength.chpl:11: node violates rule LineLength
+LineLength.chpl:12: node violates rule LineLength
+LineLength.chpl:13: node violates rule LineLength
+LineLength.chpl:16: node violates rule LineLength
+LineLength.chpl:18: node violates rule LineLength
+LineLength.chpl:19: node violates rule IncorrectIndentation
+LineLength.chpl:19: node violates rule LineLength
+LineLength.chpl:20: node violates rule LineLength
+LineLength.chpl:21: node violates rule LineLength
+LineLength.chpl:22: node violates rule LineLength
+LineLength.chpl:23: node violates rule LineLength
+=== chplcheckopts 3 ===
+LineLength.chpl:3: node violates rule LineLength
+LineLength.chpl:5: node violates rule UnattachedCurly
+LineLength.chpl:6: node violates rule LineLength
+LineLength.chpl:7: node violates rule LineLength
+LineLength.chpl:19: node violates rule IncorrectIndentation
+LineLength.chpl:19: node violates rule LineLength
+=== chplcheckopts 4 ===
+LineLength.chpl:2: node violates rule LineLength
+LineLength.chpl:3: node violates rule LineLength
+LineLength.chpl:5: node violates rule UnattachedCurly
+LineLength.chpl:5: node violates rule LineLength
+LineLength.chpl:6: node violates rule LineLength
+LineLength.chpl:7: node violates rule LineLength
+LineLength.chpl:11: node violates rule LineLength
+LineLength.chpl:12: node violates rule LineLength
+LineLength.chpl:19: node violates rule IncorrectIndentation
+LineLength.chpl:19: node violates rule LineLength
+LineLength.chpl:22: node violates rule LineLength
+LineLength.chpl:23: node violates rule LineLength

--- a/test/chplcheck/LineLength20.chpl
+++ b/test/chplcheck/LineLength20.chpl
@@ -1,6 +1,0 @@
-module LineLength20 {
-  // This is a comment with a line length over 20 characters
-  var thisIsMyVeryLongVariableName:
-                       /*this inline comment also triggers it*/
-  int = 0;
-}

--- a/test/chplcheck/LineLength20.chplcheckopts
+++ b/test/chplcheck/LineLength20.chplcheckopts
@@ -1,1 +1,0 @@
---setting LineLength.Max=20

--- a/test/chplcheck/LineLength20.good
+++ b/test/chplcheck/LineLength20.good
@@ -1,4 +1,0 @@
-LineLength20.chpl:1: node violates rule LineLength
-LineLength20.chpl:2: node violates rule LineLength
-LineLength20.chpl:3: node violates rule LineLength
-LineLength20.chpl:4: node violates rule LineLength

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -136,6 +136,46 @@ def extract_only_bool(
     return check_for_bool.value()
 
 
+def find_docstring_ranges(
+    lines: typing.List[str],
+) -> typing.List[typing.Tuple[typing.Tuple[int, int], typing.Tuple[int, int]]]:
+    docstring_ranges = []
+    for row, line in enumerate(lines, start=1):
+        idx = 0
+        len_line = len(line)
+        while idx < len_line:
+            if line[idx] == "/" and idx + 1 < len_line and line[idx + 1] == "*":
+                docstring_ranges.append(((row, idx), (-1, -1)))
+                idx += 2
+            elif (
+                line[idx] == "*" and idx + 1 < len_line and line[idx + 1] == "/"
+            ):
+                # find the most recent docstring range that doesn't have an end yet and set its end
+                for i in range(len(docstring_ranges) - 1, -1, -1):
+                    if docstring_ranges[i][1] == (-1, -1):
+                        docstring_ranges[i] = (
+                            docstring_ranges[i][0],
+                            (row, idx + 2),
+                        )
+                        break
+                idx += 2
+            else:
+                idx += 1
+    return docstring_ranges
+
+
+def is_in_docstring(
+    loc: typing.Tuple[int, int],
+    docstring_ranges: typing.List[
+        typing.Tuple[typing.Tuple[int, int], typing.Tuple[int, int]]
+    ],
+) -> bool:
+    for start, end in docstring_ranges:
+        if start <= loc and loc <= end:
+            return True
+    return False
+
+
 def rules(driver: LintDriver):
     @driver.basic_rule(VarLikeDecl, default=False)
     def CamelOrPascalCaseVariables(context: Context, node: VarLikeDecl):
@@ -1637,12 +1677,20 @@ def rules(driver: LintDriver):
         )
         return [fixit]
 
-    @driver.location_rule(settings=[".Max"])
-    def LineLength(_: chapel.Context, path: str, lines: List[str], Max=None):
+    @driver.location_rule(settings=[".Max", ".IgnoreDocStrings"])
+    def LineLength(
+        _: chapel.Context,
+        path: str,
+        lines: List[str],
+        Max=None,
+        IgnoreDocStrings=None,
+    ):
         """
         Warn for lines that exceed a maximum length.
         By default, the maximum line length is 80 characters. This can be
-        configured with `--setting LineLength.Max=<number>`.
+        configured with ``--setting LineLength.Max=<number>``.
+        By default, docstrings are included in this check, but they can be
+        ignored with ``--setting LineLength.IgnoreDocStrings=true``.
         """
 
         Max = Max or "80"  # default to 80 characters
@@ -1650,7 +1698,23 @@ def rules(driver: LintDriver):
             max_line_length = int(Max)
         except ValueError:
             raise ValueError("Invalid value for Max: '{}'".format(Max))
+        if IgnoreDocStrings not in (None, "true", "false"):
+            raise ValueError(
+                "Invalid value for IgnoreDocStrings: '{}'".format(
+                    IgnoreDocStrings
+                )
+            )
+        IgnoreDocStrings = IgnoreDocStrings == "true"  # default to False
 
-        for i, line in enumerate(lines, start=1):
-            if len(line) > max_line_length:
-                yield RuleLocation(path, (i, 1), (i, len(line) + 1))
+        docstring_ranges = []
+        if IgnoreDocStrings:
+            docstring_ranges = find_docstring_ranges(lines)
+
+        for row, line in enumerate(lines, start=1):
+            nowhitespace = line.rstrip()
+            if IgnoreDocStrings and is_in_docstring(
+                (row, len(nowhitespace)), docstring_ranges
+            ):
+                continue
+            if len(nowhitespace) > max_line_length:
+                yield RuleLocation(path, (row, 1), (row, len(nowhitespace) + 1))

--- a/tools/chplcheck/src/rules.py
+++ b/tools/chplcheck/src/rules.py
@@ -140,27 +140,31 @@ def find_docstring_ranges(
     lines: typing.List[str],
 ) -> typing.List[typing.Tuple[typing.Tuple[int, int], typing.Tuple[int, int]]]:
     docstring_ranges = []
+    docstring_stack = []
     for row, line in enumerate(lines, start=1):
         idx = 0
         len_line = len(line)
         while idx < len_line:
-            if line[idx] == "/" and idx + 1 < len_line and line[idx + 1] == "*":
-                docstring_ranges.append(((row, idx), (-1, -1)))
+            cur = (line[idx], line[idx + 1] if idx + 1 < len_line else None)
+            if cur == ("/", "*"):
+                docstring_stack.append((row, idx))
                 idx += 2
-            elif (
-                line[idx] == "*" and idx + 1 < len_line and line[idx + 1] == "/"
-            ):
-                # find the most recent docstring range that doesn't have an end yet and set its end
-                for i in range(len(docstring_ranges) - 1, -1, -1):
-                    if docstring_ranges[i][1] == (-1, -1):
-                        docstring_ranges[i] = (
-                            docstring_ranges[i][0],
-                            (row, idx + 2),
-                        )
-                        break
+            elif cur == ("*", "/"):
+                # pop stack and add a docstring range from the popped location
+                # to here
+                if docstring_stack:
+                    start = docstring_stack.pop()
+                    docstring_ranges.append((start, (row, idx + 2)))
+                else:
+                    # mismatched comment end, ignore it. should have been caught
+                    # by the chapel parser anyways
+                    pass
                 idx += 2
             else:
                 idx += 1
+    # if docstring_stack is not empty here, we have mismatched comment starts,
+    # but we'll ignore those too since they should have been caught by the
+    # chapel parser
     return docstring_ranges
 
 


### PR DESCRIPTION
Adds a new option, `--setting LineLength.IgnoreDocStrings=true`, to disable line length checking inside of docstrings, since there are some docstrings that cannot be forced under the character limit (for example, a long link)

This PR also fixes a few other things with the LineLength rule
* fixes line length checking at the 80 col boundary
* fixes line length checking with trailing whitespace

- [x] `start_test chplcheck`

[Reviewed by @DanilaFe]