### PR TITLE
Fix pulling mason dependencies with ssh

### DIFF
--- a/test/mason/cloneFallback.chpl
+++ b/test/mason/cloneFallback.chpl
@@ -1,0 +1,13 @@
+use MasonUtils;
+import ThirdParty.Pathlib.path;
+
+
+proc main() {
+
+  // test that cloneSource falls back to https if git clone fails with an ssh url, and that it throws an error if both attempts fail
+  try {
+    cloneSource("git@github.com:unknown/repo.git", "dummy":path);
+  } catch e {
+    writeln(e.message());
+  }
+}

--- a/test/mason/cloneFallback.execenv
+++ b/test/mason/cloneFallback.execenv
@@ -1,0 +1,1 @@
+MASON_LOG_LEVEL=debug

--- a/test/mason/cloneFallback.good
+++ b/test/mason/cloneFallback.good
@@ -1,0 +1,7 @@
+mason utils: Cloning from git@github.com:unknown/repo.git to (pathStr = dummy)
+mason utils: runWithStatus (quiet=true, capture=true): git clone --quiet git@github.com:unknown/repo.git dummy
+mason utils: Failed to clone from git@github.com:unknown/repo.git to (pathStr = dummy)
+mason utils: Retrying with https url: https://github.com/unknown/repo.git
+mason utils: runWithStatus (quiet=true, capture=true): git clone --quiet https://github.com/unknown/repo.git dummy
+mason utils: Failed to clone from https://github.com/unknown/repo.git to (pathStr = dummy)
+Failed to clone from git@github.com:unknown/repo.git

--- a/test/mason/gitErrors.chpl
+++ b/test/mason/gitErrors.chpl
@@ -1,11 +1,21 @@
 use FileSystem;
 use MasonUtils;
+use MasonBuild;
 use CTypes;
+use List;
 
+var path: string;
+extern proc setenv(name: c_ptrConst(c_char),
+                   envval: c_ptrConst(c_char), overwrite: c_int): c_int;
+extern proc getenv(name: c_ptrConst(c_char)): c_ptrConst(c_char);
 proc removePath() {
-  extern proc setenv(name: c_ptrConst(c_char), envval: c_ptrConst(c_char), overwrite: c_int): c_int;
+  path = string.createCopyingBuffer(getenv("PATH"));
   setenv("PATH", "", 1);
 }
