### PR TITLE
Adjust `FileSystem.listDir` to have error handling

### DIFF
--- a/doc/rst/technotes/editions.rst
+++ b/doc/rst/technotes/editions.rst
@@ -157,6 +157,9 @@ remain in the preview until they are deemed sufficiently complete.
 - The ``string.contains()`` and ``bytes.contains()`` methods return whether
   a given pattern is found within the receiver string or bytes value.
 
-- The ``list.find()`` and ``list.contains()`` methods can optionally accept a 
-  predicate callable, allowing users to search for elements matching a custom 
+- The ``list.find()`` and ``list.contains()`` methods can optionally accept a
+  predicate callable, allowing users to search for elements matching a custom
   condition rather than only equality comparison.
+
+- The ``FileSystem.listDir()`` iterator throws when it encounters an error,
+  rather than just printing the error to stdout.

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -953,8 +953,54 @@ proc isMount(name: string): bool throws {
 
    :yield: The names of the specified directory's contents, as strings
 */
+@edition(last="2.0")
 iter listDir(path: string = ".", hidden: bool = false, dirs: bool = true,
               files: bool = true, listlinks: bool = true): string {
+  try {
+    for l in listDirHelper(path=path, hidden=hidden,
+                          dirs=dirs, files=files, listlinks=listlinks) do
+      yield l;
+  } catch e {
+    writeln(e.message());
+  }
+}
+/* Lists the contents of a directory.  May be invoked in serial
+   contexts only.
+
+   :arg path: The directory whose contents should be listed
+              (defaults to ``"."``)
+   :type path: `string`
+
+   :arg hidden: Indicates whether hidden files/directory should be listed
+                (defaults to `false`)
+   :type hidden: `bool`
+
+   :arg dirs: Indicates whether directories should be listed
+              (defaults to `true`)
+   :type dirs: `bool`
+
+   :arg files: Indicates whether files should be listed (defaults to `true`)
+   :type files: `bool`
+
+   :arg listlinks: Indicates whether symbolic links should be listed
+                   (defaults to `true`)
+   :type listlinks: `bool`
+
+   :yield: The names of the specified directory's contents, as strings
+
+   :throws SystemError: Thrown to describe a system error
+   :throws Errror: Thrown to describe an unknown error
+*/
+@edition(first="preview")
+iter listDir(path: string = ".", hidden: bool = false, dirs: bool = true,
+              files: bool = true, listlinks: bool = true): string throws {
+  for l in listDirHelper(path=path, hidden=hidden,
+                         dirs=dirs, files=files, listlinks=listlinks) do
+    yield l;
+}
+@chpldoc.nodoc
+iter listDirHelper(path: string, hidden: bool, dirs: bool,
+                   files: bool, listlinks: bool): string throws {
   extern record DIR {}
   extern type DIRptr = c_ptr(DIR);
   extern "struct dirent" record chpl_dirent {}
@@ -970,32 +1016,28 @@ iter listDir(path: string = ".", hidden: bool = false, dirs: bool = true,
   }
 
   var dir: DIRptr = opendir(unescape(path).c_str());
-  if (dir != nil) {
+  if dir != nil {
     var ent: direntptr = readdir(dir);
-    while (ent != nil) {
+    while ent != nil {
       var filename: string;
-      try! {
-        filename = string.createCopyingBuffer(ent.d_name(),
-                                             policy=decodePolicy.escape);
-      }
-      if (hidden || filename[0] != '.') {
-        if (filename != "." && filename != "..") {
+      filename = string.createCopyingBuffer(ent.d_name(),
+                                            policy=decodePolicy.escape);
+      if hidden || filename[0] != '.' {
+        if filename != "." && filename != ".." {
           const fullpath = path + "/" + filename;
 
           // TODO: revisit error handling for this method
           try {
-            if (listlinks || !isSymlink(fullpath)) {
-              if (dirs && isDir(fullpath)) then
+            if listlinks || !isSymlink(fullpath) {
+              if dirs && isDir(fullpath) then
                 yield filename;
-              else if (files && isFile(fullpath)) then
+              else if files && isFile(fullpath) then
                 yield filename;
             }
           } catch e: SystemError {
-            writeln("error in listDir(): ", errorToString(e.err));
-            break;
+            throw e;
           } catch {
-            writeln("unknown error in listDir()");
-            break;
+            throw new Error("unknown error in listDir()");
           }
         }
       }
@@ -1003,8 +1045,7 @@ iter listDir(path: string = ".", hidden: bool = false, dirs: bool = true,
     }
     closedir(dir);
   } else {
-    extern proc perror(s: c_ptrConst(c_char));
-    perror(("error in listDir(): " + path).c_str());
+    throw new SystemError(errno:errorCode, "error in listDir(): " + path);
   }
 }
 

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -989,7 +989,7 @@ iter listDir(path: string = ".", hidden: bool = false, dirs: bool = true,
    :yield: The names of the specified directory's contents, as strings
 
    :throws SystemError: Thrown to describe a system error
-   :throws Errror: Thrown to describe an unknown error
+   :throws Error: Thrown to describe an unknown error
 */
 @edition(first="preview")
 iter listDir(path: string = ".", hidden: bool = false, dirs: bool = true,

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1026,7 +1026,6 @@ iter listDirHelper(path: string, hidden: bool, dirs: bool,
         if filename != "." && filename != ".." {
           const fullpath = path + "/" + filename;
 
-          // TODO: revisit error handling for this method
           try {
             if listlinks || !isSymlink(fullpath) {
               if dirs && isDir(fullpath) then

--- a/modules/standard/OS.chpl
+++ b/modules/standard/OS.chpl
@@ -1276,11 +1276,9 @@ module OS {
     */
     override proc message() {
       var strerror_err: c_int = 0;
-      var errstr              = sys_strerror_syserr_str(err, strerror_err);
+      var errstr = sys_strerror_syserr_str(err, strerror_err);
       var err_msg: string;
-      try! {
-        err_msg = string.createAdoptingBuffer(errstr);
-      }
+      err_msg = try! string.createAdoptingBuffer(errstr);
 
       if !details.isEmpty() then
         err_msg += " (" + details + ")";
@@ -1302,9 +1300,7 @@ module OS {
     var strerror_err: c_int = 0;
     var errstr = sys_strerror_syserr_str(err, strerror_err);
     var err_msg: string;
-    try! {
-      err_msg = string.createAdoptingBuffer(errstr);
-    }
+    err_msg = try! string.createAdoptingBuffer(errstr);
 
     // return appropriate error
     select err {
@@ -1752,8 +1748,7 @@ module OS {
   pragma "insert line file info"
   pragma "always propagate line file info"
   @chpldoc.nodoc
-  proc ioerror(error:errorCode, msg:string, path:string, offset:int(64)) throws
-  {
+  proc ioerror(error:errorCode, msg:string, path:string, offset:int(64)) throws {
     if error {
       const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
       var   details    = msg + " with path " + quotedpath +
@@ -1765,8 +1760,7 @@ module OS {
   pragma "insert line file info"
   pragma "always propagate line file info"
   @chpldoc.nodoc // documented in the offset version
-  proc ioerror(error:errorCode, msg:string, path:string) throws
-  {
+  proc ioerror(error:errorCode, msg:string, path:string) throws {
     if error {
       const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
       var   details    = msg + " with path " + quotedpath;
@@ -1777,8 +1771,7 @@ module OS {
   pragma "insert line file info"
   pragma "always propagate line file info"
   @chpldoc.nodoc // documented in the offset version
-  proc ioerror(error:errorCode, msg:string) throws
-  {
+  proc ioerror(error:errorCode, msg:string) throws {
     if error then throw createSystemOrChplError(error, msg);
   }
 
@@ -1795,8 +1788,7 @@ module OS {
   pragma "insert line file info"
   pragma "always propagate line file info"
   @chpldoc.nodoc
-  proc ioerror(errstr:string, msg:string, path:string, offset:int(64)) throws
-  {
+  proc ioerror(errstr:string, msg:string, path:string, offset:int(64)) throws {
     const quotedpath = quote_string(path, path.numBytes:c_ssize_t);
     const details    = errstr + " " + msg + " with path " + quotedpath +
                        " offset " + offset:string;
@@ -1808,13 +1800,10 @@ module OS {
      :arg error: the error code
      :returns: a string describing the error
    */
-  proc errorToString(error:errorCode):string
-  {
+  proc errorToString(error:errorCode): string {
     var strerror_err:c_int = 0;
     const errstr = sys_strerror_syserr_str(error, strerror_err);
-    try! {
-      return string.createAdoptingBuffer(errstr);
-    }
+    return try! string.createAdoptingBuffer(errstr);
   }
 
 }

--- a/test/edition/preview/listDir.chpl
+++ b/test/edition/preview/listDir.chpl
@@ -1,0 +1,9 @@
+use FileSystem;
+
+proc main() {
+  try {
+    listDir("doesNotExist");
+  } catch e {
+    writeln("Thrown: ", e.message());
+  }
+}

--- a/test/edition/preview/listDir.compopts
+++ b/test/edition/preview/listDir.compopts
@@ -1,0 +1,2 @@
+ # listDir.good
+--edition=preview # listDir.new.good

--- a/test/edition/preview/listDir.good
+++ b/test/edition/preview/listDir.good
@@ -1,0 +1,1 @@
+No such file or directory (error in listDir(): doesNotExist)

--- a/test/edition/preview/listDir.new.good
+++ b/test/edition/preview/listDir.new.good
@@ -1,0 +1,1 @@
+Thrown: No such file or directory (error in listDir(): doesNotExist)

--- a/test/library/standard/FileSystem/filerator/listdir-errors.good
+++ b/test/library/standard/FileSystem/filerator/listdir-errors.good
@@ -1,2 +1,2 @@
-error in listDir(): no/such/dir/ever: No such file or directory
-error in listDir(): listdir-errors.chpl: Not a directory
+No such file or directory (error in listDir(): no/such/dir/ever)
+Not a directory (error in listDir(): listdir-errors.chpl)


### PR DESCRIPTION
I found that `FileSystem.listDir` would not throw errors when it encountered them (or even halt). Instead, it would just print the errors to the console and keep going.

This PR makes the iterator a throwing iterator, and it throws when it encounters errors. This is a breaking change and is guarded by an edition.


- [x] paratest

[Reviewed by @arifthpe]