### PR TITLE
Fix bugs and revert "non-user-writeable" changes to Fortran tests

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -1509,16 +1509,16 @@ static void handleOpaqueCTypeAlias(TypeSymbol* ts) {
                   aliasName.c_str());
   }
 
+  if (auto eqts = equivalentChapelType->symbol) {
+    // Make sure the equivalent type is generated first.
+    if (!eqts->hasLLVMType()) eqts->codegenDef();
+  }
+
   auto llvmImplType = equivalentChapelType->symbol->llvmImplType;
   auto llvmAlignment = equivalentChapelType->symbol->llvmAlignment;
   bool isUnsigned = !isSignedType(equivalentChapelType);
 
   if (nullptr == info->lvt->getType(aliasName)) {
-    if (auto eqts = equivalentChapelType->symbol) {
-      // Make sure the equivalent type is generated first.
-      if (!eqts->hasLLVMType()) eqts->codegenDef();
-    }
-
     // Emplace the primitive C type if we need to. This only happens once,
     // but the use of the pragma triggers the mapping for a given C type.
     info->lvt->addGlobalType(aliasName, llvmImplType, isUnsigned);

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -44,15 +44,15 @@ std::map<TypeSymbol*, std::string> fortranKindNames;
 std::map<TypeSymbol*, std::string> fortranTypeNames;
 
 static bool shouldGeneratePrototype(FnSymbol* fn) {
-  if (fn->hasFlag(FLAG_EXPORT) && isUserRoutine(fn)) return true;
+  if (fn->hasFlag(FLAG_EXPORT)) {
+    if (isUserRoutine(fn)) return true;
 
-  if (!strcmp(fn->name, "chpl_library_init") ||
-      !strcmp(fn->name, "chpl_library_finalize")) {
-    // These functions must be exposed. TODO: There may be a situation where
-    // these are declared 'extern' for some reason, in which case this assert
-    // will fire. Figure out something then (e.g., just skip those?).
-    INT_ASSERT(fn->hasFlag(FLAG_EXPORT));
-    return true;
+    if (fn->name == astr("chpl_library_init") ||
+        fn->name == astr("chpl_library_finalize")) {
+      if (auto mod = fn->getModule()) {
+        if (mod->modTag == MOD_INTERNAL) return true;
+      }
+    }
   }
 
   return false;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4036,7 +4036,7 @@ static clang::CanQualType getClangType(::Type* t, bool makeRef) {
 
   } else if (t->symbol->hasFlag(FLAG_OPAQUE_C_TYPE_ALIAS)) {
     if (::Type* t = chapelTypeForPrimitiveCTypeName(cname)) {
-      ret = getClangType(dt_c_char, makeRef);
+      ret = getClangType(t, makeRef);
     } else {
       INT_FATAL(t->symbol, "Unhandled type alias when fetching Clang type");
     }

--- a/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
+++ b/test/interop/fortran/FortranCallChapel/chapelProcs.chpl
@@ -2,14 +2,13 @@ var chplInt: int;
 var chplReal: real;
 
 export proc chpl_library_init_ftn() {
-  use ChapelProgramEntrypoints;
   use CTypes;
 
-  var filenamePtr1 = "fake" : c_ptr(c_char);
-  var filenamePtr2 = c_ptrTo(filenamePtr1);
+  extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
 
-  const argc = __primitive("cast", chpl_opaque_c_int, (1 : c_int));
-  const argv = __primitive("cast", chpl_opaque_argv_array, filenamePtr2);
+  var filenamePtr1 = "fake" : c_ptr(c_char);
+  const argc: c_int = 1;
+  const argv: c_ptr(c_ptr(c_char)) = c_ptrTo(filenamePtr1);
 
   chpl_library_init(argc, argv);
   chpl__init_chapelProcs();

--- a/test/interop/fortran/genFortranInterface/chapelProcs.chpl
+++ b/test/interop/fortran/genFortranInterface/chapelProcs.chpl
@@ -2,14 +2,13 @@ var chplInt: int;
 var chplReal: real;
 
 export proc chpl_library_init_ftn() {
-  use ChapelProgramEntrypoints;
   use CTypes;
 
-  var filenamePtr1 = "fake" : c_ptr(c_char);
-  var filenamePtr2 = c_ptrTo(filenamePtr1);
+  extern proc chpl_library_init(argc: c_int, argv: c_ptr(c_ptr(c_char)));
 
-  const argc = __primitive("cast", chpl_opaque_c_int, (1 : c_int));
-  const argv = __primitive("cast", chpl_opaque_argv_array, filenamePtr2);
+  var filenamePtr1 = "fake" : c_ptr(c_char);
+  const argc: c_int = 1;
+  const argv: c_ptr(c_ptr(c_char)) = c_ptrTo(filenamePtr1);
 
   chpl_library_init(argc, argv);
   chpl__init_chapelProcs();


### PR DESCRIPTION
Fix bugs in the implementation of `pragma "opaque c type alias"` and undo unfortunate changes to two Fortran tests.

In the PR #28630 I made changes to two Fortran tests to workaround an `INT_ASSERT`. I wasn't happy with those changes (and in a followup comment Jade also pointed them out). After fixing one compiler bug, it revealed another even sillier bug in LLVM code generation.

Fix those bugs and revert the test changes.

Reviewed by @jabraham17. Thanks!