### PR TITLE
Convert weekly meetings from Teams to Zoom

### DIFF
--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -72,8 +72,9 @@ jobs:
             This discussion is for the weekly Chapel project meeting.
             
             **Date/Time: ${{ env.next_meeting_date }} at 10am PT**
-            **Join the meeting using [this Teams link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2M5M2E2NTEtNTFkMi00ZjA1LThiNDQtMjFjY2U2ZDc5ODk3%40thread.v2/0?context=%7b%22Tid%22%3a%22105b2061-b669-4b31-92ac-24d304d195dc%22%2c%22Oid%22%3a%22bef28eea-6179-4f21-b284-84c6a0aeacc3%22%7d)**
-            
+            **Join the meeting using [this Zoom link](https://zoom-lfx.platform.linuxfoundation.org/meeting/97154927840?password=96736b6d-0900-4b20-81ba-ff6bf48668af)**
+            See the [Chapel community calendar](https://chapel-lang.org/calendar/) for additional details and dial-in options
+
             ---
             
             Prior to the meeting, propose any agenda items using comments below.  After the meeting, rough notes will be added in comments.


### PR DESCRIPTION
There seemed to be support for this, at least for the meantime and within HPE, and this will save me from needing to update the discussions threads manually, weekly.
