### PR TITLE
Expand CLS+Mason support

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -129,6 +129,7 @@ from lsprotocol.types import (
 )
 
 from lsp_util import *
+from mason import MasonProject
 
 
 class ChapelLanguageServer(LanguageServer):
@@ -258,7 +259,8 @@ class ChapelLanguageServer(LanguageServer):
     def eagerly_process_all_files(self, context: ContextContainer):
         cfg = context.config
         if cfg:
-            for file in cfg.files:
+            for file in cfg.files():
+                log("eagerly processing file", file)
                 # Invocation records the compiler call, and is not really
                 # a file.
                 #
@@ -390,10 +392,7 @@ class ChapelLanguageServer(LanguageServer):
             return "\n".join(lines)
 
     def register_workspace(self, uri: str):
-        path = os.path.join(uri[len("file://") :], ".cls-commands.json")
-        config = WorkspaceConfig.from_file(self, path)
-        if config:
-            self.configurations[uri] = config
+        self.configurations[uri] = WorkspaceConfig.from_file(self, uri)
 
     def unregister_workspace(self, uri: str):
         if uri in self.configurations:

--- a/tools/chpl-language-server/src/lsp_util.py
+++ b/tools/chpl-language-server/src/lsp_util.py
@@ -44,6 +44,7 @@ import importlib.util
 import copy
 import configargparse
 import functools
+from pathlib import Path
 
 import chapel
 from chapel.lsp import location_to_range
@@ -62,6 +63,8 @@ from lsprotocol.types import (
     SymbolInformation,
     SymbolKind,
 )
+
+from mason import MasonProject
 
 
 def log(*args, **kwargs):
@@ -666,14 +669,16 @@ class ContextContainer:
         self.instantiation_id_counter = 0
 
         if config:
-            file_config = config.for_file(file)
-            if file_config:
-                self.module_paths = file_config["module_dirs"]
-                self.file_paths = file_config["files"]
+            module_dirs, files = config.for_file(file)
+            self.module_paths.extend(module_dirs)
+            self.file_paths.extend(files)
 
         self.std_module_root = self.cls_config.get("std_module_root")
         self.module_paths.extend(self.cls_config.get("module_dir"))
 
+        log("Setting module paths with std module root '{}', module paths '{}', and file paths '{}'".format(
+            self.std_module_root, self.module_paths, self.file_paths
+        ))
         self.context._set_module_paths(
             self.std_module_root, self.module_paths, self.file_paths
         )
@@ -1448,7 +1453,7 @@ class FileInfo:
 
 class WorkspaceConfig:
     def __init__(self, ls: "ChapelLanguageServer", json: Dict[str, Any]):
-        self.files: Dict[str, Dict[str, Any]] = {}
+        self._files: Dict[str, Dict[str, Any]] = {}
 
         for key in json:
             compile_commands = json[key]
@@ -1470,23 +1475,39 @@ class WorkspaceConfig:
                 )
                 continue
 
-            self.files[key] = compile_commands[0]
+            self._files[key] = compile_commands[0]
 
-    def file_paths(self) -> Iterable[str]:
-        return self.files.keys()
+        self.mason: Optional[MasonProject] = None
 
-    def for_file(self, path: str) -> Optional[Dict[str, Any]]:
-        if path in self.files:
-            return self.files[path]
-        return None
+    def for_file(self, path: str) -> Tuple[List[str], List[str]]:
+        file_cfg = self._files.get(path, {"module_dirs": [], "files": []})
+        module_dirs = file_cfg.get("module_dirs", [])
+        files = file_cfg.get("files", [])
+        if self.mason:
+            module_dirs += self.mason.get_module_dirs()
+            files += self.mason.get_files()
+        return module_dirs, files
+
+    def files(self) -> List[str]:
+        files = set()
+        for file_cfg in self._files.values():
+            files.update(file_cfg.get("files", []))
+        if self.mason:
+            files.update(self.mason.get_files())
+        return list(files)
 
     @staticmethod
-    def from_file(ls: "ChapelLanguageServer", path: str):
-        if os.path.exists(path):
+    def from_file(ls: "ChapelLanguageServer", workspace_root_uri: str) -> "WorkspaceConfig":
+        workspace_root = Path(workspace_root_uri[len("file://") :])
+        path = workspace_root / ".cls-commands.json"
+        if path.exists():
             with open(path) as f:
                 commands = json.load(f)
