### PR TITLE
CLS: fix goto-type-definition on record/class member fields

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -981,7 +981,11 @@ def run_lsp():
 
         fi, _ = ls.get_file_info(text_doc.uri)
 
-        node_and_loc = fi.get_target_segment_at_position(params.position)
+        # Use the source expression (identifier under cursor) rather than the
+        # declaration it resolves to, because the expression's type is more
+        # sensitive to the current context (e.g., when instantiations are
+        # in play), and because it already has the type information.
+        node_and_loc = fi.get_source_segment_at_position(params.position)
         if not node_and_loc:
             return None
 

--- a/tools/chpl-language-server/src/lsp_util.py
+++ b/tools/chpl-language-server/src/lsp_util.py
@@ -1394,6 +1394,32 @@ class FileInfo:
 
         return None
 
+    def get_source_segment_at_position(
+        self, position: Position
+    ) -> Optional[NodeAndRange]:
+        """
+        Like get_target_segment_at_position, but returns the source expression
+        (the identifier under the cursor) rather than the declaration it resolves
+        to. This is useful for queries like go-to-type-definition, where we want
+        the type of the expression written by the user, not the type stored on
+        the declaration node (which is generally harder to come by and ought
+        to be equivalent).
+        """
+
+        segment = self.get_call_segment_at_position(position)
+        if segment:
+            return segment.ident
+
+        segment = self.get_use_segment_at_position(position)
+        if segment:
+            return segment.ident
+
+        segment = self.get_def_segment_at_position(position)
+        if segment:
+            return segment
+
+        return None
+
     def file_lines(self) -> List[str]:
         file_text = self.context.context.get_file_text(
             self.uri[len("file://") :]

--- a/tools/chpl-language-server/test/basic_resolver.py
+++ b/tools/chpl-language-server/test/basic_resolver.py
@@ -118,6 +118,38 @@ async def test_go_to_call_generic(client: LanguageClient):
 
 
 @pytest.mark.asyncio
+async def test_goto_type_def_member_field(client: LanguageClient):
+    """
+    Ensure that goto-type-definition works on a field accessed via implicit
+    'this' inside a method body (issue #28574).
+    """
+
+    file = """
+           record myOtherRec {
+             proc foo(x) { }
+           }
+           record myRec {
+             var x: myOtherRec;
+             proc doIt() {
+               var y = x;
+               x.foo(1);
+               y.foo(1);
+             }
+           }
+           var r: myRec;
+           r.doIt();
+           """
+
+    async with source_file(client, file) as doc:
+        # Both 'y' and 'x' are of type 'myOtherRec' and go-to-type-def
+        # should take you there.
+        await check_goto_type_def(client, doc, pos((6, 8)), pos((0, 7)))
+        await check_goto_type_def(client, doc, pos((6, 12)), pos((0, 7)))
+        await check_goto_type_def(client, doc, pos((7, 4)), pos((0, 7)))
+        await check_goto_type_def(client, doc, pos((8, 4)), pos((0, 7)))
+
+
+@pytest.mark.asyncio
 async def test_string(client: LanguageClient):
     """
     Ensure that goto-type works on a string.


### PR DESCRIPTION
Closes #28574.

Go to type definition now works when the cursor is on an identifier that refers to a field accessed via implicit 'this' inside a method.

The root cause was that `get_type_def` called `.type()` on the declaration node returned by `get_target_segment_at_position`. In general, this is not easy to use because a) we don't have good support for "compute type via record", and b) loses information about the particular instantiation of the record. The reference identifier node itself carries the resolved type, so use that when possible.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] CLS tests