### PR TITLE
dlopen: Adjust some codegen-time arrays to be `GEN_VAL` instead of `GEN_PTR`

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2221,6 +2221,7 @@ codegen_config() {
     genGlobalInt("mainPreserveDelimiter", mainPreserveDelimiter, false);
     genGlobalInt("warnUnstable", fWarnUnstable, false);
 
+    fprintf(outfile, "void CreateConfigVarTable(void);\n");
     fprintf(outfile, "void CreateConfigVarTable(void) {\n");
     fprintf(outfile, "initConfigVarTable();\n");
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1538,7 +1538,7 @@ static void genGlobalSerializeTable(GenInfo* info) {
         llvm::ConstantArray::get(
           global_serializeTableType, global_serializeTable));
     info->lvt->addGlobalValue("chpl_global_serialize_table",
-                              global_serializeTableGVar, GEN_PTR, true, dtCVoidPtr);
+                              global_serializeTableGVar, GEN_VAL, true, dtCVoidPtr);
 #endif
   }
 }
@@ -2085,7 +2085,7 @@ static void codegen_header(std::set<const char*> & cnames,
     chpl_globals_registryGVar->setInitializer(
         llvm::Constant::getNullValue(globValType));
     info->lvt->addGlobalValue("chpl_globals_registry",
-                              chpl_globals_registryGVar, GEN_PTR, true, /* chplType= */ nullptr);
+                              chpl_globals_registryGVar, GEN_VAL, true, /* chplType= */ nullptr);
 #endif
   }
   if( hdrfile ) {
@@ -2111,7 +2111,7 @@ static void codegen_header(std::set<const char*> & cnames,
     chpl_memDescsGVar->setInitializer(
         llvm::ConstantArray::get(memDescTableType, memDescTable));
     chpl_memDescsGVar->setConstant(true);
-    info->lvt->addGlobalValue("chpl_mem_descs", chpl_memDescsGVar, GEN_PTR, true, dtStringC);
+    info->lvt->addGlobalValue("chpl_mem_descs", chpl_memDescsGVar, GEN_VAL, true, dtStringC);
 #endif
   }
 
@@ -2161,7 +2161,7 @@ static void codegen_header(std::set<const char*> & cnames,
         llvm::ConstantArray::get(
           private_broadcastTableType, private_broadcastTable));
     info->lvt->addGlobalValue("chpl_private_broadcast_table",
-                              private_broadcastTableGVar, GEN_PTR, true, dtCVoidPtr);
+                              private_broadcastTableGVar, GEN_VAL, true, dtCVoidPtr);
     genGlobalInt("chpl_private_broadcast_table_len",
                  private_broadcastTable.size(), false);
 #endif

--- a/test/dynamic-loading/CodegenTimeArrays.chpl
+++ b/test/dynamic-loading/CodegenTimeArrays.chpl
@@ -1,10 +1,10 @@
 use CTypes;
 