-                return WorkspaceConfig(ls, commands)
-        return None
+                ws_cfg = WorkspaceConfig(ls, commands)
+        else:
+            ws_cfg = WorkspaceConfig(ls, {})
+        ws_cfg.mason = MasonProject.from_ws(ls.config.get("mason_path"), workspace_root_uri)
+        return ws_cfg
 
 
 class CLSConfig:
@@ -1556,6 +1577,8 @@ class CLSConfig:
         self.parser.add_argument("--end-markers", default="none")
         self.parser.add_argument("--end-marker-threshold", type=int, default=10)
 
+        self.parser.add_argument("--mason-path", default="mason", help=configargparse.SUPPRESS)
+
         chplcheck().config.add_bool_flag(
             self.parser, "chplcheck", "do_linting", False
         )
@@ -1588,16 +1611,10 @@ class CLSConfig:
                 None, "Cannot specify 'all' with other end marker choices"
             )
 
-    def _mason_setup(self):
-        # if this is a mason project, add 'src' as a module-dir
-        if os.path.exists(os.path.join(os.getcwd(), "Mason.toml")):
-            self.args["module_dir"] = self.args["module_dir"] + ["src"]
-
     def parse_args(self):
         self.args = copy.deepcopy(vars(self.parser.parse_args()))
         self._parse_end_markers()
         self._validate_end_markers()
-        self._mason_setup()
 
     def get(self, key: str):
         return self.args[key]

--- a/tools/chpl-language-server/src/lsp_util.py
+++ b/tools/chpl-language-server/src/lsp_util.py
@@ -676,9 +676,11 @@ class ContextContainer:
         self.std_module_root = self.cls_config.get("std_module_root")
         self.module_paths.extend(self.cls_config.get("module_dir"))
 
-        log("Setting module paths with std module root '{}', module paths '{}', and file paths '{}'".format(
-            self.std_module_root, self.module_paths, self.file_paths
-        ))
+        log(
+            "Setting module paths with std module root '{}', module paths '{}', and file paths '{}'".format(
+                self.std_module_root, self.module_paths, self.file_paths
+            )
+        )
         self.context._set_module_paths(
             self.std_module_root, self.module_paths, self.file_paths
         )
@@ -1497,7 +1499,9 @@ class WorkspaceConfig:
         return list(files)
 
     @staticmethod
-    def from_file(ls: "ChapelLanguageServer", workspace_root_uri: str) -> "WorkspaceConfig":
+    def from_file(
+        ls: "ChapelLanguageServer", workspace_root_uri: str
+    ) -> "WorkspaceConfig":
         workspace_root = Path(workspace_root_uri[len("file://") :])
         path = workspace_root / ".cls-commands.json"
         if path.exists():
@@ -1506,7 +1510,9 @@ class WorkspaceConfig:
                 ws_cfg = WorkspaceConfig(ls, commands)
         else:
             ws_cfg = WorkspaceConfig(ls, {})
-        ws_cfg.mason = MasonProject.from_ws(ls.config.get("mason_path"), workspace_root_uri)
+        ws_cfg.mason = MasonProject.from_ws(
+            ls.config.get("mason_path"), workspace_root_uri
+        )
         return ws_cfg
 
 
@@ -1577,7 +1583,9 @@ class CLSConfig:
         self.parser.add_argument("--end-markers", default="none")
         self.parser.add_argument("--end-marker-threshold", type=int, default=10)
 