+proc restorePath() {
+  setenv("PATH", path.c_str(), 1);
+}
+
 
 proc main(){
 
@@ -20,9 +30,38 @@ proc main(){
 
   try {
     removePath();
+    defer restorePath();
     gitC("srcTest", "git init");
   } catch e {
     writeln(e); // should get a missing git error
+  }
+
+  var srcList = new list([
+    new srcSource("this-url-will-not-exist", "dummy", "0.1.0"),
+    new srcSource("this-url-will-not-exist-either", "dummy2", "0.1.0")]);
+  var gitList = new list([
+    new gitSource("this-url-will-not-exist", "dummy", "HEAD", "123456"),
+    new gitSource("this-url-will-not-exist-either", "dummy2", "HEAD", "123456")]);
+
+  try {
+    getSrcCode(srcList, skipUpdate=false, show=true);
+  } catch e {
+    writeln(e); // should get errors
+  }
+  try {
+    getSrcCode(srcList, skipUpdate=true, show=true);
+  } catch e {
+    writeln(e); // should get errors
+  }
+  try {
+    getGitCode(gitList, skipUpdate=false, show=true);
+  } catch e {
+    writeln(e); // should get errors
+  }
+  try {
+    getGitCode(gitList, skipUpdate=true, show=true);
+  } catch e {
+    writeln(e); // should get errors
   }
 
 }

--- a/test/mason/gitErrors.chpl
+++ b/test/mason/gitErrors.chpl
@@ -23,7 +23,7 @@ proc main(){
   defer rmTree("srcTest");
 
   try {
-    gitC("srcTest", "git ini");
+    gitC("srcTest", "git ini", quiet=true);
   } catch e {
     writeln(e); // should get an unknown git error
   }
@@ -31,7 +31,7 @@ proc main(){
   try {
     removePath();
     defer restorePath();
-    gitC("srcTest", "git init");
+    gitC("srcTest", "git init", quiet=true);
   } catch e {
     writeln(e); // should get a missing git error
   }
@@ -44,22 +44,22 @@ proc main(){
     new gitSource("this-url-will-not-exist-either", "dummy2", "HEAD", "123456")]);
 
   try {
-    getSrcCode(srcList, skipUpdate=false, show=true);
+    getSrcCode(srcList, skipUpdate=false, show=false);
   } catch e {
     writeln(e); // should get errors
   }
   try {
-    getSrcCode(srcList, skipUpdate=true, show=true);
+    getSrcCode(srcList, skipUpdate=true, show=false);
   } catch e {
     writeln(e); // should get errors
   }
   try {
-    getGitCode(gitList, skipUpdate=false, show=true);
+    getGitCode(gitList, skipUpdate=false, show=false);
   } catch e {
     writeln(e); // should get errors
   }
   try {
-    getGitCode(gitList, skipUpdate=true, show=true);
+    getGitCode(gitList, skipUpdate=true, show=false);
   } catch e {
     writeln(e); // should get errors
   }

--- a/test/mason/gitErrors.good
+++ b/test/mason/gitErrors.good
@@ -3,16 +3,16 @@ MasonError: Command failed: 'git init'
 Downloading dependency: dummy-0.1.0
 Downloading dependency: dummy2-0.1.0
 MasonError: The following errors were encountered while installing source dependencies:
-- Command failed: 'git clone -n this-url-will-not-exist $CWD/mason_home/src/dummy-0.1.0/'
-- Command failed: 'git clone -n this-url-will-not-exist-either $CWD/mason_home/src/dummy2-0.1.0/'
+- Failed to clone from this-url-will-not-exist
+- Failed to clone from this-url-will-not-exist-either
 MasonError: The following errors were encountered while installing source dependencies:
 - Dependency dummy-0.1.0 cannot be installed in offline mode
 - Dependency dummy2-0.1.0 cannot be installed in offline mode
 Downloading dependency: dummy-HEAD
 Downloading dependency: dummy2-HEAD
 MasonError: The following errors were encountered while installing git dependencies:
-- Command failed: 'git clone -n this-url-will-not-exist $CWD/mason_home/git/dummy-HEAD/'
-- Command failed: 'git clone -n this-url-will-not-exist-either $CWD/mason_home/git/dummy2-HEAD/'
+- Failed to clone from this-url-will-not-exist
+- Failed to clone from this-url-will-not-exist-either
 MasonError: The following errors were encountered while installing git dependencies:
 - Dependency dummy-HEAD cannot be installed in offline mode
 - Dependency dummy2-HEAD cannot be installed in offline mode

--- a/test/mason/gitErrors.good
+++ b/test/mason/gitErrors.good
@@ -1,2 +1,18 @@
 MasonError: Command failed: 'git ini'
 MasonError: Command failed: 'git init'
+Downloading dependency: dummy-0.1.0
+Downloading dependency: dummy2-0.1.0
+MasonError: The following errors were encountered while installing source dependencies:
+- Command failed: 'git clone -n this-url-will-not-exist $CWD/mason_home/src/dummy-0.1.0/'
+- Command failed: 'git clone -n this-url-will-not-exist-either $CWD/mason_home/src/dummy2-0.1.0/'
+MasonError: The following errors were encountered while installing source dependencies:
+- Dependency dummy-0.1.0 cannot be installed in offline mode
+- Dependency dummy2-0.1.0 cannot be installed in offline mode
+Downloading dependency: dummy-HEAD
+Downloading dependency: dummy2-HEAD
+MasonError: The following errors were encountered while installing git dependencies:
+- Command failed: 'git clone -n this-url-will-not-exist $CWD/mason_home/git/dummy-HEAD/'
+- Command failed: 'git clone -n this-url-will-not-exist-either $CWD/mason_home/git/dummy2-HEAD/'
+MasonError: The following errors were encountered while installing git dependencies:
+- Dependency dummy-HEAD cannot be installed in offline mode
+- Dependency dummy2-HEAD cannot be installed in offline mode

--- a/test/mason/gitErrors.prediff
+++ b/test/mason/gitErrors.prediff
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
-# prediff out anything thats not `MasonError`
-# the other messages are not portable to other systems
-cat $2 | grep "^MasonError:" > $2.prediff.tmp
-mv $2.prediff.tmp $2
-
 # depending on the platform, the error message may be different
 cat $2 | sed 's/Command not found:/Command failed:/' > $2.prediff.tmp
+mv $2.prediff.tmp $2
+
+CWD=$(cd $(dirname $0) ; pwd)
+sed -e "s|$CWD|\$CWD|g" $2 > $2.prediff.tmp
 mv $2.prediff.tmp $2

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -34,6 +34,8 @@ use MasonLogger;
 use Subprocess;
 use TOML;
 
+import ThirdParty.Pathlib.path;
+
 import Path;
 import FileSystem;
 import MasonPrereqs;
@@ -230,7 +232,7 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string,
         log.debugf("Adding source dependency %s's flags\n", name);
         cmd.pushBack(depSrc);
 
-        for flag in MasonPrereqs.chplFlags(depDir) {
+        for flag in MasonPrereqs.chplFlags(depDir:path) {
           log.debugf("+compflag %s\n", flag);
           cmd.pushBack(flag);
         }
@@ -245,7 +247,7 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string,
       const gitDepSrc = Path.joinPath(depDir, "src", name + ".chpl");
       cmd.pushBack(gitDepSrc);
 
-      for flag in MasonPrereqs.chplFlags(depDir) {
+      for flag in MasonPrereqs.chplFlags(depDir:path) {
         log.debugf("+compflag %s\n", flag);
         cmd.pushBack(flag);
       }
@@ -313,70 +315,110 @@ proc genSourceList(lockFile: borrowed Toml) {
    the src code dependency pool */
 proc getSrcCode(sourceList: list(srcSource),
                 skipUpdate: bool, show: bool) throws {
-  var baseDir = MASON_HOME +'/src/';
-  forall (srcURL, name, version) in srcSource.iterList(sourceList) {
+  var baseDir = MASON_HOME:path / "src";
+  if !baseDir.isDir() then baseDir.mkdir(parents=true);
+
+  var errors = new list(string, true);
+  forall (srcURL, name, version) in srcSource.iterList(sourceList)
+  with (ref errors) {
     // version of -1 specifies a git dep
     if version != "-1" {
       const nameVers = name + "-" + version;
-      const destination = baseDir + nameVers;
+      const destination = baseDir / nameVers;
       if !depExists(nameVers) {
-        if skipUpdate then
-          throw new MasonError(
-            "Dependency cannot be installed in offline mode");
-        writeln("Downloading dependency: " + nameVers);
-        var getDependency = "git clone -qn "+ srcURL + ' ' + destination +'/';
-        var checkout = "git checkout -q v" + version;
-        if show {
-          getDependency = "git clone -n " + srcURL + ' ' + destination + '/';
-          checkout = "git checkout v" + version;
+        if !skipUpdate {
+          writeln("Downloading dependency: " + nameVers);
+          try {
+            cloneSource(srcURL, destination, quiet=!show, checkout=false);
+            checkoutSource(destination, "v" + version, quiet=!show);
+          } catch e: MasonError {
+            errors.pushBack(e.message());
+          } catch {
+            errors.pushBack("An unknown error occurred while " +
+                            "installing dependency " + nameVers);
+          }
+        } else {
+          errors.pushBack("Dependency " + nameVers +
+                          " cannot be installed in offline mode");
         }
-        runCommand(getDependency);
-        gitC(destination, checkout);
       }
 
       // add prerequisites
       for prereq in MasonPrereqs.prereqs(destination) {
-        MasonPrereqs.install(destination, prereq);
+        try {
+          MasonPrereqs.install(destination, prereq);
+        } catch e: MasonError {
+          errors.pushBack(e.message());
+        } catch {
+          errors.pushBack("An unknown error occurred while " +
+                          "installing prerequisites for " + nameVers);
+        }
       }
     }
+  }
+  if errors.size > 0 {
+    var errorMsg = "The following errors were encountered while " +
+                   "installing source dependencies:";
+    for err in errors do errorMsg += "\n- " + err;
+    throw new MasonError(errorMsg);
   }
 }
 
 proc getGitCode(gitList: list(gitSource),
                 skipUpdate: bool, show: bool) throws {
-  if !isDir(MASON_HOME + '/git/') {
-    mkdir(MASON_HOME + '/git/', parents=true);
-  }
-  var baseDir = MASON_HOME +'/git/';
-  forall (srcURL, name, branch, revision) in gitSource.iterList(gitList) {
+  const baseDir = MASON_HOME:path / "git";
+  if !baseDir.isDir() then baseDir.mkdir(parents=true);
+
+  var errors = new list(string, true);
+  forall (srcURL, name, branch, revision) in gitSource.iterList(gitList)
+  with (ref errors) {
     const nameVers = name + "-" + branch;
-    const destination = baseDir + nameVers;
+    const destination = baseDir / nameVers;
     if !depExists(nameVers, '/git/') {
-      if skipUpdate then
-        throw new MasonError("Dependency cannot be installed in offline mode");
-      writeln("Downloading dependency: " + nameVers);
-      var getDependency = "git clone -qn "+ srcURL + ' ' + destination +'/';
-      var checkout = "git checkout -q " + revision;
-      if show {
-        getDependency = "git clone -n " + srcURL + ' ' + destination + '/';
-        checkout = "git checkout " + revision;
+      if !skipUpdate {
+        writeln("Downloading dependency: " + nameVers);
+        try {
+          cloneSource(srcURL, destination, quiet=!show, checkout=false);
+          checkoutSource(destination, revision, quiet=!show);
+        } catch e: MasonError {
+          errors.pushBack(e.message());
+        } catch {
+          errors.pushBack("An unknown error occurred while " +
+                          "installing dependency " + nameVers);
+        }
+      } else {
+        errors.pushBack("Dependency " + nameVers +
+                        " cannot be installed in offline mode");
       }
-      runCommand(getDependency);
-      gitC(destination, checkout);
     } else {
       writeln("Checking out specified revision for " + nameVers + "...");
-
-      var checkoutBranch = "git checkout -q " + revision;
-      if show {
-        checkoutBranch = "git checkout " + revision;
+      try {
+        checkoutSource(destination, revision, quiet=!show);
+      } catch e: MasonError {
+        errors.pushBack(e.message());
+      } catch {
+        errors.pushBack("An unknown error occurred while " +
+                        "checking out dependency " + nameVers);
       }
-      gitC(destination, checkoutBranch);
     }
 
     // add prerequisites
     for prereq in MasonPrereqs.prereqs(destination) {
-      MasonPrereqs.install(destination, prereq);
+      try {
+        MasonPrereqs.install(destination, prereq);
+      } catch e: MasonError {
+        errors.pushBack(e.message());
+      } catch {
+        errors.pushBack("An unknown error occurred while " +
+                        "installing prerequisites for " + nameVers);
+      }
     }
+  }
+  if errors.size > 0 {
+    var errorMsg = "The following errors were encountered while " +
+                   "installing git dependencies:";
+    for err in errors do errorMsg += "\n- " + err;
+    throw new MasonError(errorMsg);
   }
 }
 

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -333,9 +333,10 @@ proc getSrcCode(sourceList: list(srcSource),
             checkoutSource(destination, "v" + version, quiet=!show);
           } catch e: MasonError {
             errors.pushBack(e.message());
-          } catch {
+          } catch e {
             errors.pushBack("An unknown error occurred while " +
-                            "installing dependency " + nameVers);
+                            "installing dependency " + nameVers +
+                            ": " + e.message());
           }
         } else {
           errors.pushBack("Dependency " + nameVers +
@@ -349,9 +350,10 @@ proc getSrcCode(sourceList: list(srcSource),
           MasonPrereqs.install(destination, prereq);
         } catch e: MasonError {
           errors.pushBack(e.message());
-        } catch {
+        } catch e {
           errors.pushBack("An unknown error occurred while " +
-                          "installing prerequisites for " + nameVers);
+                          "installing prerequisites for " + nameVers +
+                          ": " + e.message());
         }
       }
     }
@@ -382,9 +384,10 @@ proc getGitCode(gitList: list(gitSource),
           checkoutSource(destination, revision, quiet=!show);
         } catch e: MasonError {
           errors.pushBack(e.message());
-        } catch {
+        } catch e {
           errors.pushBack("An unknown error occurred while " +
-                          "installing dependency " + nameVers);
+                          "installing dependency " + nameVers +
+                          ": " + e.message());
         }
       } else {
         errors.pushBack("Dependency " + nameVers +
@@ -396,9 +399,10 @@ proc getGitCode(gitList: list(gitSource),
         checkoutSource(destination, revision, quiet=!show);
       } catch e: MasonError {
         errors.pushBack(e.message());
-      } catch {
+      } catch e {
         errors.pushBack("An unknown error occurred while " +
-                        "checking out dependency " + nameVers);
+                        "checking out dependency " + nameVers +
+                        ": " + e.message());
       }
     }
 
@@ -408,9 +412,10 @@ proc getGitCode(gitList: list(gitSource),
         MasonPrereqs.install(destination, prereq);
       } catch e: MasonError {
         errors.pushBack(e.message());
-      } catch {
+      } catch e {
         errors.pushBack("An unknown error occurred while " +
-                        "installing prerequisites for " + nameVers);
+                        "installing prerequisites for " + nameVers +
+                        ": " + e.message());
       }
     }
   }

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -33,6 +33,7 @@ use Subprocess;
 use TOML;
 import MasonLogger;
 import MasonPrereqs;
+import ThirdParty.Pathlib.path;
 
 private var log = new MasonLogger.logger("mason example");
 
@@ -205,7 +206,7 @@ private proc getBuildInfo(projectHome: string,
         log.debugf("Adding source dependency %s's flags\n", name);
         compopts.pushBack(depSrc);
 
-        for flag in MasonPrereqs.chplFlags(depDir) {
+        for flag in MasonPrereqs.chplFlags(depDir:path) {
           log.debugf("+compflag %s\n", flag);
           compopts.pushBack(flag);
         }
@@ -220,7 +221,7 @@ private proc getBuildInfo(projectHome: string,
       const gitDepSrc = Path.joinPath(depDir, "src", name + ".chpl");
       compopts.pushBack(gitDepSrc);
 
-      for flag in MasonPrereqs.chplFlags(depDir) {
+      for flag in MasonPrereqs.chplFlags(depDir:path) {
         log.debugf("+compflag %s\n", flag);
         compopts.pushBack(flag);
       }

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -29,6 +29,7 @@ use MasonLogger;
 use Path;
 use SpecParser;
 use TOML;
+import ThirdParty.Pathlib.path;
 
 var log = new logger("mason external");
 
@@ -95,8 +96,8 @@ proc masonExternal(args: [] string) {
       // If spack registry is not installed then install it
       if !isDir(spackRegistryDefaultPath) {
         log.infoln("Installing Spack Registry ...");
-        const dest = spackRegistryDefaultPath;
-        const branch = ' --branch releases/latest ';
+        const dest:path = spackRegistryDefaultPath;
+        const branch = "releases/latest";
         const status = cloneSpackRepository(branch, dest);
         if status != 0 then
           throw new owned MasonError("Spack registry installation failed.");
@@ -123,8 +124,7 @@ proc masonExternal(args: [] string) {
       // mason dependency if a package has a spack-based dependency.
       if !isDir(SPACK_ROOT) {
         writeln("Installing Spack backend ... ");
-        const spackLatestBranch = ' --branch ' + spackBranch + ' ';
-        const status = cloneSpackRepository(spackLatestBranch, SPACK_ROOT);
+        const status = cloneSpackRepository(spackBranch, SPACK_ROOT:path);
         if isDir(spackRegistryDefaultPath) then generateYAML();
         if status != 0 then
           throw new owned MasonError("Spack installation failed.");
@@ -202,12 +202,12 @@ proc spackInstalled() throws {
 /* Spack installed to MASON_HOME/spack */
 proc setupSpack() throws {
   writeln("Installing Spack backend ...");
-  const destCLI = MASON_HOME + "/spack/";
-  const spackLatestBranch = ' --branch v' + minSpackVersion.str() + ' ';
-  const destPackages = MASON_HOME + "/spack-registry";
-  const spackMasterBranch = ' --branch releases/latest ';
+  const destCLI = MASON_HOME:path / "spack";
+  const spackLatestBranch = "v" + minSpackVersion.str();
+  const destPackages = MASON_HOME: path / "spack-registry";
+  const spackMasterBranch = "releases/latest";
   const statusCLI = cloneSpackRepository(spackLatestBranch, destCLI);
-  const statusPackages = cloneSpackRepository(spackMasterBranch, destPackages);
+  const statusPackages = cloneSpackRepository("releases/latest", destPackages);
   generateYAML();
   if statusCLI != 0 && statusPackages != 0 {
     throw new owned MasonError("Spack installation failed");
@@ -215,23 +215,25 @@ proc setupSpack() throws {
 }
 
 /* Clones the Spack repository */
-proc cloneSpackRepository(branch : string, dest: string) {
-  const repo = "https://github.com/spack/spack ";
-  const depth = '--depth 1 ';
-  const command = 'git clone -q -c advice.detachedHead=false ' +
-                  branch + depth + repo + dest;
-  const statusPackages = runWithStatus(command);
-  if statusPackages != 0 then return -1;
-  else return 0;
+proc cloneSpackRepository(branch: string, dest: path): int {
+  const repo = "https://github.com/spack/spack";
+  const extra = ["-c", "advice.detachedHead=false"];
+  try {
+    cloneSource(repo, dest, branch=branch, depth=1, extra=extra);
+  } catch {
+    return -1;
+  }
+  return 0;
 }
 
 /* git checkout command run at SPACK_ROOT */
 proc gitCheckOutSpack(tag: string) {
-  const checkOutCommand = 'git ' + '-C ' + SPACK_ROOT +
-                      ' checkout -q ' + tag;
-  const status = runWithStatus(checkOutCommand);
-  if status != 0 then return -1;
-  else return 0;
+  try {
+    checkoutSource(SPACK_ROOT:path, tag);
+  } catch {
+    return -1;
+  }
+  return 0;
 }
 
 /* git fetch command run at SPACK_ROOT */

--- a/tools/mason/MasonPrereqs.chpl
+++ b/tools/mason/MasonPrereqs.chpl
@@ -80,7 +80,8 @@ iter prereqs(const baseDir = path.cwd()): path {
   const prereqsDir = "prereqs";
   const prereqsPath = baseDir / prereqsDir;
 
-  log.debugf("Looking for the prerequisites directory %s\n", prereqsPath:string);
+  log.debugf("Looking for the prerequisites directory %s\n",
+             prereqsPath:string);
   if prereqsPath.exists() {
     if prereqsPath.isDir() {
       log.infof("Prerequisites directory exists (%s)\n", prereqsPath:string);

--- a/tools/mason/MasonPrereqs.chpl
+++ b/tools/mason/MasonPrereqs.chpl
@@ -19,9 +19,8 @@
  */
 
 import FileSystem as FS;
-use FileSystem only cwd,chdir; // these are tertiary methods on locale
-import Path;
 import List.list;
+import ThirdParty.Pathlib.path;
 
 import MasonLogger;
 import MasonUtils;
@@ -30,47 +29,41 @@ private config param makeTargetChplFlags = "printchplflags";
 
 private var log = new MasonLogger.logger("mason prereqs");
 
-record pushdMgr: contextManager {
-  var path: string;
-  var initDir = here.cwd();
 
-  proc ref enterContext() do here.chdir(path);
-  proc ref exitContext(in err: owned Error?) throws {
-    if err then throw err;
-    here.chdir(initDir);
-  }
-}
-
-private inline proc pushd(path: string) {
-  return new pushdMgr(path);
-}
-
-proc install(baseDir: string, path: string) throws {
-  log.infof("Installing prerequisite %s\n", path);
-  manage pushd(path) {
-    // TODO check for errors
-    MasonUtils.runCommand(["make", "MASON_PACKAGE_HOME=" + baseDir]);
-  }
+proc install(baseDir: path, p: path) throws {
+  log.infof("Installing prerequisite %s\n", p:string);
+  const oldDir = path.cwd();
+  p.chdir();
+  defer oldDir.chdir();
+  // TODO: I would love to use p.pushChdir(), but I don't trust
+  // error handling + context managers enough
+  // TODO check for errors
+  MasonUtils.runCommand(["make", "MASON_PACKAGE_HOME=" + baseDir:string]);
 }
 
 proc install() throws {
-  const baseDir = here.cwd();
+  const baseDir = path.cwd();
   for prereq in prereqs(baseDir=baseDir) {
     install(baseDir, prereq);
   }
   log.infoln("Prerequisites have been installed");
 }
 
-iter chplFlags(const baseDir = here.cwd()) throws {
+iter chplFlags(const baseDir = path.cwd()) throws {
   var flags: list(string);
 
   const cmd = ["make",
                "CHPL_HOME=" + MasonUtils.CHPL_HOME,
-               "MASON_PACKAGE_HOME=" + baseDir,
+               "MASON_PACKAGE_HOME=" + baseDir:string,
                "--quiet", makeTargetChplFlags];
   for prereq in prereqs(baseDir) {
     var makeOutput: string;
-    manage pushd(prereq) do makeOutput = MasonUtils.runCommand(cmd).strip();
+    const oldDir = path.cwd();
+    prereq.chdir();
+    defer oldDir.chdir();
+    // TODO: I would love to use prereq.pushChdir(), but I don't trust
+    // error handling + context managers enough
+    makeOutput = MasonUtils.runCommand(cmd).strip();
 
     for pFlag in makeOutput.split(" ") {
       if pFlag.strip() != "" then
@@ -79,37 +72,38 @@ iter chplFlags(const baseDir = here.cwd()) throws {
   }
 }
 
-proc dirHasMakefile(dir: string) {
-  const checkPath = Path.joinPath(dir, "Makefile");
-  return FS.isFile(checkPath);
+proc dirHasMakefile(dir: path) {
+  return (dir / "Makefile").isFile();
 }
 
-iter prereqs(const baseDir = here.cwd()) {
+iter prereqs(const baseDir = path.cwd()): path {
   const prereqsDir = "prereqs";
-  const prereqsPath = Path.joinPath(baseDir, prereqsDir);
+  const prereqsPath = baseDir / prereqsDir;
 
-  log.debugf("Looking for the prerequisites directory %s\n", prereqsPath);
-  if FS.exists(prereqsPath) {
-    if FS.isDir(prereqsPath) {
-      log.infof("Prerequisites directory exists (%s)\n", prereqsPath);
+  log.debugf("Looking for the prerequisites directory %s\n", prereqsPath:string);
+  if prereqsPath.exists() {
+    if prereqsPath.isDir() {
+      log.infof("Prerequisites directory exists (%s)\n", prereqsPath:string);
 
       // You shouldn't need an array here, but there seems to be a compiler bug
       // See https://github.com/chapel-lang/chapel/issues/27855
-      const dirs = FS.walkDirs(prereqsPath, depth=1);
+      const dirs = FS.walkDirs(prereqsPath:string, depth=1);
 
       for dir in dirs[1..] {
-        if dirHasMakefile(dir) {
-          yield dir;
+        const dirP = dir:path;
+        if dirHasMakefile(dirP) {
+          yield dirP;
         } else {
           log.warnf("%s is in prereqs directory. But doesn't have a Makefile." +
-                    " Ignoring.\n", dir);
+                    " Ignoring.\n", dirP:string);
         }
       }
     } else {
       log.infof("%s is supposed to be directory with prerequisites " +
-                "but it looks to be a file. It will be ignored.\n", prereqsDir);
+                "but it looks to be a file. It will be ignored.\n",
+                prereqsDir:string);
     }
   } else {
-    log.debugf("%s don't exist.\n", prereqsDir);
+    log.debugf("%s don't exist.\n", prereqsDir:string);
   }
 }

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -32,6 +32,8 @@ use Subprocess;
 use TOML;
 import Path;
 
+import ThirdParty.Pathlib.path;
+
 import MasonLogger;
 
 private var log = new MasonLogger.logger("mason publish");
@@ -88,30 +90,31 @@ proc masonPublish(args: [] string) throws {
   }
 
   if createReg {
-    var pathReg = registryPath;
-    if !isDir(pathReg) then
-      mkdir(pathReg);
+    const pathReg:path = registryPath;
+    if !pathReg.isDir() then
+      pathReg.mkdir();
     else
-      throw new MasonError("Registry already exists at %s".format(pathReg));
-    if !isDir(pathReg + '/Bricks') then
-      mkdir(pathReg + '/Bricks');
-    if !isDir(pathReg + '/README.md') then
-      touch(pathReg + '/README.md');
-    if !isDir(pathReg + '/.git') {
+      throw new MasonError("Registry already exists at %s"
+                            .format(pathReg:string));
+    if !(pathReg / "Bricks").isDir() then
+      (pathReg / "Bricks").mkdir();
+    if !(pathReg / "README.md").isDir() then
+      (pathReg / "README.md").touch();
+    if !(pathReg / ".git").isDir() {
       gitC(pathReg, ["git", "init", "-q"]);
       gitC(pathReg, ["git", "add", "."]);
       gitC(pathReg, ["git", "commit", "-q", "-m", "initialized registry"]);
     }
-    const absPathReg = Path.absPath(pathReg);
-    writeln("Initialized local registry at %s".format(pathReg));
+    const absPathReg = pathReg.resolve();
+    writeln("Initialized local registry at %s".format(pathReg:string));
     writeln("Add this registry to MASON_REGISTRY environment variable "
         + "to include it in search path:");
 
     writeln("   export MASON_REGISTRY=\"%s|%s,%s|%s\""
         .format("mason-registry",
           regUrl,
-          basename(pathReg),
-          absPathReg));
+          basename(pathReg:string),
+          absPathReg:string));
 
     return;
   }
@@ -280,7 +283,7 @@ proc dryRun(username: string, registryPath : string, isLocal : bool) throws {
       const s = """
       Package can be published to the mason-registry
       Commands that will be run:
-      > git clone git:github.com:[username]/mason-registry mason-registry
+      > git clone git@github.com:[username]/mason-registry mason-registry
       > git checkout -b [package name]
       Package Name will be added to the Bricks in the mason-registry
       > git add .
@@ -324,16 +327,12 @@ proc cloneMasonReg(username: string,
                    safeDir: string,
                    registryPath: string) throws {
   try! {
-    if registryPath == MASON_HOME {
-      const gitClone =
-        'git clone --quiet git@github.com:%s/mason-registry mason-registry';
-      var ret = gitC(safeDir, gitClone.format(username), false);
-      return ret;
-    } else {
-      const gitClone = 'git clone --quiet %s mason-registry';
-      var gitCall = gitC(safeDir, gitClone.format(registryPath), false);
-      return gitCall;
-    }
+    const url = if registryPath == MASON_HOME
+      then "https://github.com/%s/mason-registry".format(username)
+      else registryPath;
+    const dest = safeDir:path / "mason-registry";
+
+    cloneSource(url, dest, quiet=false);
   } catch {
     throw new MasonError(
       'Error cloning the fork of mason-registry. ' +
@@ -413,10 +412,9 @@ private proc gitUrl(dir: string) {
   fork, name or branch is taken from the Mason.toml of the mason package.
  */
 proc branchMasonReg(name: string, safeDir: string) throws {
-  try! {
-    const branchCommand = "git checkout --quiet -b  "+ name: string;
-    var ret = gitC(safeDir + '/mason-registry', branchCommand, false);
-    return ret;
+  try {
+    const dir = safeDir:path / "mason-registry";
+    checkoutSource(dir, name, createBranch=true);
   } catch {
     throw new MasonError('Error branching the registry, make sure you have a ' +
                          'remote origin set up');
@@ -512,7 +510,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string,
   registry path, and other issues that may prevent a package from being
   published to a registry.
  */
-proc check(path: string, ci: bool) throws {
+proc check(p: string, ci: bool) throws {
   const spacer = '------------------------------------------------------';
   const package = (ensureMasonProject(here.cwd(), 'Mason.toml') == 'true');
   const projectCheckHome = here.cwd();
@@ -636,7 +634,7 @@ proc check(path: string, ci: bool) throws {
       writeln('   Remote Origin: ' + getRemoteOrigin());
     } else {
       writeln('   Package has no remote origin and cannot be publish to a ' +
-              'registry with path:' + path + ' (FAILED)');
+              'registry with path:' + p + ' (FAILED)');
       remoteTest = false;
     }
     writeln(spacer);
@@ -722,28 +720,29 @@ proc check(path: string, ci: bool) throws {
   copy of the repo.
 */
 proc refreshLicenseList(overwrite=false) throws {
-  const dest = MASON_HOME + '/spdx';
-  const branch = '--branch main ';
-  const depth = '--depth 1 ';
-  const url = 'https://github.com/spdx/license-list-data.git ';
-  const referIfAble = if MASON_LICENSE_CACHE_PATH != "" then
-    " --reference-if-able " + MASON_LICENSE_CACHE_PATH +
-      "/license-list-data.git" else "";
-  const command = 'git clone -q ' + branch + depth + url + dest + referIfAble;
-  if !isDir(dest) {
-    runCommand(command);
-  } else if overwrite {
-    rmTree(dest);
-    runCommand(command);
-  }
+  const dest = MASON_HOME:path / "spdx";
+  const url = "https://github.com/spdx/license-list-data.git";
+  const extraCloneArgs: list(string) = if MASON_LICENSE_CACHE_PATH != ""
+    then new list(["--reference-if-able",
+                   MASON_LICENSE_CACHE_PATH + "/license-list-data.git"])
+    else new list(string);
 
-  if !isDir(dest + "/text") {
-    throw new owned MasonError("Expected to find license list data at " + dest +
-                               "/text, but location does not exist. Try running\
-                               'mason publish --refresh-licenses' to update the\
-                               license list.");
+  if overwrite && dest.exists() then
+    dest.remove();
+  if !dest.isDir() then
+    cloneSource(url, dest, depth=1, branch="main",
+                quiet=true, extra=extraCloneArgs.toArray());
+
+  const licenseListPath = dest / "text";
+
+  if !licenseListPath.isDir() {
+    throw new MasonError("Expected to find license list data at " +
+                         licenseListPath:string +
+                         ", but location does not exist. Try running " +
+                         "'mason publish --refresh-licenses' to update the " +
+                         "license list.");
   }
-  const licenseList = listDir(dest + "/text");
+  const licenseList = listDir(licenseListPath:string);
   return licenseList;
 }
 
@@ -788,10 +787,10 @@ private proc attemptToBuild() throws {
   check whether the registry that someone is trying to publish to is properly
   set up and has the correct structure.
  */
-private proc registryPathCheck(path: string,
+private proc registryPathCheck(p: string,
                                username: string,
                                trueIfLocal: bool) throws {
-  if path == MASON_HOME {
+  if p == MASON_HOME {
     var forkCheck = usernameCheck(username);
     if forkCheck == 0 {
       writeln('   The mason-registry is forked under username: ' +
@@ -804,23 +803,23 @@ private proc registryPathCheck(path: string,
     }
   } else {
     if trueIfLocal {
-      const isLocalGit = exists(path + '/.git');
-      const hasBricks = exists(path + '/Bricks/');
+      const isLocalGit = exists(p + '/.git');
+      const hasBricks = exists(p + '/Bricks/');
       if !isLocalGit {
         writeln('   Registry with path ' +
-                path + ' is not a git repository. (FAILED)');
+                p + ' is not a git repository. (FAILED)');
         writeln("   Local registries must be git repositories " +
                 "in order to publish");
         return false;
       } else if !hasBricks {
         writeln('   The registry with path ' +
-                path + ' does not have proper registry structure (FAILED)');
+                p + ' does not have proper registry structure (FAILED)');
         writeln("   A registry must have a /Bricks/ " +
                 "directory to be a valid registry");
         return false;
       } else {
         writeln('   The local registry with path ' +
-                path + ' is a valid registry to be publish too (PASSED)');
+                p + ' is a valid registry to be publish too (PASSED)');
         return true;
       }
     } else {
@@ -958,9 +957,9 @@ proc masonTomlFileCheck(projectHome: string): tomlCheckResult {
   var missingFields: list(string);
   var mismatchedTypes: list(string);
 
-  const requireStringFields = ('name', 'version', 'chplVersion',
-                               'source', 'license');
-  const requireStringOrListFields = ('authors',);
+  const requireStringFields = ("name", "version", "chplVersion",
+                               "source", "license");
+  const requireStringOrListFields = ("authors",);
   for field in requireStringFields {
     if !tomlFile.pathExists("brick." + field) then
       missingFields.pushBack(field);

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -34,6 +34,8 @@ use TestResult;
 use Time;
 use TOML;
 
+import ThirdParty.Pathlib.path;
+
 import MasonLogger;
 import MasonPrereqs;
 
@@ -264,7 +266,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, filter: string,
         log.debugf("Adding source dependency %s's flags\n", name);
         compopts.pushBack(depSrc);
 
-        for flag in MasonPrereqs.chplFlags(depDir) {
+        for flag in MasonPrereqs.chplFlags(depDir:path) {
           log.debugf("+compflag %s\n", flag);
           compopts.pushBack(flag);
         }
@@ -278,7 +280,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, filter: string,
       const depDir = Path.joinPath(gitDepPath, name + "-" + branch);
       const gitDepSrc = Path.joinPath(depDir, "src", name + ".chpl");
       compopts.pushBack(gitDepSrc);
-      for flag in MasonPrereqs.chplFlags(depDir) {
+      for flag in MasonPrereqs.chplFlags(depDir:path) {
         log.debugf("+compflag %s\n", flag);
         compopts.pushBack(flag);
       }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -205,12 +205,11 @@ proc updateRegistry(skipUpdate: bool, show=true) throws {
       gitC(registryHome, pullRegistry);
     } else {
       // Registry has moved or does not exist
-      mkdir(MASON_HOME + '/src', parents=true);
-      const localRegistry = registryHome;
-      mkdir(localRegistry, parents=true);
-      const cloneRegistry = 'git clone -q ' + registry + ' .';
+      (MASON_HOME:path / "src").mkdir(parents=true);
+      const localRegistry:path = registryHome;
+      localRegistry.mkdir(parents=true);
       if show then writeln("Updating ", name);
-      gitC(localRegistry, cloneRegistry);
+      cloneSource(registry, localRegistry, quiet=true);
     }
   }
 }
@@ -558,7 +557,7 @@ private proc pullGitDeps(gitDeps, show=false) {
 
   // Pull git repositories so that we can have access to the
   // current revision and TOML file to get dependencies
-  var baseDir = MASON_HOME +'/git/';
+  const baseDir = MASON_HOME:path / "git";
   for val in gitDepMap.keys() {
     var (srcURL, origBranch, revision) = gitDepMap[val];
     log.debugf("Processing dependency %s: url: '%s', branch: '%s', rev='%s'\n",
@@ -567,27 +566,20 @@ private proc pullGitDeps(gitDeps, show=false) {
     // Default to head if branch isn't specified
     var branch = if origBranch == "" then "HEAD" else origBranch;
     const nameVers = val + "-" + branch;
-    const destination = baseDir + nameVers;
+    const destination = baseDir / nameVers;
     if !depExists(nameVers, '/git/') {
       writef("Downloading dependency: %s\n", nameVers);
-      var getDependency = "git clone -q "+ srcURL + ' ' + destination +'/';
-      runCommand(getDependency);
+      cloneSource(srcURL, destination, quiet=true);
 
       if (branch != "HEAD") || (revision != "") {
         // Use the revision to checkout, if specified
-        var toCheckout = if revision != "" then revision else branch;
-        var checkout = "git checkout -q " + toCheckout;
-        if show {
-          getDependency = "git clone " + srcURL + ' ' + destination + '/';
-          checkout = "git checkout " + toCheckout;
-        }
-
-        gitC(destination, checkout);
+        const toCheckout = if revision != "" then revision else branch;
+        checkoutSource(destination, toCheckout, quiet=!show);
       }
 
       // get the revision to store in lock if not specified
       if revision == "" {
-        var revParse = "git rev-parse HEAD";
+        const revParse = "git rev-parse HEAD";
         revision = gitC(destination, revParse, true).strip();
       }
       gitDepsWithRevision.pushBack((val, srcURL, branch, revision));
@@ -610,11 +602,8 @@ private proc pullGitDeps(gitDeps, show=false) {
 
         writeln("Checking out specified revision for " + nameVers + "...");
         // Use the revision to checkout, if specified
-        var toCheckout = if revision != "" then revision else branch;
-        var checkout = "git checkout -q " + toCheckout;
-        if show then checkout = "git checkout " + toCheckout;
-
-        gitC(destination, checkout);
+        const toCheckout = if revision != "" then revision else branch;
+        checkoutSource(destination, toCheckout, quiet=!show);
       }
 
       // get the revision to store in lock if not specified

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -108,7 +108,7 @@ proc runCommand(cmd: [] string, quiet=false,
   }
   var ret: retType;
   try {
-    log.debugf("runCommand: %?\n", cmd);
+    log.debugf("runCommand (quiet=%?): '%?'\n", quiet, cmd);
     var process = spawn(cmd, stdout=pipeStyle.pipe, stderr=pipeStyle.pipe);
 
     log.debugln("stdout:");
@@ -134,17 +134,17 @@ proc runCommand(cmd: [] string, quiet=false,
     log.debugf("exitCode: %i\n", process.exitCode);
     if process.exitCode != 0 {
       var cmdStr = " ".join(cmd);
-      throw new owned MasonError("Command failed: '" + cmdStr + "'");
+      throw new MasonError("Command failed: '" + cmdStr + "'");
     }
   } catch e: FileNotFoundError {
     log.debugf("Caught FileNotFoundError for command: %?\n", cmd);
     var cmdStr = " ".join(cmd);
-    throw new owned MasonError("Command not found: '" + cmdStr + "'");
+    throw new MasonError("Command not found: '" + cmdStr + "'");
   } catch e: MasonError {
     throw e;
   } catch e {
     log.debugf("Caught unknown error ('%?') for command: %?\n", e, cmd);
-    throw new owned MasonError("Internal mason error");
+    throw new MasonError("Internal mason error");
   }
   return ret;
 }
@@ -162,7 +162,8 @@ proc runWithStatus(command: string, quiet=false, capture=true): int {
 }
 proc runWithStatus(command: [] string, quiet=false, capture=true): int {
   try {
-    log.debugf("runWithStatus: %?\n", command);
+    log.debugf("runWithStatus (quiet=%?, capture=%?): %?\n",
+               quiet, capture, command);
     if !capture then log.flush();
     var sub =
       if capture
@@ -448,10 +449,16 @@ proc getChapelVersionStr() throws {
   return chplVersion;
 }
 
-proc gitC(newDir, command, quiet=false) throws {
-  const oldDir = here.cwd();
-  here.chdir(newDir);
-  defer here.chdir(oldDir);
+// TODO: only exists because I don't want to rewrite everything to use path, yet
+proc gitC(newDir:string, command, quiet=false) throws {
+  return gitC(newDir:path, command, quiet);
+}
+proc gitC(newDir:path, command, quiet=false) throws {
+  const oldDir = path.cwd();
+  newDir.chdir();
+  defer oldDir.chdir();
+  // TODO: I would love to use newDir.pushChdir(), but I don't trust
+  // error handling + context managers enough
   var ret = runCommand(command, quiet=quiet);
 
   return ret;
@@ -610,13 +617,80 @@ proc getMasonDependencies(sourceList: list(srcSource),
 proc depExists(dependency: string, repo='/src/') {
   var repos = MASON_HOME + repo;
   var exists = false;
-  for dir in listDir(repos) {
-    if dir == dependency then
-      exists = true;
+  if !isDir(repos) then
+    return false;
+  try {
+    for dir in listDir(repos) {
+      if dir == dependency then
+        exists = true;
+    }
+  } catch e {
+    log.debugf("Caught error ('%?') when checking for dependency in %s\n",
+               e, repos);
+    exists = false;
   }
   return exists;
 }
 
+
+private const dummyExtraArgs: [1..0] string;
+proc cloneSource(url: string, dest: path,
+                 quiet=true, checkout=true, branch="", depth=-1,
+                 extra=dummyExtraArgs) throws {
+  log.debugf("Cloning from %s to %?\n", url, dest);
+  var baseCmd = new list(["git", "clone"]);
+  if quiet then
+    baseCmd.pushBack("--quiet");
+  if !checkout then
+    baseCmd.pushBack("--no-checkout");
+  if branch != "" then
+    baseCmd.pushBack("--branch=" + branch);
+  if depth > 0 then
+    baseCmd.pushBack("--depth=" + depth:string);
+  if extra.size > 0 then
+    baseCmd.pushBack(extra);
+
+  var cmd: [0..#(baseCmd.size + 2)] string;
+  cmd[0..#baseCmd.size] = baseCmd.toArray();
+  cmd[baseCmd.size] = url;
+  cmd[baseCmd.size + 1] = dest:string;
+
+  var cloneSucceeded = false;
+  if runWithStatus(cmd, quiet=quiet) == 0 {
+    cloneSucceeded = true;
+  } else {
+    log.debugf("Failed to clone from %s to %?\n", url, dest);
+    // there was an error, if the url starts with git@, try with https
+    if url.startsWith("git@") {
+      var httpsUrl = url
+        .replace(":", "/", count=1)
+        .replace("git@", "https://", count=1);
+      log.debugf("Retrying with https url: %s\n", httpsUrl);
+      // rewrite the command with the new url
+      cmd[baseCmd.size] = httpsUrl;
+      if runWithStatus(cmd, quiet=quiet) == 0 {
+        cloneSucceeded = true;
+      } else {
+        log.debugf("Failed to clone from %s to %?\n", httpsUrl, dest);
+      }
+    }
+  }
+  if !cloneSucceeded then
+    throw new MasonError("Failed to clone from " + url);
+}
+
+proc checkoutSource(repo: path, target: string, quiet=true,
+                     createBranch=false) throws {
+  var cmd: list(string);
+  cmd.pushBack("git");
+  cmd.pushBack("checkout");
+  if quiet then
+    cmd.pushBack("--quiet");
+  if createBranch then
+    cmd.pushBack("-b");
+  cmd.pushBack(target);
+  gitC(repo:string, cmd.toArray());
+}
 
 proc getProjectType(): string throws {
   const cwd = here.cwd();

--- a/tools/mason/ThirdParty/masonDeps.txt
+++ b/tools/mason/ThirdParty/masonDeps.txt
@@ -1,2 +1,2 @@
 TemplateString.chpl@https://raw.githubusercontent.com/jabraham17/TemplateString/refs/tags/v0.1.0/src/TemplateString.chpl@fd58c3e4a10fbc5921151ea03e343fc8bcee4e2822100562ce7145e3202f8197
-Pathlib.chpl@https://raw.githubusercontent.com/jabraham17/Pathlib/refs/tags/v0.1.0/src/Pathlib.chpl@f0e18d3a1c89d79e6a215dd828dd890eb3032c30f3536b1093b50f0069d4291b
+Pathlib.chpl@https://raw.githubusercontent.com/jabraham17/Pathlib/refs/tags/v0.2.0/src/Pathlib.chpl@b20eb4a4b9fb612763351cd834f1356c0aa70c188514fef1f8c88f0f004e5a7c


### PR DESCRIPTION
Fixes several issues I found with mason when trying to pull dependencies via ssh, as well as some improvements I made along the way

* fixes git errors being reported poorly as uncaught TaskErrors.
* git cannot clone ssh based urls without ssh and without an installed ssh key. to fix this, this PR implements an automatic fallback to https
* refactors many git operations to use dedicated helpers
* makes more usage of `path`, and starts to use Pathlib@0.2.0 for more operations

Resolves https://github.com/chapel-lang/chapel/issues/28674

- [x] paratest 

[Reviewed by @benharsh]