-
 extern {
   #include "chpltypes.h"
   #include <stdio.h>
 
+  // Test to see what happens when we load or store into a struct.
   typedef struct holder {
     void** global_serialize_table;
     void** globals_registry;

--- a/test/dynamic-loading/CodegenTimeArrays.chpl
+++ b/test/dynamic-loading/CodegenTimeArrays.chpl
@@ -1,0 +1,104 @@
+use CTypes;
+
+
+extern {
+  #include "chpltypes.h"
+  #include <stdio.h>
+
+  typedef struct holder {
+    void** global_serialize_table;
+    void** globals_registry;
+    char** mem_descs;
+    void** private_broadcast_table;
+  } holder;
+
+  // Pass in the values materialized from the addresses through Chapel.
+  void getter_chpl_global_serialize_table(void** x);
+  void getter_chpl_globals_registry(void** x);
+  void getter_chpl_mem_descs(char** x);
+  void getter_chpl_private_broadcast_table(void** x);
+  void get_from_holder(holder* x);
+
+  // Realize the addresses in C.
+  extern void* const chpl_global_serialize_table[];
+  extern ptr_wide_ptr_t chpl_globals_registry[];
+  extern const char* chpl_mem_descs[];
+  extern void* const chpl_private_broadcast_table[];
+
+  #define PRINTER(in__, name__) do {                        \
+    void* ptr1 = ((void*) in__);                            \
+    void* ptr2 = ((void*) name__);                          \
+    printf("%s\n", __FUNCTION__);                           \
+    const char* msg = (ptr1 == ptr2) ? "GOOD" : "FAIL";     \
+    printf("%s\n", msg );                                   \
+  } while (0)
+    
+  void getter_chpl_global_serialize_table(void** x) {
+    PRINTER(x, chpl_global_serialize_table);
+  }
+
+  void getter_chpl_globals_registry(void** x) {
+    PRINTER(x, chpl_globals_registry);
+  }
+
+  void getter_chpl_mem_descs(char** x) {
+    PRINTER(x, chpl_mem_descs);
+  }
+
+  void getter_chpl_private_broadcast_table(void** x) {
+    PRINTER(x, chpl_private_broadcast_table);
+  }
+
+  void get_from_holder(holder* x) {
+    printf("-- %s --\n", __FUNCTION__);
+    getter_chpl_global_serialize_table(x->global_serialize_table);
+    getter_chpl_globals_registry(x->globals_registry);
+    getter_chpl_mem_descs(x->mem_descs);
+    getter_chpl_private_broadcast_table(x->private_broadcast_table);
+  }
+
+  #undef PRINTER
+}
+
+proc callTheGetter(param name: string, in x) {
+  select name {
+    // Can generate calls to these using 'name' and pass a 'void*' to copy,
+    // but opt not to do that here in order to simplify the testing surface.
+    when 'chpl_global_serialize_table'  do getter_chpl_global_serialize_table(x);
+    when 'chpl_globals_registry'        do getter_chpl_globals_registry(x);
+    when 'chpl_mem_descs'               do getter_chpl_mem_descs(x);
+    when 'chpl_private_broadcast_table' do getter_chpl_private_broadcast_table(x);
+    otherwise                           halt('Not handled!');
+  }
+}
+
+// chpl_global_serialize_table
+// chpl_globals_registry
+// chpl_mem_descs
+// chpl_private_broadcast_table
+proc test() {
+  extern const chpl_global_serialize_table:     c_ptr(c_ptr(void));
+  extern const chpl_globals_registry:           c_ptr(c_ptr(void));
+  extern const chpl_mem_descs:                  c_ptr(c_ptr(c_char));
+  extern const chpl_private_broadcast_table:    c_ptr(c_ptr(void));
+
+  callTheGetter('chpl_global_serialize_table',
+                 chpl_global_serialize_table);
+  callTheGetter('chpl_globals_registry',
+                 chpl_globals_registry);
+  callTheGetter('chpl_mem_descs', chpl_mem_descs);
+  callTheGetter('chpl_private_broadcast_table',
+                 chpl_private_broadcast_table);
+
+  var x: holder;
+  x.global_serialize_table  = chpl_global_serialize_table;
+  x.globals_registry        = chpl_globals_registry;
+  x.mem_descs               = chpl_mem_descs;
+  x.private_broadcast_table = chpl_private_broadcast_table;
+
+  get_from_holder(c_ptrTo(x));
+}
+
+proc main() {
+  test();
+}

--- a/test/dynamic-loading/CodegenTimeArrays.good
+++ b/test/dynamic-loading/CodegenTimeArrays.good
@@ -1,0 +1,17 @@
+getter_chpl_global_serialize_table
+GOOD
+getter_chpl_globals_registry
+GOOD
+getter_chpl_mem_descs
+GOOD
+getter_chpl_private_broadcast_table
+GOOD
+-- get_from_holder --
+getter_chpl_global_serialize_table
+GOOD
+getter_chpl_globals_registry
+GOOD
+getter_chpl_mem_descs
+GOOD
+getter_chpl_private_broadcast_table
+GOOD

--- a/test/dynamic-loading/CodegenTimeArrays.skipif
+++ b/test/dynamic-loading/CodegenTimeArrays.skipif
@@ -1,1 +1,1 @@
-CHPL_LLVM=none
+CHPL_LLVM == none

--- a/test/dynamic-loading/CodegenTimeArrays.skipif
+++ b/test/dynamic-loading/CodegenTimeArrays.skipif
@@ -1,0 +1,1 @@
+CHPL_LLVM=none


### PR DESCRIPTION
This PR adjusts several constant arrays prepared at codegen-time under LLVM to be marked as `GEN_VAL` instead of `GEN_PTR` as preparation for further dynamic loading work. It also adds a test to lock in the correct behavior for the LLVM backend.

This change has no effect on the C backend. The generated code remains the exact same.

For the LLVM backend, before this change the Chapel compiler would emit a load instruction and deref the symbol's address. Then, it would pass the deref'd pointer around, which effectively contained garbage. This caused bizarre behavior within C code that inspected the pointer.

After this change, the LLVM code emitted by the Chapel compiler just uses the symbol directly. Intuitively, this more closely matches C semantics (e.g., if we have a `char** foo`, we want to just pass that `foo` around as a value as opposed to doing `*foo` every time we try to read it).

While here, also forward declare a function `CreateConfigVarTable(void);` under the C backend. This will be needed later when it is no longer forward declared by the runtime.

TESTING

- [x] `standard`
- [x] `COMM=none`, `COMPILER=clang`
- [x] `COMM=gasnet`
- [x] `COMM=gasnet`, `COMPILER=clang`
- [x] `COMM=none`, `LLVM=none`

Reviewed @benharsh. Thanks!