-        self.parser.add_argument("--mason-path", default="mason", help=configargparse.SUPPRESS)
+        self.parser.add_argument(
+            "--mason-path", default="mason", help=configargparse.SUPPRESS
+        )
 
         chplcheck().config.add_bool_flag(
             self.parser, "chplcheck", "do_linting", False

--- a/tools/chpl-language-server/src/mason.py
+++ b/tools/chpl-language-server/src/mason.py
@@ -29,10 +29,10 @@ class MasonProject:
     def __init__(self, mason: str, mason_file: Path):
         self._mason = mason
         self._mason_file = mason_file
-        self._module_dirs = [mason_file.parent / "src"]
+        self._module_dirs = [str(mason_file.parent / "src")]
         self._files = self._get_mason_modules()
 
-    def _get_mason_modules(self) -> List[Path]:
+    def _get_mason_modules(self) -> List[str]:
         result = run_mason_cmd(
             self._mason_file.parent,
             self._mason,
@@ -44,8 +44,11 @@ class MasonProject:
             return []
         try:
             output = json.loads(result)
-            modules = output.get("modules", [])
-            return [Path(m) for m in modules]
+            modules = []
+            for module in output.get("modules", []):
+                if Path(module).is_file():
+                    modules.append(module)
+            return modules
         except json.JSONDecodeError as e:
             from lsp_util import log
 
@@ -55,10 +58,10 @@ class MasonProject:
             return []
 
     def get_module_dirs(self) -> List[str]:
-        return [str(d) for d in self._module_dirs]
+        return self._module_dirs
 
     def get_files(self) -> List[str]:
-        return [str(f) for f in self._files]
+        return self._files
 
     @classmethod
     def from_ws(

--- a/tools/chpl-language-server/src/mason.py
+++ b/tools/chpl-language-server/src/mason.py
@@ -77,19 +77,25 @@ class MasonProject:
 def run_mason_cmd(
     project_home: Path, mason: str, cmd: str, *args
 ) -> Optional[str]:
+    from lsp_util import log
+
+    log(
+        f"Running mason command: '{mason} {cmd} {' '.join(args)}' in {project_home}"
+    )
     env = os.environ.copy()
     env["MASON_LOG_LEVEL"] = "error"
+
     result = subprocess.run(
         [mason, cmd] + list(args),
         cwd=project_home,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         env=env,
+        check=False,
     )
     if result.returncode != 0:
-        from lsp_util import log
-
         log(f"Error running mason command: {result.stderr}")
         return None
     return result.stdout

--- a/tools/chpl-language-server/src/mason.py
+++ b/tools/chpl-language-server/src/mason.py
@@ -23,6 +23,7 @@ import subprocess
 import os
 import json
 
+
 class MasonProject:
 
     def __init__(self, mason: str, mason_file: Path):
@@ -32,7 +33,13 @@ class MasonProject:
         self._files = self._get_mason_modules()
 
     def _get_mason_modules(self) -> List[Path]:
-        result = run_mason_cmd(self._mason_file.parent, self._mason, "modules", "--format=json", "--no-update")
+        result = run_mason_cmd(
+            self._mason_file.parent,
+            self._mason,
+            "modules",
+            "--format=json",
+            "--no-update",
+        )
         if result is None:
             return []
         try:
@@ -41,7 +48,10 @@ class MasonProject:
             return [Path(m) for m in modules]
         except json.JSONDecodeError as e:
             from lsp_util import log
-            log(f"Error parsing mason modules output as JSON: {result}, error: {e}")
+
+            log(
+                f"Error parsing mason modules output as JSON: {result}, error: {e}"
+            )
             return []
 
     def get_module_dirs(self) -> List[str]:
@@ -51,9 +61,12 @@ class MasonProject:
         return [str(f) for f in self._files]
 
     @classmethod
-    def from_ws(cls, mason: str, workspace_root_uri: str) -> Optional["MasonProject"]:
+    def from_ws(
+        cls, mason: str, workspace_root_uri: str
+    ) -> Optional["MasonProject"]:
         workspace_root = Path(workspace_root_uri[len("file://") :])
         from lsp_util import log
+
         log(f"looking for Mason.toml in workspace root {workspace_root}")
         mason_file = workspace_root / "Mason.toml"
         if mason_file.is_file():
@@ -61,8 +74,9 @@ class MasonProject:
         return None
 
 
-
-def run_mason_cmd(project_home: Path, mason: str, cmd: str, *args) -> Optional[str]:
+def run_mason_cmd(
+    project_home: Path, mason: str, cmd: str, *args
+) -> Optional[str]:
     env = os.environ.copy()
     env["MASON_LOG_LEVEL"] = "error"
     result = subprocess.run(
@@ -75,6 +89,7 @@ def run_mason_cmd(project_home: Path, mason: str, cmd: str, *args) -> Optional[s
     )
     if result.returncode != 0:
         from lsp_util import log
+
         log(f"Error running mason command: {result.stderr}")
         return None
     return result.stdout

--- a/tools/chpl-language-server/src/mason.py
+++ b/tools/chpl-language-server/src/mason.py
@@ -1,0 +1,80 @@
+#
+# Copyright 2024-2026 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pathlib import Path
+from typing import List, Optional
+import subprocess
+import os
+import json
+
+class MasonProject:
+
+    def __init__(self, mason: str, mason_file: Path):
+        self._mason = mason
+        self._mason_file = mason_file
+        self._module_dirs = [mason_file.parent / "src"]
+        self._files = self._get_mason_modules()
+
+    def _get_mason_modules(self) -> List[Path]:
+        result = run_mason_cmd(self._mason_file.parent, self._mason, "modules", "--format=json", "--no-update")
+        if result is None:
+            return []
+        try:
+            output = json.loads(result)
+            modules = output.get("modules", [])
+            return [Path(m) for m in modules]
+        except json.JSONDecodeError as e:
+            from lsp_util import log
+            log(f"Error parsing mason modules output as JSON: {result}, error: {e}")
+            return []
+
+    def get_module_dirs(self) -> List[str]:
+        return [str(d) for d in self._module_dirs]
+
+    def get_files(self) -> List[str]:
+        return [str(f) for f in self._files]
+
+    @classmethod
+    def from_ws(cls, mason: str, workspace_root_uri: str) -> Optional["MasonProject"]:
+        workspace_root = Path(workspace_root_uri[len("file://") :])
+        from lsp_util import log
+        log(f"looking for Mason.toml in workspace root {workspace_root}")
+        mason_file = workspace_root / "Mason.toml"
+        if mason_file.is_file():
+            return cls(mason, mason_file)
+        return None
+
+
+
+def run_mason_cmd(project_home: Path, mason: str, cmd: str, *args) -> Optional[str]:
+    env = os.environ.copy()
+    env["MASON_LOG_LEVEL"] = "error"
+    result = subprocess.run(
+        [mason, cmd] + list(args),
+        cwd=project_home,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        from lsp_util import log
+        log(f"Error running mason command: {result.stderr}")
+        return None
+    return result.stdout

--- a/tools/chpl-language-server/test/mason.py
+++ b/tools/chpl-language-server/test/mason.py
@@ -1,9 +1,5 @@
 """
 Tests for mason project support in the language server.
-
-Two kinds of tests:
-  1. Integration tests that require the mason executable (skipped if unavailable).
-  2. Unit tests that use a fake mason script so the real mason is not needed.
 """
 
 import os

--- a/tools/chpl-language-server/test/mason.py
+++ b/tools/chpl-language-server/test/mason.py
@@ -137,12 +137,12 @@ async def test_mason(client: LanguageClient):
             MyDep = "0.1.0"
             """
 
-    async with unrelated_source_files_dict(
+    async with with_file_structure(
         client,
         {
-            "src/Package": filePackage,
-            "test/Test": fileTest,
-            "example/Example": fileExample,
+            "src/Package.chpl": filePackage,
+            "test/Test.chpl": fileTest,
+            "example/Example.chpl": fileExample,
             "Mason.toml": toml,
             fake_mason_dep: fileMyDep,
         },
@@ -194,12 +194,12 @@ async def test_mason(client: LanguageClient):
             docs("src/Package"),
             docs("test/Test"),
             docs("example/Example"),
-            docs("in/a/weird/far/away/place/MyDep"),
+            docs(fake_mason_dep),
         )
         assert len(client.diagnostics[docs("src/Package").uri]) == 0
         assert len(client.diagnostics[docs("test/Test").uri]) == 0
         assert len(client.diagnostics[docs("example/Example").uri]) == 0
         assert (
-            len(client.diagnostics[docs("in/a/weird/far/away/place/MyDep").uri])
+            len(client.diagnostics[docs(fake_mason_dep).uri])
             == 0
         )

--- a/tools/chpl-language-server/test/mason.py
+++ b/tools/chpl-language-server/test/mason.py
@@ -1,0 +1,207 @@
+"""
+Tests for mason project support in the language server.
+
+Two kinds of tests:
+  1. Integration tests that require the mason executable (skipped if unavailable).
+  2. Unit tests that use a fake mason script so the real mason is not needed.
+"""
+
+import os
+import shutil
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from lsprotocol.types import ClientCapabilities
+from lsprotocol.types import InitializeParams
+import pytest
+import pytest_lsp
+from pytest_lsp import ClientServerConfig, LanguageClient
+
+from util.utils import *
+from util.config import CLS_PATH
+
+
+def _write_fake_mason(directory: str, modules_output: str) -> None:
+    """Write a small shell script called ``mason`` into *directory*.
+
+    When invoked as ``mason modules`` it prints *modules_output* to stdout.
+    All other sub-commands exit 0 with no output.
+    """
+    script = os.path.join(directory, "mason")
+    with open(script, "w") as f:
+        f.write("#!/usr/bin/env python3\n")
+        f.write("import sys\n")
+        f.write('if len(sys.argv) >= 2 and sys.argv[1] == "modules":\n')
+        f.write(f'  print("{{\\"modules\\": [\\"{modules_output}\\"]}}")\n')
+    os.chmod(
+        script,
+        os.stat(script).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH,
+    )
+
+
+def make_fake_mason_env(modules_output: str) -> tuple:
+    """Create a temporary directory containing a fake ``mason`` and return
+    ``(tmpdir, server_env)`` where *server_env* is suitable for passing to
+    ``ClientServerConfig(server_env=...)``.
+
+    The caller is responsible for cleaning up *tmpdir* (it is a
+    ``tempfile.TemporaryDirectory``).
+    """
+    tmpdir = tempfile.TemporaryDirectory()
+    fake_mason_dep = os.path.join(tmpdir.name, modules_output)
+    _write_fake_mason(tmpdir.name, fake_mason_dep)
+    env = os.environ.copy()
+    env["PATH"] = tmpdir.name + os.pathsep + env.get("PATH", "")
+    return tmpdir, env, fake_mason_dep
+
+
+_fake_mason_dir, _fake_mason_env, fake_mason_dep = make_fake_mason_env(
+    "in/a/weird/far/away/place/MyDep.chpl"
+)
+
+def teardown_module():
+    _fake_mason_dir.cleanup()
+
+
+@pytest_lsp.fixture(
+    config=ClientServerConfig(
+        server_command=[sys.executable, CLS_PATH()],
+        server_env=_fake_mason_env,
+        client_factory=get_base_client,
+    ),
+)
+async def client(lsp_client: LanguageClient):
+    # Setup
+    params = InitializeParams(capabilities=ClientCapabilities())
+    await lsp_client.initialize_session(params)
+
+    yield
+
+    # Teardown
+    await lsp_client.shutdown_session()
+
+
+@pytest.mark.asyncio
+async def test_mason(client: LanguageClient):
+    """
+    Test that the mock_get_mason_modules context manager correctly patches
+    """
+
+    filePackage = """
+            module Package {
+              import MyDep;
+              var x = 42;
+              var z = MyDep.y;
+              proc main() {
+                writeln(x);
+                writeln(z);
+              }
+            }
+            """
+    fileTest = """
+            use UnitTest;
+            import Package;
+            import MyDep;
+
+            proc myTest(test: borrowed Test) throws {
+              test.assertEqual(Package.x, 42);
+              test.assertEqual(Package.z, MyDep.y);
+            }
+
+            UnitTest.main();
+            """
+    fileExample = """
+            import Package;
+            import MyDep;
+            proc main() {
+              writeln(Package.x);
+              writeln(MyDep.y);
+              writeln(Package.z);
+            }
+            """
+
+    fileMyDep = """
+            module MyDep {
+              var y = 99;
+            }
+            """
+    toml = """
+            [brick]
+            chplVersion = "2.9.0"
+            license = "None"
+            name = "Package"
+            type = "application"
+            version = "0.1.0"
+
+            [dependencies]
+            MyDep = "0.1.0"
+            """
+
+    async with unrelated_source_files_dict(
+        client,
+        {
+            "src/Package": filePackage,
+            "test/Test": fileTest,
+            "example/Example": fileExample,
+            "Mason.toml": toml,
+            fake_mason_dep: fileMyDep,
+        },
+    ) as docs:
+
+        x_def = (docs("src/Package"), pos((2, 6)))
+        y_def = (docs(fake_mason_dep), pos((1, 6)))
+        z_def = (docs("src/Package"), pos((3, 6)))
+        myDep_def = (docs(fake_mason_dep), pos((0, 7)))
+
+        x_use = [
+            (docs("src/Package"), pos((5, 12))),
+            (docs("test/Test"), pos((5, 27))),
+            (docs("example/Example"), pos((3, 18))),
+        ]
+        y_use = [
+            (docs("src/Package"), pos((3, 16))),
+            (docs("test/Test"), pos((6, 36))),
+            (docs("example/Example"), pos((4, 16))),
+        ]
+        z_use = [
+            (docs("src/Package"), pos((6, 12))),
+            (docs("test/Test"), pos((6, 27))),
+            (docs("example/Example"), pos((5, 18))),
+        ]
+        myDep_use = [
+            (docs("src/Package"), pos((1, 9))),
+            (docs("src/Package"), pos((3, 10))),
+            (docs("test/Test"), pos((2, 7))),
+            (docs("test/Test"), pos((6, 30))),
+            (docs("example/Example"), pos((1, 7))),
+            (docs("example/Example"), pos((4, 10))),
+        ]
+
+        to_check = [
+            (x_def, x_use),
+            (y_def, y_use),
+            (z_def, z_use),
+            (myDep_def, myDep_use),
+        ]
+        for def_loc, use_locs in to_check:
+            for use_loc in use_locs:
+                await check_goto_decl_def(client, use_loc[0], use_loc[1], def_loc)
+
+
+        await save_file(
+            client,
+            docs("src/Package"),
+            docs("test/Test"),
+            docs("example/Example"),
+            docs("in/a/weird/far/away/place/MyDep"),
+        )
+        assert len(client.diagnostics[docs("src/Package").uri]) == 0
+        assert len(client.diagnostics[docs("test/Test").uri]) == 0
+        assert len(client.diagnostics[docs("example/Example").uri]) == 0
+        assert (
+            len(client.diagnostics[docs("in/a/weird/far/away/place/MyDep").uri])
+            == 0
+        )

--- a/tools/chpl-language-server/test/mason.py
+++ b/tools/chpl-language-server/test/mason.py
@@ -62,6 +62,7 @@ _fake_mason_dir, _fake_mason_env, fake_mason_dep = make_fake_mason_env(
     "in/a/weird/far/away/place/MyDep.chpl"
 )
 
+
 def teardown_module():
     _fake_mason_dir.cleanup()
 
@@ -188,8 +189,9 @@ async def test_mason(client: LanguageClient):
         ]
         for def_loc, use_locs in to_check:
             for use_loc in use_locs:
-                await check_goto_decl_def(client, use_loc[0], use_loc[1], def_loc)
-
+                await check_goto_decl_def(
+                    client, use_loc[0], use_loc[1], def_loc
+                )
 
         await save_file(
             client,

--- a/tools/chpl-language-server/test/show_generic.py
+++ b/tools/chpl-language-server/test/show_generic.py
@@ -501,9 +501,7 @@ async def test_lenses_default_rect_with_calls(client: LanguageClient):
         default_inlays,
     ]
 
-    await click_lenses_and_check_inlays(
-        client, expected_lens, all_inlays, A=file
-    )
+    await click_lenses_and_check_inlays(client, expected_lens, all_inlays, A=file)
 
 
 @pytest.mark.asyncio

--- a/tools/chpl-language-server/test/show_generic.py
+++ b/tools/chpl-language-server/test/show_generic.py
@@ -412,7 +412,9 @@ async def test_lenses_default_rect_twoargs(client: LanguageClient):
         default_inlays,
     ]
 
-    await click_lenses_and_check_inlays(client, expected_lens, all_inlays, A=file)
+    await click_lenses_and_check_inlays(
+        client, expected_lens, all_inlays, A=file
+    )
 
 
 @pytest.mark.asyncio
@@ -454,7 +456,9 @@ async def test_lenses_default_rect_other_args(client: LanguageClient):
         default_inlays,
     ]
 
-    await click_lenses_and_check_inlays(client, expected_lens, all_inlays, A=file)
+    await click_lenses_and_check_inlays(
+        client, expected_lens, all_inlays, A=file
+    )
 
 
 @pytest.mark.asyncio
@@ -497,7 +501,9 @@ async def test_lenses_default_rect_with_calls(client: LanguageClient):
         default_inlays,
     ]
 
-    await click_lenses_and_check_inlays(client, expected_lens, all_inlays, A=file)
+    await click_lenses_and_check_inlays(
+        client, expected_lens, all_inlays, A=file
+    )
 
 
 @pytest.mark.asyncio

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -76,35 +76,60 @@ class SourceFilesContext:
     def __init__(
         self,
         client: LanguageClient,
-        files: typing.Dict[str, str],
-        build_cls_commands: bool = True,
+        tempdir: tempfile.TemporaryDirectory,
     ):
-        self.tempdir = tempfile.TemporaryDirectory()
         self.client = client
+        self.tempdir = tempdir
 
+    @classmethod
+    def from_files(cls, client: LanguageClient, files: typing.Dict[str, str], build_cls_commands: bool = True):
+        tempdir = tempfile.TemporaryDirectory()
+        instance = cls(client, tempdir)
+        if build_cls_commands:
+            instance._build_cls_commands(files)
+        else:
+            instance._add_files(files)
+        return instance
+
+    @classmethod
+    def from_explicit_files(cls, client: LanguageClient, files: typing.Dict[str, str]):
+        tempdir = tempfile.TemporaryDirectory()
+        instance = cls(client, tempdir)
+        instance._add_explicit_files(files)
+        return instance
+
+    @staticmethod
+    def _create_file_at_path(path: str, contents: str):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(strip_leading_whitespace(contents))
+
+    def _add_files(self, files: typing.Dict[str, str]):
+        for name, contents in files.items():
+            filepath = os.path.join(self.tempdir.name, name + ".chpl")
+            SourceFilesContext._create_file_at_path(filepath, contents)
+
+    def _add_explicit_files(self, files: typing.Dict[str, str]):
+        for name, contents in files.items():
+            if not os.path.isabs(name):
+                filepath = os.path.join(self.tempdir.name, name)
+                SourceFilesContext._create_file_at_path(filepath, contents)
+            else:
+                SourceFilesContext._create_file_at_path(name, contents)
+
+    def _build_cls_commands(self, files: typing.Dict[str, str]):
         commands = {}
         allfiles = []
         for name, contents in files.items():
-            p = os.path.normpath(name)
-            if not os.path.isabs(p):
-                if "." in name:
-                    filepath = os.path.join(self.tempdir.name, name)
-                else:
-                    filepath = os.path.join(self.tempdir.name, name + ".chpl")
-            else:
-                filepath = p
-            os.makedirs(os.path.dirname(filepath), exist_ok=True)
-            with open(filepath, "w") as f:
-                f.write(strip_leading_whitespace(contents))
+            filepath = os.path.join(self.tempdir.name, name + ".chpl")
+            SourceFilesContext._create_file_at_path(filepath, contents)
 
-            if filepath.endswith(".chpl"):
-                allfiles.append(filepath)
-                commands[filepath] = [{"module_dirs": [], "files": allfiles}]
+            allfiles.append(filepath)
+            commands[filepath] = [{"module_dirs": [], "files": allfiles}]
 
         commandspath = os.path.join(self.tempdir.name, ".cls-commands.json")
-        if build_cls_commands:
-            with open(commandspath, "w") as f:
-                json.dump(commands, f)
+        with open(commandspath, "w") as f:
+            json.dump(commands, f)
 
     def _get_doc(self, name: str) -> TextDocumentIdentifier:
         if os.path.isabs(name):
@@ -138,7 +163,7 @@ class SourceFileContext:
         num_errors: typing.Optional[int],
     ):
         self.main_file = main_file
-        self.source_files_context = SourceFilesContext(client, files)
+        self.source_files_context = SourceFilesContext.from_files(client, files)
         self.num_errors = num_errors
 
     async def __aenter__(self):
@@ -165,7 +190,7 @@ def source_files(client: LanguageClient, **files: str):
     Also creates a .cls-commands.json file that can be used by the
     language server to connect the files together in the workspace.
     """
-    return SourceFilesContext(client, files)
+    return SourceFilesContext.from_files(client, files)
 
 
 def unrelated_source_files(client: LanguageClient, **files: str):
@@ -173,17 +198,18 @@ def unrelated_source_files(client: LanguageClient, **files: str):
     Same as 'source_files', but doesn't create a .cls-commands.json file that
     would cause the files to be treated as "connected" and resolved together.
     """
-    return SourceFilesContext(client, files, build_cls_commands=False)
+    return SourceFilesContext.from_files(client, files, build_cls_commands=False)
 
 
-def unrelated_source_files_dict(
+def with_file_structure(
     client: LanguageClient, files: typing.Dict[str, str]
 ):
     """
-    Same as 'source_files', but doesn't create a .cls-commands.json file that
-    would cause the files to be treated as "connected" and resolved together.
+    Same as 'source_files', but requires an explicit file structure. relative
+    paths will be treated as relative to the temporary directory, and absolute
+    paths will be used as-is. No .cls-commands.json file will be created
     """
-    return SourceFilesContext(client, files, build_cls_commands=False)
+    return SourceFilesContext.from_explicit_files(client, files)
 
 
 def source_file(
@@ -208,7 +234,7 @@ def source_files_dict(client: LanguageClient, files: typing.Dict[str, str]):
     Also creates a .cls-commands.json file that can be used by the
     language server to connect the files together in the workspace.
     """
-    return SourceFilesContext(client, files)
+    return SourceFilesContext.from_files(client, files)
 
 
 async def save_file(client: LanguageClient, *docs: TextDocumentIdentifier):

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -85,20 +85,21 @@ class SourceFilesContext:
         commands = {}
         allfiles = []
         for name, contents in files.items():
-            # make the directory structure, last component is the name
-            dir_path = self.tempdir.name
-            components = os.path.normpath(name).split(os.sep)
-            name = components[-1]
-            for component in components[:-1]:
-                dir_path = os.path.join(dir_path, component)
-                os.makedirs(dir_path, exist_ok=True)
-
-            filepath = os.path.join(dir_path, name + ".chpl")
+            p = os.path.normpath(name)
+            if not os.path.isabs(p):
+                if "." in name:
+                    filepath = os.path.join(self.tempdir.name, name)
+                else:
+                    filepath = os.path.join(self.tempdir.name, name + ".chpl")
+            else:
+                filepath = p
+            os.makedirs(os.path.dirname(filepath), exist_ok=True)
             with open(filepath, "w") as f:
                 f.write(strip_leading_whitespace(contents))
 
-            allfiles.append(filepath)
-            commands[filepath] = [{"module_dirs": [], "files": allfiles}]
+            if filepath.endswith(".chpl"):
+                allfiles.append(filepath)
+                commands[filepath] = [{"module_dirs": [], "files": allfiles}]
 
         commandspath = os.path.join(self.tempdir.name, ".cls-commands.json")
         if build_cls_commands:
@@ -106,8 +107,12 @@ class SourceFilesContext:
                 json.dump(commands, f)
 
     def _get_doc(self, name: str) -> TextDocumentIdentifier:
+        if os.path.isabs(name):
+            filepath = name
+        else:
+            filepath = os.path.join(self.tempdir.name, name + '.chpl')
         return TextDocumentIdentifier(
-            uri=f"file://{os.path.join(self.tempdir.name, name + '.chpl')}"
+            uri=f"file://{filepath}"
         )
 
     async def __aenter__(self):
@@ -166,6 +171,14 @@ def source_files(client: LanguageClient, **files: str):
 
 
 def unrelated_source_files(client: LanguageClient, **files: str):
+    """
+    Same as 'source_files', but doesn't create a .cls-commands.json file that
+    would cause the files to be treated as "connected" and resolved together.
+    """
+    return SourceFilesContext(client, files, build_cls_commands=False)
+
+
+def unrelated_source_files_dict(client: LanguageClient, files: typing.Dict[str, str]):
     """
     Same as 'source_files', but doesn't create a .cls-commands.json file that
     would cause the files to be treated as "connected" and resolved together.

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -110,10 +110,8 @@ class SourceFilesContext:
         if os.path.isabs(name):
             filepath = name
         else:
-            filepath = os.path.join(self.tempdir.name, name + '.chpl')
-        return TextDocumentIdentifier(
-            uri=f"file://{filepath}"
-        )
+            filepath = os.path.join(self.tempdir.name, name + ".chpl")
+        return TextDocumentIdentifier(uri=f"file://{filepath}")
 
     async def __aenter__(self):
         self.tempdir.__enter__()
@@ -178,7 +176,9 @@ def unrelated_source_files(client: LanguageClient, **files: str):
     return SourceFilesContext(client, files, build_cls_commands=False)
 
 
-def unrelated_source_files_dict(client: LanguageClient, files: typing.Dict[str, str]):
+def unrelated_source_files_dict(
+    client: LanguageClient, files: typing.Dict[str, str]
+):
     """
     Same as 'source_files', but doesn't create a .cls-commands.json file that
     would cause the files to be treated as "connected" and resolved together.


### PR DESCRIPTION
Further improves the CLS+Mason support by having CLS interrogate `mason` to determine mason dependencies.

The result of this PR is that if a user opens a mason project with dependencies, CLS should be able to resolve everything in the editor automatically with no extra work from the user (no `chpl-shim`, no custom `-M` flags)

Requires https://github.com/chapel-lang/chapel/pull/28671

[Reviewed by @DanilaFe]