### PR TITLE
Fix python CI format check

### DIFF
--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
-          options: "--check --verbose --line-length 80 --extend-exclude '^/(third-party|test|util/test|util/devel/test)/'"
+          options: "--check --verbose --line-length 80 --extend-exclude '^/(third-party|test)/'"
           src: "."
       - uses: psf/black@stable
         with:

--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -9,5 +9,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
-          options: "--check --verbose --line-length 80 --extend-exclude '(third-party/|test/)'"
+          options: "--check --verbose --line-length 80 --extend-exclude '^/(third-party|test|util/test|util/devel/test)/'"
           src: "."
+      - uses: psf/black@stable
+        with:
+          options: "--check --verbose --line-length 80 --extend-exclude '(install|build)/'"
+          src: "third-party/chpl-venv"

--- a/third-party/chpl-venv/chpldeps-main.py
+++ b/third-party/chpl-venv/chpldeps-main.py
@@ -25,20 +25,26 @@ import sys
 import importlib.util
 import importlib.metadata
 
+
 def missing_subcommand():
     print("chpldeps requires a subcommand", file=sys.stderr)
     print(__doc__, file=sys.stderr)
     sys.exit(-1)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
 
     # leave out a python3 call if present
     starti = 1
     if starti >= len(sys.argv):
         missing_subcommand()
 
-    if (sys.argv[1] == 'python3' or sys.argv[1] == 'python' or
-        sys.argv[1].endswith('/python3') or sys.argv[1].endswith('/python')):
+    if (
+        sys.argv[1] == "python3"
+        or sys.argv[1] == "python"
+        or sys.argv[1].endswith("/python3")
+        or sys.argv[1].endswith("/python")
+    ):
 
         starti = 2
 
@@ -54,37 +60,41 @@ if __name__ == '__main__':
     argv.extend(sys.argv[starti:])
     sys.argv = argv
 
-    if subcommand == 'sphinx-build':
+    if subcommand == "sphinx-build":
         # copied from sphinx-build's body
         from sphinx.cmd.build import main
+
         sys.exit(main())
 
-    elif subcommand == 'rst2man.py':
+    elif subcommand == "rst2man.py":
         # copied from rst2man.py's body
         import locale
+
         try:
-            locale.setlocale(locale.LC_ALL, '')
+            locale.setlocale(locale.LC_ALL, "")
         except:
             pass
 
         from docutils.core import publish_cmdline, default_description
         from docutils.writers import manpage
 
-        description = ("Generates plain unix manual documents.  " + default_description)
+        description = (
+            "Generates plain unix manual documents.  " + default_description
+        )
 
         publish_cmdline(writer=manpage.Writer(), description=description)
 
-    elif subcommand == 'register-python-argcomplete':
+    elif subcommand == "register-python-argcomplete":
 
         # Run the argument as a program within bin/
         # just by exec'ing it
         # (can't import something with dashes)
-        my_bin_dir = os.path.join(os.path.dirname(__file__), 'bin')
+        my_bin_dir = os.path.join(os.path.dirname(__file__), "bin")
         subcommand_path = os.path.join(my_bin_dir, subcommand)
 
         exec(open(subcommand_path).read())
 
-    elif subcommand == 'version':
+    elif subcommand == "version":
         arg = sys.argv[1]
         print(importlib.metadata.version(arg))
         sys.exit(0)
@@ -102,7 +112,9 @@ if __name__ == '__main__':
         sys.exit(mod.main())
 
     else:
-        print("Unknown chpldeps subcommand {0}".format(subcommand),
-              file=sys.stderr)
+        print(
+            "Unknown chpldeps subcommand {0}".format(subcommand),
+            file=sys.stderr,
+        )
         print(__doc__, file=sys.stderr)
         sys.exit(-1)

--- a/third-party/chpl-venv/chpldoc-sphinx-project/source/conf.py
+++ b/third-party/chpl-venv/chpldoc-sphinx-project/source/conf.py
@@ -16,7 +16,7 @@ import sys
 import os
 from pathlib import Path
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -26,50 +26,50 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.0'
+needs_sphinx = "1.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.todo',
-    'sphinxcontrib.chapeldomain',
-    'sphinx.ext.mathjax',
+    "sphinx.ext.todo",
+    "sphinxcontrib.chapeldomain",
+    "sphinx.ext.mathjax",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = {'.rst' : 'restructuredtext'}
+source_suffix = {".rst": "restructuredtext"}
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
 # The root toctree document.
-root_doc = 'index'
+root_doc = "index"
 
 # General information about the project.
-project = os.environ.get('CHPLDOC_PROJECT_NAME', 'PROJECT NAME')
-project_description = os.environ.get('CHPLDOC_PROJECT_DESCRIPTION', '')
+project = os.environ.get("CHPLDOC_PROJECT_NAME", "PROJECT NAME")
+project_description = os.environ.get("CHPLDOC_PROJECT_DESCRIPTION", "")
 
-copyright_text = os.environ.get('CHPLDOC_PROJECT_COPYRIGHT', '2015')
-author_text = os.environ.get('CHPLDOC_AUTHOR', None)
+copyright_text = os.environ.get("CHPLDOC_PROJECT_COPYRIGHT", "2015")
+author_text = os.environ.get("CHPLDOC_AUTHOR", None)
 
 if author_text:
-    copyright = u'{0}, {1}'.format(copyright_text, author_text)
+    copyright = "{0}, {1}".format(copyright_text, author_text)
 else:
-    copyright = u'{0}'.format(copyright_text)
+    copyright = "{0}".format(copyright_text)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-version = os.environ.get('CHPLDOC_PROJECT_VERSION', '').split("-")[0]
+version = os.environ.get("CHPLDOC_PROJECT_VERSION", "").split("-")[0]
 # version = '0.0.1-alpha'
 # The full version, including alpha/beta/rc tags.
-release = os.environ.get('CHPLDOC_PROJECT_VERSION', '')
+release = os.environ.get("CHPLDOC_PROJECT_VERSION", "")
 
 
 rst_prolog = f"""
@@ -118,7 +118,7 @@ exclude_patterns.extend(chpldoc_exclude_patterns)
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
@@ -133,10 +133,11 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 if not on_rtd:
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
+
+    html_theme = "sphinx_rtd_theme"
 
     html_theme_options = {
-        'sticky_navigation': True,
+        "sticky_navigation": True,
     }
 
 
@@ -167,7 +168,7 @@ if not on_rtd:
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -216,28 +217,31 @@ html_static_path = ['_static']
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'chpldocdoc'
+htmlhelp_basename = "chpldocdoc"
 
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', f'{project}.tex', f'{project} Documentation',
-   author_text, 'manual'),
+    (
+        "index",
+        f"{project}.tex",
+        f"{project} Documentation",
+        author_text,
+        "manual",
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -265,10 +269,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    ('index', project, f'{project} Documentation',
-     [author_text], 1)
-]
+man_pages = [("index", project, f"{project} Documentation", [author_text], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -280,8 +281,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', project, f'{project} Documentation',
-   author_text, project, project_description, 'Miscellaneous'),
+    (
+        "index",
+        project,
+        f"{project} Documentation",
+        author_text,
+        project,
+        project_description,
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/tools/chpl-language-server/test/show_generic.py
+++ b/tools/chpl-language-server/test/show_generic.py
@@ -412,7 +412,9 @@ async def test_lenses_default_rect_twoargs(client: LanguageClient):
         default_inlays,
     ]
 
-    await click_lenses_and_check_inlays(client, expected_lens, all_inlays, A=file)
+    await click_lenses_and_check_inlays(
+        client, expected_lens, all_inlays, A=file
+    )
 
 
 @pytest.mark.asyncio
@@ -454,7 +456,9 @@ async def test_lenses_default_rect_other_args(client: LanguageClient):
         default_inlays,
     ]
 
-    await click_lenses_and_check_inlays(client, expected_lens, all_inlays, A=file)
+    await click_lenses_and_check_inlays(
+        client, expected_lens, all_inlays, A=file
+    )
 
 
 @pytest.mark.asyncio
@@ -497,7 +501,9 @@ async def test_lenses_default_rect_with_calls(client: LanguageClient):
         default_inlays,
     ]
 
-    await click_lenses_and_check_inlays(client, expected_lens, all_inlays, A=file)
+    await click_lenses_and_check_inlays(
+        client, expected_lens, all_inlays, A=file
+    )
 
 
 @pytest.mark.asyncio

--- a/util/devel/test/portability/apptainer/extract-docs.py
+++ b/util/devel/test/portability/apptainer/extract-docs.py
@@ -17,21 +17,24 @@ directories = ["current", "../vagrant/current"]
 
 
 def gather_provision_script_cmds(path):
-    cmds = [ ]
+    cmds = []
     with open(path) as file:
         for line in file:
             line = line.strip()
             if line.startswith("#!"):
-                pass # ignore shebang line
-            elif (line.startswith("alias unsudo") or
-                  line.startswith("alias hide") or
-                  line.startswith("hide") or
-                  line.endswith("#hide") or
-                  line.endswith("# hide")):
-                pass # ignore these hidden details
+                pass  # ignore shebang line
+            elif (
+                line.startswith("alias unsudo")
+                or line.startswith("alias hide")
+                or line.startswith("hide")
+                or line.endswith("#hide")
+                or line.endswith("# hide")
+            ):
+                pass  # ignore these hidden details
             elif line:
                 cmds.append(line)
     return cmds
+
 
 def title(name):
     name = name.capitalize()
@@ -80,35 +83,36 @@ def title(name):
         name = '25.10 "Questing Quokka"'
     return name
 
+
 def fixname(subdir):
     name = os.path.basename(subdir)
     # remove -cloud-base from e.g. fedora-32-cloud-base
     if name.endswith("-cloud-base"):
-        name = name[:name.find("-cloud-base")]
+        name = name[: name.find("-cloud-base")]
     # remove -STABLE from e.g. freebsd-FreeBSD-12.2-STABLE
     if name.endswith("-STABLE"):
-        name = name[:name.find("-STABLE")]
+        name = name[: name.find("-STABLE")]
     # remove first freebsd in freebsd-FreeBSD-12.2-STABLE
     if name.startswith("freebsd-FreeBSD-"):
-        name = name[len("freebsd-"):]
+        name = name[len("freebsd-") :]
     if name.startswith("bento-freebsd-"):
-        name = name[len("bento-"):]
+        name = name[len("bento-") :]
     # remove 64 in ubuntu-impish64
     if name.endswith("64"):
-        name = name[:name.find("64")]
+        name = name[: name.find("64")]
     if name.endswith("homebrew"):
         name = "Homebrew"
 
     parts = name.split("-")
-    adj = [ ]
+    adj = []
     for part in parts:
         if part.endswith("linux"):
             # e.g. rockylinux -> Rocky Linux
-            tmp = part[:part.find("linux")]
+            tmp = part[: part.find("linux")]
             adj.append(title(tmp))
             adj.append("Linux")
-        elif re.search('\\d$', part):
-            sections = re.split('([0-9.]+)', part)
+        elif re.search("\\d$", part):
+            sections = re.split("([0-9.]+)", part)
             for s in sections:
                 s = s.strip()
                 if s:
@@ -118,8 +122,9 @@ def fixname(subdir):
 
     return " ".join(adj)
 
+
 def extract_sdef_commands(sdef):
-    cmds = [ ]
+    cmds = []
     with open(sdef) as file:
         inSectionToRead = False
         for line in file:
@@ -131,36 +136,42 @@ def extract_sdef_commands(sdef):
                 line = line.strip()
 
                 if line.startswith("DEBIAN_FRONTEND=noninteractive"):
-                    line = line.replace("DEBIAN_FRONTEND=noninteractive", "").strip()
+                    line = line.replace(
+                        "DEBIAN_FRONTEND=noninteractive", ""
+                    ).strip()
 
                 if line.startswith("/provision-scripts/"):
-                    spath = line[1:] # remove leading /
+                    spath = line[1:]  # remove leading /
                     subcmds = gather_provision_script_cmds(spath)
                     cmds.extend(subcmds)
                 elif line:
                     cmds.append(line)
     return cmds
 
+
 def extract_vfile_commands(vfile):
-    cmds = [ ]
+    cmds = []
     with open(vfile) as file:
         for line in file:
             line = line.strip()
-            if 'provision-scripts' in line:
+            if "provision-scripts" in line:
                 parts = line.split('"')
                 for part in parts:
-                    if 'provision-scripts' in part:
-                        spath = part[part.find('provision-scripts'):]
-                        if ('git-clone-chapel.sh' in spath or
-                            'gmake-chapel-quick.sh' in spath or
-                            'make-chapel-quick.sh' in spath or
-                            'freebsd-repo-fix.sh' in spath or
-                            'proxy-setup.sh' in spath):
-                            pass # skip these
+                    if "provision-scripts" in part:
+                        spath = part[part.find("provision-scripts") :]
+                        if (
+                            "git-clone-chapel.sh" in spath
+                            or "gmake-chapel-quick.sh" in spath
+                            or "make-chapel-quick.sh" in spath
+                            or "freebsd-repo-fix.sh" in spath
+                            or "proxy-setup.sh" in spath
+                        ):
+                            pass  # skip these
                         else:
                             subcmds = gather_provision_script_cmds(spath)
                             cmds.extend(subcmds)
     return cmds
+
 
 @contextmanager
 def cd(newdir):
@@ -171,32 +182,33 @@ def cd(newdir):
     finally:
         os.chdir(prevdir)
 
+
 def main():
     directories = ["current", "../vagrant/current"]
 
-    subdirs = [ ]
+    subdirs = []
     for d in directories:
         for subdir in os.listdir(d):
             subpath = os.path.join(d, subdir)
             if "nollvm" in subpath:
-                continue # skip these configurations
+                continue  # skip these configurations
             if "homebrew" in subpath:
-                continue # skip these configurations
-                        # (not sure how useful this is)
+                continue  # skip these configurations
+                # (not sure how useful this is)
             if "nix" in subpath:
-                continue # skip these configurations
-                        # (not sure how useful this is)
+                continue  # skip these configurations
+                # (not sure how useful this is)
             if "generic-x32-debian" in subpath:
-                continue # skip this one, redudant with other debian ones
+                continue  # skip this one, redudant with other debian ones
 
             subdirs.append(subpath)
 
     subdirs.sort(key=fixname)
 
-    tocmds = { }
+    tocmds = {}
 
     for subpath in subdirs:
-        cmds = [ ]
+        cmds = []
         if os.path.isdir(subpath):
             sdef = os.path.join(subpath, "image.def")
             vfile = os.path.join(subpath, "Vagrantfile")
@@ -207,13 +219,13 @@ def main():
             else:
                 print("NO CMDS FILE FOUND for", subpath)
 
-        result = [ ]
+        result = []
         for cmd in cmds:
             if cmd.startswith("#"):
-                pass # ignore comments
+                pass  # ignore comments
             else:
                 words = cmd.split()
-                adj = [ ]
+                adj = []
                 sudo = True
                 if words[0] == "sudo":
                     words.pop(0)
@@ -223,7 +235,11 @@ def main():
                 if words[-1] == "#unsudo":
                     sudo = False
                     words.pop(-1)
-                if len(words) >= 2 and words[-2] == "#" and words[-1] == "unsudo":
+                if (
+                    len(words) >= 2
+                    and words[-2] == "#"
+                    and words[-1] == "unsudo"
+                ):
                     sudo = False
                     words.pop(-1)
                     words.pop(-1)
@@ -231,7 +247,7 @@ def main():
                     sudo = False
                 for word in words:
                     if word == "-y" or word == "--yes" or word == "--noconfirm":
-                        pass # filter these out
+                        pass  # filter these out
                     elif word == "/home/vagrant/.bashrc":
                         adj.append("~/.bashrc")
                     else:
@@ -243,12 +259,12 @@ def main():
 
         tocmds[subpath] = result
 
-    tab = { }
+    tab = {}
 
     i = 0
     while i < len(subdirs):
         subpath = subdirs[i]
-        names = [ ]
+        names = []
 
         # find how many configs have the same commands
         cmds = tocmds[subpath]
@@ -258,7 +274,7 @@ def main():
 
         # summarize names string
         # remove words that occur repeatedly
-        shortnames = [ ]
+        shortnames = []
         firstwords = names[0].split()
         first = True
         for name in names:
@@ -273,8 +289,12 @@ def main():
                 mayskip = True
                 shortname = ""
                 while j < len(words):
-                    if mayskip and j < len(firstwords) and firstwords[j] == words[j]:
-                        pass # skip redundant word
+                    if (
+                        mayskip
+                        and j < len(firstwords)
+                        and firstwords[j] == words[j]
+                    ):
+                        pass  # skip redundant word
                     else:
                         mayskip = False
                         shortname += " " + words[j]
@@ -285,12 +305,13 @@ def main():
 
     # finally, output the table
     for names, cmds in sorted(tab.items(), key=lambda x: x[0]):
-        print("  * " + names + '::')
+        print("  * " + names + "::")
         print()
         for cmd in cmds:
             print("      " + cmd)
         print()
         print()
+
 
 if __name__ == "__main__":
     SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/util/devel/test/portability/apptainer/tryit.py
+++ b/util/devel/test/portability/apptainer/tryit.py
@@ -1,38 +1,42 @@
 #!/usr/bin/env python3
 
-""" Runs a command (or series of commands) on all the images.
-    Prints a summary of the output at the end.
-    Saves all of the command output in a file called 'log'. """
+"""Runs a command (or series of commands) on all the images.
+Prints a summary of the output at the end.
+Saves all of the command output in a file called 'log'."""
 
 import argparse, glob, os, subprocess, shutil, sys
 
+
 def gatherDirs(skip_nollvm):
-    dirs = [ ]
-    for d in glob.glob('current/*'):
-        if os.path.exists(os.path.join(d, 'image.def')):
-            if skip_nollvm and 'nollvm' in d:
-                pass # skip -nollvm versions if requested
+    dirs = []
+    for d in glob.glob("current/*"):
+        if os.path.exists(os.path.join(d, "image.def")):
+            if skip_nollvm and "nollvm" in d:
+                pass  # skip -nollvm versions if requested
             else:
                 dirs.append(d)
     dirs.sort()
     return dirs
 
+
 def dirNameToConfigName(d):
-    return os.path.basename(d.rstrip('/'))
+    return os.path.basename(d.rstrip("/"))
+
 
 def printAndLog(log, s):
     print(s)
     print(s, file=log)
 
+
 # Returns a tuple consisting of (exit code, last line)
 def runAndLog(log, command):
     printAndLog(log, "Running command: {}\n".format(" ".join(command)))
     try:
-        with subprocess.Popen(command,
-                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                              text=True) as p:
+        with subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        ) as p:
             for line in p.stdout:
-                line = line.rstrip('\n')
+                line = line.rstrip("\n")
                 printAndLog(log, line)
                 lastline = line
             p.wait()
@@ -40,31 +44,48 @@ def runAndLog(log, command):
     except OSError as e:
         return (-1, str(e))
 
+
 def main():
     parser = argparse.ArgumentParser(
-            description='Run a command on all the images.')
-    parser.add_argument('--cleanup', dest='cleanup', action='store_true',
-                        help='delete each image and checkout after using it')
-    parser.add_argument('--rebuild', dest='rebuild', action='store_true',
-                        help='rebuild each image before running it')
-    parser.add_argument('--start', dest='start', action='store',
-                        help='run configurations starting with the passed one')
-    parser.add_argument('--skip-nollvm', dest='skip_nollvm', action='store_true',
-                        help='skip nollvm configurations')
-    parser.add_argument('command', nargs='+', help='command to run')
+        description="Run a command on all the images."
+    )
+    parser.add_argument(
+        "--cleanup",
+        dest="cleanup",
+        action="store_true",
+        help="delete each image and checkout after using it",
+    )
+    parser.add_argument(
+        "--rebuild",
+        dest="rebuild",
+        action="store_true",
+        help="rebuild each image before running it",
+    )
+    parser.add_argument(
+        "--start",
+        dest="start",
+        action="store",
+        help="run configurations starting with the passed one",
+    )
+    parser.add_argument(
+        "--skip-nollvm",
+        dest="skip_nollvm",
+        action="store_true",
+        help="skip nollvm configurations",
+    )
+    parser.add_argument("command", nargs="+", help="command to run")
 
     args = parser.parse_args()
 
-    logpath = 'log'
+    logpath = "log"
 
     startDir = os.getcwd()
 
-    status = { }
+    status = {}
 
-    apptainer_image = os.environ.get('APPTAINER_IMAGE')
+    apptainer_image = os.environ.get("APPTAINER_IMAGE")
     if not apptainer_image:
-        printAndLog(sys.stderr,
-                    "APPTAINER_IMAGE environment variable not set.")
+        printAndLog(sys.stderr, "APPTAINER_IMAGE environment variable not set.")
         sys.exit(1)
     elif apptainer_image == "all":
         printAndLog(sys.stderr, "Running on all images.")
@@ -73,11 +94,11 @@ def main():
         printAndLog(sys.stderr, "Running on image: " + apptainer_image)
         only = apptainer_image
 
-    with open(logpath, 'w', encoding="utf-8") as log:
+    with open(logpath, "w", encoding="utf-8") as log:
         dirs = gatherDirs(args.skip_nollvm)
         if only != None:
             hadDirs = dirs
-            dirs = [ ]
+            dirs = []
             for d in hadDirs:
                 if dirNameToConfigName(d) == dirNameToConfigName(only):
                     dirs.append(d)
@@ -87,7 +108,7 @@ def main():
 
         if args.start != None:
             hadDirs = dirs
-            dirs = [ ]
+            dirs = []
             started = False
             for d in hadDirs:
                 if dirNameToConfigName(d) == dirNameToConfigName(args.start):
@@ -107,8 +128,7 @@ def main():
             name = dirNameToConfigName(d)
 
             os.chdir(d)
-            printAndLog(log,
-                        "     ---- " + name + " ---- ")
+            printAndLog(log, "     ---- " + name + " ---- ")
 
             statusline = ""
             # Build/rebuild image.sif if needed
@@ -116,30 +136,46 @@ def main():
                 printAndLog(log, "Removing {}/image.sif".format(d))
                 os.remove("image.sif")
             if not os.path.exists("image.sif"):
-                e,r = runAndLog(log, ["apptainer", "build", "--fakeroot",
-                                "image.sif", "image.def"])
+                e, r = runAndLog(
+                    log,
+                    [
+                        "apptainer",
+                        "build",
+                        "--fakeroot",
+                        "image.sif",
+                        "image.def",
+                    ],
+                )
                 if e != 0 or not os.path.exists("image.sif"):
                     statusline = "IMAGE BUILD FAILURE: " + r
                     ok = False
-                    print("    Image build failure: you might want to run\n" +
-                          "        cd " + d + "\n" +
-                          "        apptainer build --fakeroot image.sif image.def\n")
-
+                    print(
+                        "    Image build failure: you might want to run\n"
+                        + "        cd "
+                        + d
+                        + "\n"
+                        + "        apptainer build --fakeroot image.sif image.def\n"
+                    )
 
             # Run the command in the image
             if ok:
-                e,r = runAndLog(log,
-                                ["apptainer", "run", "image.sif"] +
-                                args.command)
+                e, r = runAndLog(
+                    log, ["apptainer", "run", "image.sif"] + args.command
+                )
                 if e == 0:
                     statusline = "OK: " + r
                 else:
                     statusline = "FAIL: " + r
                     ok = False
-                    print("    Failure: you might want to run\n" +
-                          "        cd " + d + "\n" +
-                          "        apptainer shell image.sif\n" +
-                          "        " + " ".join(args.command))
+                    print(
+                        "    Failure: you might want to run\n"
+                        + "        cd "
+                        + d
+                        + "\n"
+                        + "        apptainer shell image.sif\n"
+                        + "        "
+                        + " ".join(args.command)
+                    )
 
             status[name] = statusline
 
@@ -166,5 +202,5 @@ def main():
             sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/util/devel/test/portability/vagrant/re2-supported.py
+++ b/util/devel/test/portability/vagrant/re2-supported.py
@@ -3,17 +3,18 @@
 import os
 import sys
 
-chplenv_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', 'chplenv')
+chplenv_dir = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "..", "chplenv"
+)
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_compiler
 import compiler_utils
 
-
 # re2 requires c++11 for std atomics (and possibly other features). Use whether
 # std atomics are supported as a rough proxy for whether re2 should build
-compiler_val = chpl_compiler.get('target')
+compiler_val = chpl_compiler.get("target")
 std_atomics = compiler_utils.has_std_atomics()
 
-sys.stdout.write('bundled' if std_atomics else 'none')
-sys.stdout.write('\n')
+sys.stdout.write("bundled" if std_atomics else "none")
+sys.stdout.write("\n")

--- a/util/test/annotate.py
+++ b/util/test/annotate.py
@@ -4,15 +4,16 @@ import sys
 from collections import defaultdict
 
 import yaml
-try:
-  # Use CLoader if available for the speed boost
-  from yaml import CLoader as Loader
-except ImportError:
-  # Fall back to the python Loader otherwise
-  from yaml import Loader
 
-_dat_date_format = '%m/%d/%y'
-_csv_date_format = '%Y-%m-%d'
+try:
+    # Use CLoader if available for the speed boost
+    from yaml import CLoader as Loader
+except ImportError:
+    # Fall back to the python Loader otherwise
+    from yaml import Loader
+
+_dat_date_format = "%m/%d/%y"
+_csv_date_format = "%Y-%m-%d"
 # doubled up braces are the escape in .format
 _annotation_format = """{{\
  series: "{series}",\
@@ -26,52 +27,56 @@ _annotation_format = """{{\
 
 
 class InputError(Exception):
-  pass
+    pass
 
 
 def load(path):
-  with open(path, 'r') as source:
-    data = yaml.load(source, Loader=Loader)
+    with open(path, "r") as source:
+        data = yaml.load(source, Loader=Loader)
 
-  # replace all of the date strings with actual time structs
-  try:
-    for group in data:
-      for date in data[group].copy().keys():
-        data[group][time.strptime(date, _dat_date_format)] = data[group].pop(date)
-  except AttributeError:
-    raise InputError("Invalid annotation format in {0}".format(path))
+    # replace all of the date strings with actual time structs
+    try:
+        for group in data:
+            for date in data[group].copy().keys():
+                data[group][time.strptime(date, _dat_date_format)] = data[
+                    group
+                ].pop(date)
+    except AttributeError:
+        raise InputError("Invalid annotation format in {0}".format(path))
 
-  return data
+    return data
 
 
 def get(data, graph, series, start, end, config_name):
-  matches = defaultdict(list)
-  _find_annotations('all', matches, data, start, end, config_name)
-  _find_annotations(graph, matches, data, start, end, config_name)
+    matches = defaultdict(list)
+    _find_annotations("all", matches, data, start, end, config_name)
+    _find_annotations(graph, matches, data, start, end, config_name)
 
-  formatted = []
-  for i, date in enumerate(sorted(matches.keys()), start=1):
-    date_string = time.strftime(_csv_date_format, date)
-    ann_text = json.dumps('{0}: {1}'.format(date_string,
-      '\n'.join(matches[date])))
-    formatted.append(_annotation_format.format(
-        series = series,
-        x = date_string,
-        shortText = i,
-        text = ann_text,
-    ))
+    formatted = []
+    for i, date in enumerate(sorted(matches.keys()), start=1):
+        date_string = time.strftime(_csv_date_format, date)
+        ann_text = json.dumps(
+            "{0}: {1}".format(date_string, "\n".join(matches[date]))
+        )
+        formatted.append(
+            _annotation_format.format(
+                series=series,
+                x=date_string,
+                shortText=i,
+                text=ann_text,
+            )
+        )
 
-  return formatted
+    return formatted
 
 
 def _find_annotations(graph, matches, data, start, end, config_name):
-  if graph in data:
-    for date, annotations in data[graph].items():
-      if start <= date and date <= end:
-        for ann in annotations:
-          if isinstance(ann, dict):
-            if config_name in ann['config']:
-              matches[date].append(ann['text'])
-          else:
-            matches[date].append(ann)
-
+    if graph in data:
+        for date, annotations in data[graph].items():
+            if start <= date and date <= end:
+                for ann in annotations:
+                    if isinstance(ann, dict):
+                        if config_name in ann["config"]:
+                            matches[date].append(ann["text"])
+                    else:
+                        matches[date].append(ann)

--- a/util/test/check_annotations.py
+++ b/util/test/check_annotations.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-""" Do basic validation and checks on the ANNOTATIONS.yaml file
+"""Do basic validation and checks on the ANNOTATIONS.yaml file
 
 This is a kinda-ugly script that does basic validation of ANNOTATIONS.yaml
 since we always manage to screw it up and cause nightly testing noise.
@@ -12,7 +12,7 @@ It does the following:
  - checks that all the configs used in the annotations file are "known"
  - checks that annotation dates are not the same as the merge date
    (annotation dates are supposed to be for the first "affected" date
- """
+"""
 
 from __future__ import print_function
 
@@ -25,10 +25,11 @@ import warnings
 
 import annotate
 
-chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
+chplenv_dir = os.path.join(os.path.dirname(__file__), "..", "chplenv")
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 from chpl_home_utils import get_chpl_home
+
 
 def main():
     """
@@ -36,8 +37,8 @@ def main():
     """
     os.environ["TZ"] = "America/Los_Angeles"
     chpl_home = get_chpl_home()
-    test_dir = os.path.join(chpl_home, 'test')
-    ann_path = os.path.join(test_dir, 'ANNOTATIONS.yaml')
+    test_dir = os.path.join(chpl_home, "test")
+    ann_path = os.path.join(test_dir, "ANNOTATIONS.yaml")
 
     with warnings.catch_warnings(record=True) as warnings_list:
         ann_data = annotate.load(ann_path)
@@ -50,61 +51,91 @@ def main():
 
         for warning in warnings_list:
             print(warning.message)
-        print('No fatal annotation errors detected')
+        print("No fatal annotation errors detected")
         return len(warnings_list) != 0
 
 
 def get_graph_names(test_dir):
     """Parse test_dir/*GRAPHFILES and return basenames for all .graph files"""
     graph_list = []
-    GRAPHFILES_files = [f for f in os.listdir(test_dir) if f.endswith("GRAPHFILES")]
+    GRAPHFILES_files = [
+        f for f in os.listdir(test_dir) if f.endswith("GRAPHFILES")
+    ]
     for GRAPHFILE in GRAPHFILES_files:
-        with open(os.path.join(test_dir, GRAPHFILE), 'r') as f:
+        with open(os.path.join(test_dir, GRAPHFILE), "r") as f:
             for l in f.readlines():
                 l = l.strip()
-                if not l or l.startswith('#'):
+                if not l or l.startswith("#"):
                     continue
-                graph_list.append(os.path.basename(l).replace('.graph', ''))
+                graph_list.append(os.path.basename(l).replace(".graph", ""))
     return graph_list
 
-def parse_date(value, dateformat='%Y-%m-%d'):
+
+def parse_date(value, dateformat="%Y-%m-%d"):
     """Parse a string into a date"""
     return time.strptime(value.strip(), dateformat)
+
 
 def try_parsing_annotations(ann_data, graph_list):
     """Parse annotations for every possible graph for all valid date ranges"""
     for graph in graph_list:
         try:
-            start_date = parse_date('2001-01-01')
-            end_date = parse_date('2100-12-31')
-            annotate.get(ann_data, graph, '', start_date, end_date, '')
+            start_date = parse_date("2001-01-01")
+            end_date = parse_date("2100-12-31")
+            annotate.get(ann_data, graph, "", start_date, end_date, "")
         except Exception as e:
             print('Error parsing annotations for "{0}"\n'.format(graph))
             raise e
 
+
 def check_graph_names(ann_data, graph_list):
     """Check that graph names in the annotation file are listed in GRAPHFILES"""
     for graph in ann_data:
-        if graph != 'all' and 'arkouda' not in graph and graph not in graph_list:
-            warnings.warn('Warning: no .graph file found for "{0}"'.format(graph))
+        if (
+            graph != "all"
+            and "arkouda" not in graph
+            and graph not in graph_list
+        ):
+            warnings.warn(
+                'Warning: no .graph file found for "{0}"'.format(graph)
+            )
+
 
 def check_configs(ann_data):
     """Check that all the configs used in the annotation file are 'known'"""
-    known_configs = {'shootout', 'chap03', 'chap04', 'bradc-lnx', 'chapcs',
-                     '16-node-xc', '1-node-xc', '16-node-cs', '16-node-cs-hdr',
-                     'chapcs.comm-counts', '1-node-p100', '1-node-mi60',
-                     '16-node-apollo-hdr', '16-node-hpe-cray-ex', '1-node-hpe-cray-ex', '1-node-a100', '1-node-mi250x',
-                     '16-node-hpe-apollo-hdr'}
+    known_configs = {
+        "shootout",
+        "chap03",
+        "chap04",
+        "bradc-lnx",
+        "chapcs",
+        "16-node-xc",
+        "1-node-xc",
+        "16-node-cs",
+        "16-node-cs-hdr",
+        "chapcs.comm-counts",
+        "1-node-p100",
+        "1-node-mi60",
+        "16-node-apollo-hdr",
+        "16-node-hpe-cray-ex",
+        "1-node-hpe-cray-ex",
+        "1-node-a100",
+        "1-node-mi250x",
+        "16-node-hpe-apollo-hdr",
+    }
     for graph in ann_data:
         for _, annotations in ann_data[graph].items():
             for ann in annotations:
-                if isinstance(ann, dict) and 'config' in ann:
-                    configs = ann['config'].split(',')
+                if isinstance(ann, dict) and "config" in ann:
+                    configs = ann["config"].split(",")
                     for config in configs:
                         config = config.strip()
                         if config not in known_configs:
-                            warnings.warn('Warning: unrecognized config "{0}" '
-                                          'for graph "{1}"'.format(config, graph))
+                            warnings.warn(
+                                'Warning: unrecognized config "{0}" '
+                                'for graph "{1}"'.format(config, graph)
+                            )
+
 
 def compute_pr_to_dates():
     """Helper function to compute a map of PR numbers to commit dates"""
@@ -113,14 +144,15 @@ def compute_pr_to_dates():
     p = subprocess.Popen(git_cmd, stdout=subprocess.PIPE, shell=True)
     git_log = p.communicate()[0]
     if sys.version_info[0] >= 3 and not isinstance(git_log, str):
-        git_log = str(git_log, 'utf-8')
+        git_log = str(git_log, "utf-8")
     for line in git_log.splitlines():
-        split_line = line.split(' ::: ')
+        split_line = line.split(" ::: ")
         date = split_line[0]
-        pr_num = re.match(r'Merge pull request #(\d+)', split_line[1]).group(1)
+        pr_num = re.match(r"Merge pull request #(\d+)", split_line[1]).group(1)
         pr_to_date_dict[pr_num] = parse_date(date)
 
     return pr_to_date_dict
+
 
 def check_pr_number_dates(ann_data):
     """
@@ -132,18 +164,20 @@ def check_pr_number_dates(ann_data):
         for date, annotations in ann_data[graph].items():
             for ann in annotations:
                 if isinstance(ann, dict):
-                    text = ann.get('text')
+                    text = ann.get("text")
                 else:
                     text = ann
-                if '#' in text:
-                    pr_num = re.match(r'.*#(\d+)', text).group(1)
+                if "#" in text:
+                    pr_num = re.match(r".*#(\d+)", text).group(1)
                     if pr_num in pr_to_date_dict:
                         pr_date = pr_to_date_dict[pr_num]
                         if pr_date >= date:
-                            warnings.warn('Warning: annotation date for "{0}: '
-                                          '{1}" is earlier than or the same as '
-                                          'the commit date'.format(graph, text))
+                            warnings.warn(
+                                'Warning: annotation date for "{0}: '
+                                '{1}" is earlier than or the same as '
+                                "the commit date".format(graph, text)
+                            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/util/test/chpl_launchcmd.py
+++ b/util/test/chpl_launchcmd.py
@@ -44,19 +44,18 @@ import time
 import xml.etree.ElementTree
 
 # Add the chplenv dir to the python path.
-chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
+chplenv_dir = os.path.join(os.path.dirname(__file__), "..", "chplenv")
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_cpu
 
-
-__all__ = ('main')
+__all__ = "main"
 
 
 def main():
     """Run the program!"""
     job = AbstractJob.init_from_environment()
-    (stdout, stderr) = job.run()
+    stdout, stderr = job.run()
     sys.stdout.buffer.write(stdout)
     sys.stderr.buffer.write(stderr)
 
@@ -107,14 +106,24 @@ class AbstractJob(object):
         self.hostlist = reservation_args.hostlist
         self.queue = reservation_args.queue
 
-        logging.debug('Created instance of: {0}'.format(self))
+        logging.debug("Created instance of: {0}".format(self))
 
     def __repr__(self):
         """Return string representation of this instance."""
         cls_name = str(type(self))
-        attrs = ', '.join(map(lambda x: '{0}={1}'.format(x, getattr(self, x, None)),
-                              ['test_command', 'num_locales', 'walltime', 'hostlist', 'queue']))
-        return '{0}({1})'.format(cls_name, attrs)
+        attrs = ", ".join(
+            map(
+                lambda x: "{0}={1}".format(x, getattr(self, x, None)),
+                [
+                    "test_command",
+                    "num_locales",
+                    "walltime",
+                    "hostlist",
+                    "queue",
+                ],
+            )
+        )
+        return "{0}({1})".format(cls_name, attrs)
 
     def full_test_command(self, output_file, error_file):
         """Returns instance's test_command prefixed with command to change to
@@ -134,7 +143,7 @@ class AbstractJob(object):
         :rtype: list
         :returns: command to run in qsub with changedir call and redirection
         """
-        full_test_command = ['cd', '$PBS_O_WORKDIR', '&&']
+        full_test_command = ["cd", "$PBS_O_WORKDIR", "&&"]
 
         # If the first argument of the test command is a file (it should
         # always be the executable), then add a "test -f ./execname" call
@@ -142,17 +151,24 @@ class AbstractJob(object):
         # configuration issues that can happen when running from lustre
         # mounted over nfs.
         if os.path.exists(self.test_command[0]):
-            logging.debug('Adding "test -f {0}" to launcher command.'.format(
-                self.test_command[0]))
-            full_test_command += ['test', '-f', self.test_command[0], '&&']
+            logging.debug(
+                'Adding "test -f {0}" to launcher command.'.format(
+                    self.test_command[0]
+                )
+            )
+            full_test_command += ["test", "-f", self.test_command[0], "&&"]
 
-        envvars = ['LANG', 'LC_ALL',  'LC_COLLATE']
-        charset = ' '.join(['{0}="{1}"'.format(e, os.getenv(e, '')) for e in envvars])
+        envvars = ["LANG", "LC_ALL", "LC_COLLATE"]
+        charset = " ".join(
+            ['{0}="{1}"'.format(e, os.getenv(e, "")) for e in envvars]
+        )
         full_test_command += [charset]
 
         full_test_command.extend(self.test_command)
         if self.redirect_output:
-            full_test_command.extend(['>{0} 2>{1}'.format(output_file, error_file)])
+            full_test_command.extend(
+                [">{0} 2>{1}".format(output_file, error_file)]
+            )
         return full_test_command
 
     @property
@@ -166,24 +182,25 @@ class AbstractJob(object):
         :returns: Number of cpus to reserve, or -1 if there was no cnselect output
         """
         try:
-            n_cpus = os.environ.get('CHPL_LAUNCHCMD_NUM_CPUS')
+            n_cpus = os.environ.get("CHPL_LAUNCHCMD_NUM_CPUS")
             if n_cpus is not None:
                 return n_cpus
-            logging.debug('Checking for number of cpus to reserve.')
+            logging.debug("Checking for number of cpus to reserve.")
             cnselect_proc = py3_compat.Popen(
-                ['cnselect', '-Lnumcores'],
+                ["cnselect", "-Lnumcores"],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT)
+                stderr=subprocess.STDOUT,
+            )
 
-            logging.debug('Communicating with cnselect process.')
+            logging.debug("Communicating with cnselect process.")
             stdout, stderr = cnselect_proc.communicate()
         except OSError as ex:
             raise RuntimeError(ex)
-        first_line = stdout.split('\n')[0]
+        first_line = stdout.split("\n")[0]
         if first_line:
             return int(first_line)
         else:
-            msg = 'cnselect -Lnumcores had no output.'
+            msg = "cnselect -Lnumcores had no output."
             logging.error(msg)
             raise ValueError(msg)
 
@@ -195,15 +212,15 @@ class AbstractJob(object):
         :rtype: str
         :returns: job name
         """
-        prefix = os.environ.get('CHPL_LAUNCHCMD_NAME_PREFIX', 'Chpl')
-        logging.debug('Job name prefix is: {0}'.format(prefix))
+        prefix = os.environ.get("CHPL_LAUNCHCMD_NAME_PREFIX", "Chpl")
+        logging.debug("Job name prefix is: {0}".format(prefix))
 
         cmd_basename = os.path.basename(self.test_command[0])
-        logging.debug('Test command basename: {0}'.format(cmd_basename))
+        logging.debug("Test command basename: {0}".format(cmd_basename))
 
-        job_name = '{0}-{1}'.format(prefix, cmd_basename)
-        job_name = job_name.replace('=','-')
-        logging.debug('Job name is: {0}'.format(job_name))
+        job_name = "{0}-{1}".format(prefix, cmd_basename)
+        job_name = job_name.replace("=", "-")
+        logging.debug("Job name is: {0}".format(job_name))
         return job_name
 
     @property
@@ -213,7 +230,7 @@ class AbstractJob(object):
         :rtype: str
         :returns: select expression suffix, or empty string
         """
-        return ''
+        return ""
 
     def _qsub_command_base(self, output_file, error_file):
         """Returns base qsub command, without any resource listing.
@@ -227,16 +244,18 @@ class AbstractJob(object):
         :rtype: list
         :returns: qsub command as list of strings
         """
-        submit_command =  [self.submit_bin, '-V', '-N', self.job_name]
+        submit_command = [self.submit_bin, "-V", "-N", self.job_name]
         if not self.redirect_output:
-            submit_command.extend(['-o', output_file, '-e', error_file])
+            submit_command.extend(["-o", output_file, "-e", error_file])
         else:
             # even when redirecting output, PBS errors are sent to the error
             # stream, so make sure we can find errors if they occur
-            submit_command.extend(['-j', 'oe', '-o', '{0}.more'.format(error_file)])
+            submit_command.extend(
+                ["-j", "oe", "-o", "{0}.more".format(error_file)]
+            )
         if self.walltime is not None:
-            submit_command.append('-l')
-            submit_command.append('walltime={0}'.format(self.walltime))
+            submit_command.append("-l")
+            submit_command.append("walltime={0}".format(self.walltime))
 
         return submit_command
 
@@ -256,32 +275,38 @@ class AbstractJob(object):
         submit_command = self._qsub_command_base(output_file, error_file)
 
         if self.queue is not None:
-            submit_command.append('-q')
-            submit_command.append('{0}'.format(self.queue))
+            submit_command.append("-q")
+            submit_command.append("{0}".format(self.queue))
         if self.num_locales >= 0:
-            submit_command.append('-l')
-            submit_command.append('{0}={1}{2}'.format(
-                self.num_nodes_resource, self.num_locales, self.select_suffix))
+            submit_command.append("-l")
+            submit_command.append(
+                "{0}={1}{2}".format(
+                    self.num_nodes_resource,
+                    self.num_locales,
+                    self.select_suffix,
+                )
+            )
         if self.hostlist is not None:
-            submit_command.append('-l')
-            submit_command.append('{0}={1}'.format(
-                self.hostlist_resource, self.hostlist))
+            submit_command.append("-l")
+            submit_command.append(
+                "{0}={1}".format(self.hostlist_resource, self.hostlist)
+            )
         if self.num_cpus_resource is not None:
-            submit_command.append('-l')
-            submit_command.append('{0}={1}'.format(
-                self.num_cpus_resource, self.num_cpus))
+            submit_command.append("-l")
+            submit_command.append(
+                "{0}={1}".format(self.num_cpus_resource, self.num_cpus)
+            )
         if self.processing_elems_per_node_resource is not None:
-            submit_command.append('-l')
-            submit_command.append('{0}={1}'.format(
-                self.processing_elems_per_node_resource, 1))
-        more_l = os.environ.get('CHPL_LAUNCHCMD_QSUB_MORE_L')
+            submit_command.append("-l")
+            submit_command.append(
+                "{0}={1}".format(self.processing_elems_per_node_resource, 1)
+            )
+        more_l = os.environ.get("CHPL_LAUNCHCMD_QSUB_MORE_L")
         if more_l:
-            submit_command.append('{0}'.format(more_l))
+            submit_command.append("{0}".format(more_l))
 
-
-        logging.info('qsub command: "{0}"'.format(' '.join(submit_command)))
+        logging.info('qsub command: "{0}"'.format(" ".join(submit_command)))
         return submit_command
-
 
     def run(self):
         """Run batch job in subprocess and wait for job to complete.
@@ -291,13 +316,19 @@ class AbstractJob(object):
         :returns: stdout/stderr from job
         """
         with _temp_dir() as working_dir:
-            output_file = os.path.join(working_dir, 'test_output.log')
-            error_file = os.path.join(working_dir, 'test_error_output.log')
-            input_file = os.path.join(working_dir, 'test_input')
+            output_file = os.path.join(working_dir, "test_output.log")
+            error_file = os.path.join(working_dir, "test_error_output.log")
+            input_file = os.path.join(working_dir, "test_input")
             testing_dir = os.getcwd()
 
-            job_id = self.submit_job(testing_dir, output_file, error_file, input_file)
-            logging.info('Test has been queued (job id: {0}). Waiting for output...'.format(job_id))
+            job_id = self.submit_job(
+                testing_dir, output_file, error_file, input_file
+            )
+            logging.info(
+                "Test has been queued (job id: {0}). Waiting for output...".format(
+                    job_id
+                )
+            )
 
             # TODO: The while condition here should look for jobs that become held,
             #       are in the queue too long, or ??? and do something
@@ -321,15 +352,15 @@ class AbstractJob(object):
             def job_status(job_id, output_file):
                 """Returns the status of the job specified by job_id
 
-                 The status is determined by calling status(job_id). If that
-                 call is successful the result is returned. The exact code
-                 returned is up to status(job_id) but it must support 'C' for
-                 complete, 'Q' for queued/waiting to run, and 'R' for running 
+                The status is determined by calling status(job_id). If that
+                call is successful the result is returned. The exact code
+                returned is up to status(job_id) but it must support 'C' for
+                complete, 'Q' for queued/waiting to run, and 'R' for running
 
-                 status(job_id) can raise a ValueError, which can indicate that
-                 the job has completed *and* been dequeued. If the output file
-                 exists and the job has been dequeued, it is safe to assume it
-                 completed. Otherwise we raise the error
+                status(job_id) can raise a ValueError, which can indicate that
+                the job has completed *and* been dequeued. If the output file
+                exists and the job has been dequeued, it is safe to assume it
+                completed. Otherwise we raise the error
                 """
                 try:
                     job_status = self.status(job_id)
@@ -340,15 +371,15 @@ class AbstractJob(object):
                     # file exists, assume success. Otherwise re raise error
                     # message.
                     if os.path.exists(output_file):
-                        return 'C'
+                        return "C"
                     raise
 
             exec_start_time = time.time()
             alreadyRunning = False
             sleep_time = 1
             status = job_status(job_id, output_file)
-            while status != 'C':
-                if not alreadyRunning and status == 'R':
+            while status != "C":
+                if not alreadyRunning and status == "R":
                     alreadyRunning = True
                     sleep_time = 1
                     exec_start_time = time.time()
@@ -362,45 +393,58 @@ class AbstractJob(object):
             # start or end time, however this does give a better estimate than
             # timing the whole binary for cases where the time in the queue is
             # large. It tends to be a second or two larger than real exec time
-            exec_time_file = os.environ.get('CHPL_LAUNCHCMD_EXEC_TIME_FILE')
+            exec_time_file = os.environ.get("CHPL_LAUNCHCMD_EXEC_TIME_FILE")
             if exec_time_file != None:
-                with open(exec_time_file, 'w') as fp:
-                    fp.write('{0:3f}'.format(exec_time))
+                with open(exec_time_file, "w") as fp:
+                    fp.write("{0:3f}".format(exec_time))
 
-            logging.debug('{0} reports job {1} as complete.'.format(
-                self.status_bin, job_id))
+            logging.debug(
+                "{0} reports job {1} as complete.".format(
+                    self.status_bin, job_id
+                )
+            )
 
             if not os.path.exists(output_file):
-                logging.error('Output file from job does not exist at: {0}'.format(
-                    output_file))
-                raise ValueError('[Error: output file from job (id: {0}) does not exist at: {1}]'.format(
-                    job_id, output_file))
+                logging.error(
+                    "Output file from job does not exist at: {0}".format(
+                        output_file
+                    )
+                )
+                raise ValueError(
+                    "[Error: output file from job (id: {0}) does not exist at: {1}]".format(
+                        job_id, output_file
+                    )
+                )
 
             # try removing the file stdin was copied to, might not exist
-            logging.debug('removing stdin file.')
+            logging.debug("removing stdin file.")
             try:
                 os.unlink(input_file)
             except OSError:
                 pass
 
-            logging.debug('Reading output file.')
-            with open(output_file, 'rb') as fp:
+            logging.debug("Reading output file.")
+            with open(output_file, "rb") as fp:
                 output = fp.read()
 
-            logging.debug('Reading error file.')
-            with open(error_file, 'rb') as fp:
+            logging.debug("Reading error file.")
+            with open(error_file, "rb") as fp:
                 error = fp.read()
 
-            logging.debug('Reading more file.')
+            logging.debug("Reading more file.")
             try:
-                with open('{0}.more'.format(error_file), 'r') as fp:
+                with open("{0}.more".format(error_file), "r") as fp:
                     for l in fp:
                         if "PBS:" in l:
                             error += py3_compat.str_to_bytes(l)
             except:
                 pass
 
-            logging.info('The test finished with output of length {0}.'.format(len(output)))
+            logging.info(
+                "The test finished with output of length {0}.".format(
+                    len(output)
+                )
+            )
 
         return (output, error)
 
@@ -422,7 +466,9 @@ class AbstractJob(object):
         :rtype: str
         :returns: job id
         """
-        raise NotImplementedError('submit_job class method is implemented by sub classes.')
+        raise NotImplementedError(
+            "submit_job class method is implemented by sub classes."
+        )
 
     @classmethod
     def _detect_job_flavor(cls):
@@ -443,30 +489,28 @@ class AbstractJob(object):
         :returns: SlurmJob, MoabJob, or PbsProJob depending on environment
         """
         qsub_callable = False
-        qsub_version = ''
+        qsub_version = ""
         srun_callable = False
-        srun_version = ''
+        srun_version = ""
 
         def get_output(cmd):
             proc = py3_compat.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
             )
-            logging.debug('Communicating with job process.')
+            logging.debug("Communicating with job process.")
             stdout, stderr = proc.communicate()
             return stdout
 
         # Detect if qsub is callable, and capture version output.
         try:
-            qsub_version = get_output(['qsub', '--version'])
+            qsub_version = get_output(["qsub", "--version"])
             qsub_callable = True
         except OSError:
             pass
 
         # Detect if srun is callable, and capture version output.
         try:
-            srun_version = get_output(['srun', '--version'])
+            srun_version = get_output(["srun", "--version"])
             srun_callable = True
         except OSError:
             pass
@@ -475,14 +519,14 @@ class AbstractJob(object):
         # that is wrapper around slurm apis.
         if srun_callable:
             return SlurmJob
-        elif qsub_callable and 'MOABHOMEDIR' in os.environ:
+        elif qsub_callable and "MOABHOMEDIR" in os.environ:
             return MoabJob
-        elif qsub_callable and 'CHPL_PBSPRO_USE_MPP' in os.environ:
+        elif qsub_callable and "CHPL_PBSPRO_USE_MPP" in os.environ:
             return MppPbsProJob
         elif qsub_callable:
             return PbsProJob
         else:  # not (qsub_callable or srun_callable)
-            raise RuntimeError('Could not find PBS or SLURM on system.')
+            raise RuntimeError("Could not find PBS or SLURM on system.")
 
     def _launch_qsub(self, testing_dir, output_file, error_file):
         """Launch job using qsub and return job id. Raises RuntimeError if
@@ -500,40 +544,54 @@ class AbstractJob(object):
         :rtype: str
         :returns: job id
         """
-        if self.submit_bin != 'qsub':
-            raise RuntimeError('_launch_qsub called for non-pbs job type!')
+        if self.submit_bin != "qsub":
+            raise RuntimeError("_launch_qsub called for non-pbs job type!")
 
         # Quiet information from LMOD about module changes that would show up
         # in our test output
-        logging.info('Setting LMOD_QUIET=1')
+        logging.info("Setting LMOD_QUIET=1")
         os.environ["LMOD_QUIET"] = "1"
 
         logging.info(
             'Starting {0} job "{1}" on {2} locales with walltime {3} '
-            'and output file: {4}'.format(
-                self.submit_bin, self.job_name, self.num_locales,
-                self.walltime, output_file))
+            "and output file: {4}".format(
+                self.submit_bin,
+                self.job_name,
+                self.num_locales,
+                self.walltime,
+                output_file,
+            )
+        )
 
-        logging.debug('Opening {0} subprocess.'.format(self.submit_bin))
+        logging.debug("Opening {0} subprocess.".format(self.submit_bin))
         submit_proc = py3_compat.Popen(
             self._qsub_command(output_file, error_file),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=testing_dir,
-            env=os.environ.copy()
+            env=os.environ.copy(),
         )
 
-        test_command_str = ' '.join(self.full_test_command(output_file, error_file))
-        logging.debug('Communicating with {0} subprocess. Sending test command on stdin: {1}'.format(
-            self.submit_bin, test_command_str))
+        test_command_str = " ".join(
+            self.full_test_command(output_file, error_file)
+        )
+        logging.debug(
+            "Communicating with {0} subprocess. Sending test command on stdin: {1}".format(
+                self.submit_bin, test_command_str
+            )
+        )
         stdout, stderr = submit_proc.communicate(input=test_command_str)
-        logging.debug('{0} process returned with status {1}, stdout: {2} stderr: {3}'.format(
-            self.submit_bin, submit_proc.returncode, stdout, stderr))
+        logging.debug(
+            "{0} process returned with status {1}, stdout: {2} stderr: {3}".format(
+                self.submit_bin, submit_proc.returncode, stdout, stderr
+            )
+        )
 
         if submit_proc.returncode != 0:
-            msg = '{0} failed with exit code {1} and output: {2}'.format(
-                self.submit_bin, submit_proc.returncode, stdout)
+            msg = "{0} failed with exit code {1} and output: {2}".format(
+                self.submit_bin, submit_proc.returncode, stdout
+            )
             logging.error(msg)
             raise ValueError(msg)
 
@@ -552,17 +610,17 @@ class AbstractJob(object):
         cls._setup_logging(args.verbose, args.info)
         cls._validate_args(args, unparsed_args)
 
-        logging.info('Num locales is: {0}'.format(args.numLocales))
-        logging.info('Walltime is set to: {0}'.format(args.walltime))
+        logging.info("Num locales is: {0}".format(args.numLocales))
+        logging.info("Walltime is set to: {0}".format(args.walltime))
 
         test_command = cls._get_test_command(args, unparsed_args)
-        logging.debug('Test command is: {0}'.format(' '.join(test_command)))
+        logging.debug("Test command is: {0}".format(" ".join(test_command)))
         if not test_command:
-            logging.error('No test command provided.')
-            raise ValueError('No test command found.')
+            logging.error("No test command provided.")
+            raise ValueError("No test command found.")
 
         job_flavor = cls._detect_job_flavor()
-        logging.info('Detected job flavor: {0}'.format(job_flavor.__name__))
+        logging.info("Detected job flavor: {0}".format(job_flavor.__name__))
         return job_flavor(test_command, args)
 
     @classmethod
@@ -576,7 +634,9 @@ class AbstractJob(object):
         :rtype: str
         :returns: job status
         """
-        raise NotImplementedError('status class method is implemented by sub classes.')
+        raise NotImplementedError(
+            "status class method is implemented by sub classes."
+        )
 
     @classmethod
     def _cli_walltime(cls, walltime_str):
@@ -591,45 +651,53 @@ class AbstractJob(object):
         """
         try:
             seconds = int(walltime_str)
-            logging.debug('Parsed walltime as integer seconds: {0}'.format(seconds))
+            logging.debug(
+                "Parsed walltime as integer seconds: {0}".format(seconds)
+            )
             return walltime_str
         except ValueError:
             pass
 
         try:
             seconds = float(walltime_str)
-            logging.debug('Parsed walltime as float seconds: {0}'.format(seconds))
+            logging.debug(
+                "Parsed walltime as float seconds: {0}".format(seconds)
+            )
             return walltime_str
         except ValueError:
             pass
 
         # http://www.csc.fi/english/pages/louhi_guide/batch_jobs/commands/qsub
         known_formats = [
-            '%M:%S',
-            '%H:%M:%S',
-            '%M:%S.%f',
-            '%H:%M:%S.%f',
+            "%M:%S",
+            "%H:%M:%S",
+            "%M:%S.%f",
+            "%H:%M:%S.%f",
         ]
         for fmt in known_formats:
             try:
                 walltime = datetime.datetime.strptime(walltime_str, fmt)
-                logging.debug('Parsed walltime as datetime with format {0}: {1}'.format(
-                    fmt, walltime))
+                logging.debug(
+                    "Parsed walltime as datetime with format {0}: {1}".format(
+                        fmt, walltime
+                    )
+                )
                 return walltime_str
             except ValueError:
                 pass
 
-        raise ValueError('Did not recognize walltime: {0}'.format(walltime_str))
+        raise ValueError("Did not recognize walltime: {0}".format(walltime_str))
 
     @classmethod
     def _validate_args(cls, args, unparsed_args):
         for arg in unparsed_args:
-            if re.search(r'^-nl[0-9]+$', arg):
+            if re.search(r"^-nl[0-9]+$", arg):
                 # TODO parse this quietly, or turn it into an error?
-                logging.warning('Argument format {} is not supported. '
-                                'Please put a space between "-nl" and number of '
-                                'locales, if that\'s the purpose.'.format(arg))
-
+                logging.warning(
+                    "Argument format {} is not supported. "
+                    'Please put a space between "-nl" and number of '
+                    "locales, if that's the purpose.".format(arg)
+                )
 
     @classmethod
     def _get_test_command(cls, args, unparsed_args):
@@ -645,12 +713,14 @@ class AbstractJob(object):
         :rtype: list
         :returns: command to be tested in qsub
         """
-        logging.debug('Rebuilding test command from parsed args: {0} and '
-                      'unparsed args: {1}'.format(args, unparsed_args))
+        logging.debug(
+            "Rebuilding test command from parsed args: {0} and "
+            "unparsed args: {1}".format(args, unparsed_args)
+        )
         if args.numLocales >= 0:
-            unparsed_args.append('-nl')
+            unparsed_args.append("-nl")
             unparsed_args.append(str(args.numLocales))
-        logging.debug('Rebuild test command: {0}'.format(unparsed_args))
+        logging.debug("Rebuild test command: {0}".format(unparsed_args))
         return unparsed_args
 
     @classmethod
@@ -658,50 +728,81 @@ class AbstractJob(object):
         """Parse and return command line arguments. Returns tuple of Namespace with
         parsed args and unparsed args.
         """
-        class OurFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
+
+        class OurFormatter(
+            argparse.ArgumentDefaultsHelpFormatter,
+            argparse.RawDescriptionHelpFormatter,
+        ):
             pass
 
         parser = argparse.ArgumentParser(
-            description=__doc__,
-            formatter_class=OurFormatter)
-        parser.add_argument('--CHPL_LAUNCHCMD_DEBUG', action='store_true', dest='verbose',
-                            default=('CHPL_LAUNCHCMD_DEBUG' in os.environ),
-                            help=('Verbose output. Setting CHPL_LAUNCHCMD_DEBUG '
-                                  'in environment also enables verbose output.'))
-        parser.add_argument('--CHPL_LAUNCHCMD_INFO', action='store_true', dest='info',
-                            default=('CHPL_LAUNCHCMD_INFO' in os.environ),
-                            help=('Informational output. Setting CHPL_LAUNCHCMD_INFO '
-                                  'in environment also enables.'))
-        parser.add_argument('-nl', '--numLocales', type=int, default=-1,
-                            help='Number locales.')
-        parser.add_argument('--n', help='Placeholder')
-        parser.add_argument('--walltime', type=cls._cli_walltime,
-                            help='Timeout as walltime for qsub.')
-        parser.add_argument('--CHPL_LAUNCHCMD_HOSTLIST', dest='hostlist',
-                            help=('Optional hostlist specification for reserving '
-                                  'specific nodes. Can also be set with env var '
-                                  'CHPL_LAUNCHCMD_HOSTLIST'))
-        parser.add_argument('--CHPL_LAUNCHCMD_QUEUE', dest='queue',
-                            help=('Optional queue specification for reserving '
-                                  'specific queues. Can also be set with env var '
-                                  'CHPL_LAUNCHCMD_QUEUES'))
-
+            description=__doc__, formatter_class=OurFormatter
+        )
+        parser.add_argument(
+            "--CHPL_LAUNCHCMD_DEBUG",
+            action="store_true",
+            dest="verbose",
+            default=("CHPL_LAUNCHCMD_DEBUG" in os.environ),
+            help=(
+                "Verbose output. Setting CHPL_LAUNCHCMD_DEBUG "
+                "in environment also enables verbose output."
+            ),
+        )
+        parser.add_argument(
+            "--CHPL_LAUNCHCMD_INFO",
+            action="store_true",
+            dest="info",
+            default=("CHPL_LAUNCHCMD_INFO" in os.environ),
+            help=(
+                "Informational output. Setting CHPL_LAUNCHCMD_INFO "
+                "in environment also enables."
+            ),
+        )
+        parser.add_argument(
+            "-nl", "--numLocales", type=int, default=-1, help="Number locales."
+        )
+        parser.add_argument("--n", help="Placeholder")
+        parser.add_argument(
+            "--walltime",
+            type=cls._cli_walltime,
+            help="Timeout as walltime for qsub.",
+        )
+        parser.add_argument(
+            "--CHPL_LAUNCHCMD_HOSTLIST",
+            dest="hostlist",
+            help=(
+                "Optional hostlist specification for reserving "
+                "specific nodes. Can also be set with env var "
+                "CHPL_LAUNCHCMD_HOSTLIST"
+            ),
+        )
+        parser.add_argument(
+            "--CHPL_LAUNCHCMD_QUEUE",
+            dest="queue",
+            help=(
+                "Optional queue specification for reserving "
+                "specific queues. Can also be set with env var "
+                "CHPL_LAUNCHCMD_QUEUES"
+            ),
+        )
 
         args, unparsed_args = parser.parse_known_args()
 
         # Allow hostlist/queue to be set in environment variables.
         if args.hostlist is None:
-            args.hostlist = os.environ.get('CHPL_LAUNCHCMD_HOSTLIST') or None
+            args.hostlist = os.environ.get("CHPL_LAUNCHCMD_HOSTLIST") or None
         if args.queue is None:
-            args.queue = os.environ.get('CHPL_LAUNCHCMD_QUEUE') or None
+            args.queue = os.environ.get("CHPL_LAUNCHCMD_QUEUE") or None
 
         # It is bad form to use a two character argument with only a single
         # dash. Unfortunately, we support it. And unfortunately, python argparse
         # thinks --n is the same thing. So, we pull out --n above so we can put it
         # back in the unparsed args here.
         if args.n:
-            logging.debug('Found a --n arg. Putting it back in the unparsed args.')
-            unparsed_args.append('--n={0}'.format(args.n))
+            logging.debug(
+                "Found a --n arg. Putting it back in the unparsed args."
+            )
+            unparsed_args.append("--n={0}".format(args.n))
 
         return args, unparsed_args
 
@@ -723,25 +824,31 @@ class AbstractJob(object):
         if args is None:
             args = []
 
-        qstat_command = ['qstat'] + args + [job_id]
-        logging.debug('qstat command to run: {0}'.format(qstat_command))
+        qstat_command = ["qstat"] + args + [job_id]
+        logging.debug("qstat command to run: {0}".format(qstat_command))
 
-        logging.debug('Opening qstat subprocess.')
+        logging.debug("Opening qstat subprocess.")
         qstat_proc = py3_compat.Popen(
             qstat_command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            env=os.environ.copy()
+            env=os.environ.copy(),
         )
 
-        logging.debug('Communicating with qstat subprocess.')
+        logging.debug("Communicating with qstat subprocess.")
         stdout, stderr = qstat_proc.communicate()
-        logging.debug('qstat process returned with status {0}, stdout: {1}, and stderr: {2}'.format(
-            qstat_proc.returncode, stdout, stderr))
+        logging.debug(
+            "qstat process returned with status {0}, stdout: {1}, and stderr: {2}".format(
+                qstat_proc.returncode, stdout, stderr
+            )
+        )
 
         if qstat_proc.returncode != 0:
-            raise ValueError('Non-zero exit code {0} from qstat: "{1}"'.format(
-                qstat_proc.returncode, stdout))
+            raise ValueError(
+                'Non-zero exit code {0} from qstat: "{1}"'.format(
+                    qstat_proc.returncode, stdout
+                )
+            )
         else:
             return stdout
 
@@ -771,17 +878,19 @@ class AbstractJob(object):
         else:
             log_level = logging.WARN
         logging.basicConfig(
-            level=log_level, format='[%(module)s] %(asctime)s [%(levelname)s] %(msg)s')
-        logging.debug('Verbose logging enabled.')
+            level=log_level,
+            format="[%(module)s] %(asctime)s [%(levelname)s] %(msg)s",
+        )
+        logging.debug("Verbose logging enabled.")
 
 
 class MoabJob(AbstractJob):
     """Moab implementation of pbs job runner."""
 
-    submit_bin = 'qsub'
-    status_bin = 'qstat'
-    hostlist_resource = 'hostlist'
-    num_nodes_resource = 'nodes'
+    submit_bin = "qsub"
+    status_bin = "qstat"
+    hostlist_resource = "hostlist"
+    num_nodes_resource = "nodes"
     num_cpus_resource = None
     redirect_output = True
 
@@ -795,17 +904,19 @@ class MoabJob(AbstractJob):
         :rtype: str
         :returns: qsub job status
         """
-        output = cls._qstat(job_id, args=['-x'])
+        output = cls._qstat(job_id, args=["-x"])
         try:
             root = xml.etree.ElementTree.fromstring(output)
-            return root.find('Job').find('job_state').text
+            return root.find("Job").find("job_state").text
         except AttributeError as ex:
-            logging.exception('Could not find job_state element in xml output: {0}'.format(ex))
-            logging.error('XML output: {0}'.format(output))
+            logging.exception(
+                "Could not find job_state element in xml output: {0}".format(ex)
+            )
+            logging.error("XML output: {0}".format(output))
             raise
         except Exception as ex:
-            logging.exception('Failed to parse qstat output: {0}'.format(ex))
-            logging.error('XML output: {0}'.format(output))
+            logging.exception("Failed to parse qstat output: {0}".format(ex))
+            logging.error("XML output: {0}".format(output))
             raise
 
     def submit_job(self, testing_dir, output_file, error_file, input_file):
@@ -829,11 +940,11 @@ class MoabJob(AbstractJob):
 class PbsProJob(AbstractJob):
     """PBSPro implementation of pbs job runner."""
 
-    submit_bin = 'qsub'
-    status_bin = 'qstat'
-    hostlist_resource = 'mppnodes'
-    num_nodes_resource = 'mppwidth'
-    num_cpus_resource = 'ncpus'
+    submit_bin = "qsub"
+    status_bin = "qstat"
+    hostlist_resource = "mppnodes"
+    num_nodes_resource = "mppwidth"
+    num_cpus_resource = "ncpus"
     redirect_output = True
 
     @property
@@ -846,7 +957,7 @@ class PbsProJob(AbstractJob):
         """
         super_name = super(PbsProJob, self).job_name
         job_name = super_name[-15:]
-        logging.debug('PBSPro job name is: {0}'.format(job_name))
+        logging.debug("PBSPro job name is: {0}".format(job_name))
         return job_name
 
     @property
@@ -856,7 +967,7 @@ class PbsProJob(AbstractJob):
         :rtype: str
         :returns: select expression suffix, or empty string
         """
-        return ''
+        return ""
 
     @classmethod
     def status(cls, job_id):
@@ -880,23 +991,32 @@ class PbsProJob(AbstractJob):
         lines = output.splitlines()
 
         if len(lines) != 3:
-            logging.error('Unexpected number of lines in qstat output: {0}'.format(output))
-            raise ValueError('Expected 3 lines of qstat output, not {0}.'.format(len(output)))
+            logging.error(
+                "Unexpected number of lines in qstat output: {0}".format(output)
+            )
+            raise ValueError(
+                "Expected 3 lines of qstat output, not {0}.".format(len(output))
+            )
 
         header_line = lines[0]
         job_line = lines[-1]
 
         # Use regex to find position of status. Then extract the one character
         # status from the job line.
-        pattern = re.compile(r'\sS\s')
+        pattern = re.compile(r"\sS\s")
         match = pattern.search(header_line)
         if match is not None:
             status_char = match.start() + 1
             return job_line[status_char]
         else:
-            logging.error('Could not find S column in header line of qstat output.')
-            raise ValueError('Could not find {0} pattern in header line: {1}'.format(
-                pattern.pattern, header_line))
+            logging.error(
+                "Could not find S column in header line of qstat output."
+            )
+            raise ValueError(
+                "Could not find {0} pattern in header line: {1}".format(
+                    pattern.pattern, header_line
+                )
+            )
 
     def _qsub_command(self, output_file, error_file):
         """Returns qsub command list using select/place syntax for resource
@@ -916,7 +1036,7 @@ class PbsProJob(AbstractJob):
 
         # Always use place=scatter to get 1 PE per node (mostly). Equivalent
         # to mppnppn=1.
-        select_pattern = 'place=scatter,select={0}'
+        select_pattern = "place=scatter,select={0}"
 
         # When comm=none sub_test/start_test passes -nl -1 (i.e. num locales
         # is -1). For the tests to work, reserve one node and the regular
@@ -925,15 +1045,17 @@ class PbsProJob(AbstractJob):
         if num_nodes == -1:
             num_nodes = 1
 
-        loc_per_node = int(os.environ.get('CHPL_RT_LOCALES_PER_NODE', '1'))
+        loc_per_node = int(os.environ.get("CHPL_RT_LOCALES_PER_NODE", "1"))
 
         logging.debug("Locales per node: {}".format(loc_per_node))
-        if num_nodes%loc_per_node != 0:
-            raise RuntimeError('Requested number of locales ({}) is not '
-                               'divisible by CHPL_RT_LOCALES_PER_NODE '
-                               '({}).'.format(num_nodes, loc_per_node))
+        if num_nodes % loc_per_node != 0:
+            raise RuntimeError(
+                "Requested number of locales ({}) is not "
+                "divisible by CHPL_RT_LOCALES_PER_NODE "
+                "({}).".format(num_nodes, loc_per_node)
+            )
 
-        num_nodes = int(num_nodes/loc_per_node)
+        num_nodes = int(num_nodes / loc_per_node)
 
         if self.hostlist is not None:
             if loc_per_node != 1:
@@ -941,29 +1063,32 @@ class PbsProJob(AbstractJob):
                 # can't tell how to handle colocales here. So, for now, I am
                 # just adding a warning. If this path is needed, we can make
                 # adjustments here.
-                logging.warning('Hostlist and the CHPL_RT_LOCALES_PER_NODE '
-                                'environment are set. You may not get correct '
-                                'number of nodes allocated')
-                                
+                logging.warning(
+                    "Hostlist and the CHPL_RT_LOCALES_PER_NODE "
+                    "environment are set. You may not get correct "
+                    "number of nodes allocated"
+                )
+
             # This relies on the caller to use the correct select syntax.
             select_stmt = select_pattern.format(self.hostlist)
-            select_stmt = select_stmt.replace('<num_nodes>', str(num_nodes))
+            select_stmt = select_stmt.replace("<num_nodes>", str(num_nodes))
         elif num_nodes > 0:
             select_stmt = select_pattern.format(num_nodes)
 
             if self.num_cpus_resource is not None:
-                select_stmt += ':{0}={1}'.format(
-                    self.num_cpus_resource, self.num_cpus)
+                select_stmt += ":{0}={1}".format(
+                    self.num_cpus_resource, self.num_cpus
+                )
 
         if self.queue is not None:
-            submit_command.append('-q')
-            submit_command.append('{0}'.format(self.queue))
+            submit_command.append("-q")
+            submit_command.append("{0}".format(self.queue))
 
         if select_stmt is not None:
             select_stmt += self.select_suffix
-            submit_command += ['-l', select_stmt]
+            submit_command += ["-l", select_stmt]
 
-        logging.info('qsub command: "{0}"'.format(' '.join(submit_command)))
+        logging.info('qsub command: "{0}"'.format(" ".join(submit_command)))
         return submit_command
 
     def submit_job(self, testing_dir, output_file, error_file, input_file):
@@ -987,23 +1112,26 @@ class PbsProJob(AbstractJob):
 class MppPbsProJob(PbsProJob):
     """PBSPro implementation of pbs job runner that uses the mpp* options."""
 
-    submit_bin = 'qsub'
-    status_bin = 'qstat'
-    hostlist_resource = 'mppnodes'
-    num_nodes_resource = 'mppwidth'
-    num_cpus_resource = 'mppdepth' if 'CHPL_PBSPRO_NO_MPPDEPTH' not in os.environ else None
-    processing_elems_per_node_resource = 'mppnppn'
+    submit_bin = "qsub"
+    status_bin = "qstat"
+    hostlist_resource = "mppnodes"
+    num_nodes_resource = "mppwidth"
+    num_cpus_resource = (
+        "mppdepth" if "CHPL_PBSPRO_NO_MPPDEPTH" not in os.environ else None
+    )
+    processing_elems_per_node_resource = "mppnppn"
     redirect_output = False
 
     def _qsub_command(self, output_file, error_file):
         return AbstractJob._qsub_command(self, output_file, error_file)
 
+
 class SlurmJob(AbstractJob):
     """SLURM implementation of abstract job runner."""
 
     submit_bin = None
-    status_bin = 'squeue'
-    hostlist_resource = 'nodelist'
+    status_bin = "squeue"
+    hostlist_resource = "nodelist"
     num_nodes_resource = None
     num_cpus_resource = None
 
@@ -1018,53 +1146,70 @@ class SlurmJob(AbstractJob):
         :returns: squeue job status
         """
         squeue_command = [
-            'squeue',
-            '--noheader',
-            '--format', '%A %T',  # "<job_id> <status>"
-            '--states', 'all',
-            '--job', job_id,
+            "squeue",
+            "--noheader",
+            "--format",
+            "%A %T",  # "<job_id> <status>"
+            "--states",
+            "all",
+            "--job",
+            job_id,
         ]
-        logging.debug('squeue command to run: {0}'.format(squeue_command))
+        logging.debug("squeue command to run: {0}".format(squeue_command))
 
-        logging.debug('Opening squeue subprocess.')
+        logging.debug("Opening squeue subprocess.")
         squeue_proc = py3_compat.Popen(
             squeue_command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            env=os.environ.copy()
+            env=os.environ.copy(),
         )
 
-        logging.debug('Communicating with squeue subprocess.')
+        logging.debug("Communicating with squeue subprocess.")
         stdout, stderr = squeue_proc.communicate()
-        logging.debug('squeue process returned with status {0}, stdout: {1}, stderr: {2}'.format(
-            squeue_proc.returncode, stdout, stderr))
+        logging.debug(
+            "squeue process returned with status {0}, stdout: {1}, stderr: {2}".format(
+                squeue_proc.returncode, stdout, stderr
+            )
+        )
 
         if squeue_proc.returncode != 0:
-            raise ValueError('Non-zero exit code {0} from squeue: "{1}"'.format(
-                squeue_proc.returncode, stdout))
+            raise ValueError(
+                'Non-zero exit code {0} from squeue: "{1}"'.format(
+                    squeue_proc.returncode, stdout
+                )
+            )
 
-        failure_statuses = ['CANCELLED', 'FAILED', 'TIMEOUT',
-                            'BOOT_FAIL', 'NODE_FAIL', 'PREEMPTED']
+        failure_statuses = [
+            "CANCELLED",
+            "FAILED",
+            "TIMEOUT",
+            "BOOT_FAIL",
+            "NODE_FAIL",
+            "PREEMPTED",
+        ]
 
-        queued_statuses = ['CONFIGURING', 'PENDING']
+        queued_statuses = ["CONFIGURING", "PENDING"]
 
-        status_parts = stdout.split(' ')
+        status_parts = stdout.split(" ")
         if len(status_parts) == 2:
             status = status_parts[1].strip()
-            logging.info('Status for job {0} is: {1}'.format(job_id, status))
+            logging.info("Status for job {0} is: {1}".format(job_id, status))
 
-            if status == 'COMPLETED':
-                logging.info('Job finished with status: {0}'.format(status))
-                return 'C'
+            if status == "COMPLETED":
+                logging.info("Job finished with status: {0}".format(status))
+                return "C"
             elif status in failure_statuses:
-                logging.info('Job finished with status: {0}'.format(status))
-                return 'C'
+                logging.info("Job finished with status: {0}".format(status))
+                return "C"
             elif status in queued_statuses:
-                return 'Q'
+                return "Q"
             else:
-                return 'R'  # running
+                return "R"  # running
         else:
-            raise ValueError('Could not parse output from squeue: {0}'.format(stdout))
+            raise ValueError(
+                "Could not parse output from squeue: {0}".format(stdout)
+            )
 
     def submit_job(self, testing_dir, output_file, error_file, input_file):
         """Launch job using executable. Set CHPL_LAUNCHER_USE_SBATCH=true in
@@ -1085,70 +1230,90 @@ class SlurmJob(AbstractJob):
         :returns: job id
         """
         env = os.environ.copy()
-        env['CHPL_LAUNCHER_USE_SBATCH'] = 'true'
-        env['CHPL_LAUNCHER_SLURM_OUTPUT_FILENAME'] = output_file
-        env['CHPL_LAUNCHER_SLURM_ERROR_FILENAME'] = error_file
+        env["CHPL_LAUNCHER_USE_SBATCH"] = "true"
+        env["CHPL_LAUNCHER_SLURM_OUTPUT_FILENAME"] = output_file
+        env["CHPL_LAUNCHER_SLURM_ERROR_FILENAME"] = error_file
 
-        if select.select([sys.stdin,],[],[],0.0)[0]: 
-            with open(input_file, 'w') as fp:
+        if select.select(
+            [
+                sys.stdin,
+            ],
+            [],
+            [],
+            0.0,
+        )[0]:
+            with open(input_file, "w") as fp:
                 fp.write(sys.stdin.read())
-            env['SLURM_STDINMODE'] = input_file
+            env["SLURM_STDINMODE"] = input_file
 
         # We could use stdout buffering for other configurations too, but I
         # don't think there's any need. Currently, single locale perf testing
         # is the only config that has any tests that produce a lot of output
-        if os.getenv('CHPL_TEST_PERF') != None and self.num_locales <= 1:
-            env['CHPL_LAUNCHER_SLURM_BUFFER_STDOUT'] = 'true'
+        if os.getenv("CHPL_TEST_PERF") != None and self.num_locales <= 1:
+            env["CHPL_LAUNCHER_SLURM_BUFFER_STDOUT"] = "true"
 
         cmd = self.test_command[:]
         # Add --nodelist into the command line
         if self.hostlist is not None:
-            cmd.append('--{0}={1}'.format(
-                self.hostlist_resource, self.hostlist))
+            cmd.append(
+                "--{0}={1}".format(self.hostlist_resource, self.hostlist)
+            )
 
         # Add --walltime back into the command line.
         if self.walltime is not None:
-            cmd.append('--walltime')
+            cmd.append("--walltime")
             cmd.append(self.walltime)
 
-        logging.debug('Command to submit job: {0}'.format(cmd))
+        logging.debug("Command to submit job: {0}".format(cmd))
 
-        logging.debug('Opening job subprocess')
+        logging.debug("Opening job subprocess")
         submit_proc = py3_compat.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=testing_dir,
-            env=env
+            env=env,
         )
 
-        logging.debug('Communicating with job subprocess')
+        logging.debug("Communicating with job subprocess")
         stdout, stderr = submit_proc.communicate()
-        logging.debug('Job process returned with status {0}, stdout: {1}, stderr: {2}'.format(
-            submit_proc.returncode, stdout, stderr))
+        logging.debug(
+            "Job process returned with status {0}, stdout: {1}, stderr: {2}".format(
+                submit_proc.returncode, stdout, stderr
+            )
+        )
 
         if submit_proc.returncode != 0:
-            msg = 'Job submission ({0}) failed with exit code {1} and output: {2}'.format(
-                cmd, submit_proc.returncode, stdout)
+            msg = "Job submission ({0}) failed with exit code {1} and output: {2}".format(
+                cmd, submit_proc.returncode, stdout
+            )
             logging.error(msg)
             raise ValueError(msg)
 
         # The output line we want is: Submitted batch job 106001
-        lines = stdout.split('\n')
+        lines = stdout.split("\n")
         for line in lines:
-            if line.startswith('Submitted batch job'):
-                id_parts = line.split(' ')
+            if line.startswith("Submitted batch job"):
+                id_parts = line.split(" ")
                 if len(id_parts) < 4:
-                    raise ValueError('Could not parse output from sbatch submission: {0}'.format(stdout))
+                    raise ValueError(
+                        "Could not parse output from sbatch submission: {0}".format(
+                            stdout
+                        )
+                    )
                 else:
                     job_id = id_parts[3].strip()
                     return job_id
 
-        raise ValueError('Did not see expected output from sbatch submission: {0}'.format(stdout))
+        raise ValueError(
+            "Did not see expected output from sbatch submission: {0}".format(
+                stdout
+            )
+        )
 
 
 @contextlib.contextmanager
-def _temp_dir(dir_prefix='chapel-test-tmp'):
+def _temp_dir(dir_prefix="chapel-test-tmp"):
     """Context manager that creates a temporary directory in the current working
     directory with name of dir_prefix. When the manager exits, the directory is
     deleted.
@@ -1158,15 +1323,19 @@ def _temp_dir(dir_prefix='chapel-test-tmp'):
     """
     try:
         cwd = os.getcwd()
-        logging.debug('Creating temporary working directory in: {0}'.format(cwd))
+        logging.debug(
+            "Creating temporary working directory in: {0}".format(cwd)
+        )
         tmp_dir = tempfile.mkdtemp(prefix=dir_prefix, dir=cwd)
 
-        logging.debug('Yielding temporary directory context manager.')
+        logging.debug("Yielding temporary directory context manager.")
         yield tmp_dir
     finally:
-        logging.debug('Deleting temporary working directory at: {0}'.format(tmp_dir))
+        logging.debug(
+            "Deleting temporary working directory at: {0}".format(tmp_dir)
+        )
         shutil.rmtree(tmp_dir)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/util/test/convert_nightly_system_command_log_to_junit_xml.py
+++ b/util/test/convert_nightly_system_command_log_to_junit_xml.py
@@ -4,42 +4,50 @@
 import argparse
 import xml.etree.ElementTree as XML
 
-parser = argparse.ArgumentParser(description='Convert nightly system command logs to JUnit XML.')
-parser.add_argument('cleanlog', type=str, help='Log listing all commands that were executed')
-parser.add_argument('errorlog', type=str, help='Log listing errors in commands that were executed')
-parser.add_argument('output', type=str, help='Output JUnit XML file')
+parser = argparse.ArgumentParser(
+    description="Convert nightly system command logs to JUnit XML."
+)
+parser.add_argument(
+    "cleanlog", type=str, help="Log listing all commands that were executed"
+)
+parser.add_argument(
+    "errorlog",
+    type=str,
+    help="Log listing errors in commands that were executed",
+)
+parser.add_argument("output", type=str, help="Output JUnit XML file")
 
 args = parser.parse_args()
 
-with open(args.cleanlog, 'r') as f:
+with open(args.cleanlog, "r") as f:
     cleanlog = f.readlines()
 
-with open(args.errorlog, 'r') as f:
+with open(args.errorlog, "r") as f:
     errorlog = f.readlines()
 
-test_suites = XML.Element('testsuites')
-test_suite = XML.SubElement(test_suites, 'testsuite')
+test_suites = XML.Element("testsuites")
+test_suite = XML.SubElement(test_suites, "testsuite")
 
 # Error lines are empty when no error occurred.
 num_errors = 0
-for (cleanline, errline) in zip(cleanlog, errorlog):
+for cleanline, errline in zip(cleanlog, errorlog):
     cleanline = cleanline.strip()
     errline = errline.strip()
 
-    test_case = XML.SubElement(test_suite, 'testcase')
-    test_case.set('name', cleanline)
-    test_case.set('classname', 'nightly system command')
-    test_case.set('time', '0')
+    test_case = XML.SubElement(test_suite, "testcase")
+    test_case.set("name", cleanline)
+    test_case.set("classname", "nightly system command")
+    test_case.set("time", "0")
 
     if errline:
-        failure = XML.SubElement(test_case, 'failure')
-        failure.set('message', errline)
+        failure = XML.SubElement(test_case, "failure")
+        failure.set("message", errline)
         num_errors += 1
 
-test_suite.set('name', 'nightly system commands')
-test_suite.set('errors', str(num_errors))
-test_suite.set('failures', str(num_errors))
-test_suite.set('tests', str(len(cleanlog)))
+test_suite.set("name", "nightly system commands")
+test_suite.set("errors", str(num_errors))
+test_suite.set("failures", str(num_errors))
+test_suite.set("tests", str(len(cleanlog)))
 
 tree = XML.ElementTree(test_suites)
 tree.write(args.output)

--- a/util/test/convert_start_test_log_to_junit_xml.py
+++ b/util/test/convert_start_test_log_to_junit_xml.py
@@ -14,11 +14,10 @@ import sys
 import xml.etree.ElementTree as XML
 
 # Add the chplenv dir to the python path.
-chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
+chplenv_dir = os.path.join(os.path.dirname(__file__), "..", "chplenv")
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_platform
-
 
 DEBUG = False
 
@@ -37,8 +36,9 @@ SKIP_MARKERS = (
     "[Skipping interpretation of",
 )
 
-SUBTEST_STARTS = ('[Starting subtest - ', '[Error running sub_test')
-SUBTEST_ENDS = ('[Finished subtest ', '[Error running sub_test')
+SUBTEST_STARTS = ("[Starting subtest - ", "[Error running sub_test")
+SUBTEST_ENDS = ("[Finished subtest ", "[Error running sub_test")
+
 
 def main():
     """Parse cli arguments and convert a start_test log file to jUnit xml
@@ -65,41 +65,41 @@ def _create_junit_report(test_cases, junit_file):
     :type junit_file: str
     :arg junit_file: filename to write the jUnit XML report
     """
-    logging.debug('Creating jUnit XML report at: {0}'.format(junit_file))
-    test_suites = XML.Element('testsuites')
-    test_suite = XML.SubElement(test_suites, 'testsuite')
+    logging.debug("Creating jUnit XML report at: {0}".format(junit_file))
+    test_suites = XML.Element("testsuites")
+    test_suite = XML.SubElement(test_suites, "testsuite")
     num_errors = 0
 
     for test_case in test_cases:
-        case_elem = XML.SubElement(test_suite, 'testcase')
-        case_elem.set('name', test_case['name'])
-        case_elem.set('classname', test_case['classname'])
-        case_elem.set('time', str(test_case['time']))
+        case_elem = XML.SubElement(test_suite, "testcase")
+        case_elem.set("name", test_case["name"])
+        case_elem.set("classname", test_case["classname"])
+        case_elem.set("time", str(test_case["time"]))
 
-        test_error = test_case['error']
+        test_error = test_case["error"]
 
-        if test_case['skipped']:
-            skip_elem = XML.SubElement(case_elem, 'skipped')
+        if test_case["skipped"]:
+            skip_elem = XML.SubElement(case_elem, "skipped")
         elif test_error is not None:
-            error_elem = XML.SubElement(case_elem, 'error')
-            error_elem.set('message', test_error['message'])
-            error_elem.text = test_error['content']
+            error_elem = XML.SubElement(case_elem, "error")
+            error_elem.set("message", test_error["message"])
+            error_elem.text = test_error["content"]
             num_errors += 1
 
-        system_out = XML.SubElement(case_elem, 'system-out')
-        system_out.text = test_case['system-out']
+        system_out = XML.SubElement(case_elem, "system-out")
+        system_out.text = test_case["system-out"]
 
-    test_suite.set('errors', str(num_errors))
-    test_suite.set('failures', str(num_errors))
-    test_suite.set('tests', str(len(test_cases)))
-    test_suite.set('name', 'start_test results')
+    test_suite.set("errors", str(num_errors))
+    test_suite.set("failures", str(num_errors))
+    test_suite.set("tests", str(len(test_cases)))
+    test_suite.set("name", "start_test results")
 
     encoding = "unicode" if sys.version_info[0] >= 3 else "us-ascii"
     xml_content = XML.tostring(test_suites, encoding=encoding)
     xml_content = _clean_xml(xml_content)
-    with open(junit_file, 'w') as fp:
+    with open(junit_file, "w") as fp:
         fp.write(xml_content)
-    logging.info('Wrote jUnit report to: {0}'.format(junit_file))
+    logging.info("Wrote jUnit report to: {0}".format(junit_file))
 
 
 def _parse_start_test_log(start_test_log):
@@ -111,11 +111,14 @@ def _parse_start_test_log(start_test_log):
     :rtype: list of dicts
     :returns: list of dicts; each dict contains info about a single test case
     """
-    logging.debug('Parsing start_test log: {0}'.format(start_test_log))
-    with open(start_test_log, 'r', encoding='utf-8', errors='ignore') as fp:
+    logging.debug("Parsing start_test log: {0}".format(start_test_log))
+    with open(start_test_log, "r", encoding="utf-8", errors="ignore") as fp:
         start_test_lines = fp.readlines()
-    logging.debug('Read {0} lines from "{1}".'.format(
-        len(start_test_lines), start_test_log))
+    logging.debug(
+        'Read {0} lines from "{1}".'.format(
+            len(start_test_lines), start_test_log
+        )
+    )
 
     # In order to catch all test results we can despite sub_test failures,
     # the code below deliberately accepts empty or non-empty "Error running sub_test"
@@ -126,7 +129,8 @@ def _parse_start_test_log(start_test_log):
     test_cases = []
     while len(start_test_lines) > 0:
         subtest_start, subtest_end = _get_block(
-            start_test_lines, SUBTEST_STARTS, SUBTEST_ENDS)
+            start_test_lines, SUBTEST_STARTS, SUBTEST_ENDS
+        )
 
         # No more sub_tests; delete the remaining lines and finish up.
         if subtest_start == -1:
@@ -135,13 +139,16 @@ def _parse_start_test_log(start_test_log):
 
         # Copy subtest lines into new list for further processing and delete
         # them from start_test_lines.
-        sub_test_lines = start_test_lines[subtest_start:subtest_end+1:1]
-        del start_test_lines[:subtest_end+1]
+        sub_test_lines = start_test_lines[subtest_start : subtest_end + 1 : 1]
+        del start_test_lines[: subtest_end + 1]
 
         subtest_error = None
         subtest_file = None
-        if sub_test_lines[-1].startswith('[Error running sub_test'):
-            match = re.match(r'\[Error running sub_test \(code [\d]+\) (?:in|for) (.*)\]', sub_test_lines[-1])
+        if sub_test_lines[-1].startswith("[Error running sub_test"):
+            match = re.match(
+                r"\[Error running sub_test \(code [\d]+\) (?:in|for) (.*)\]",
+                sub_test_lines[-1],
+            )
             if match and match.group(1) not in seen_sub_test_failures:
                 subtest_error = sub_test_lines[-1]
                 subtest_file = match.group(1)
@@ -151,41 +158,44 @@ def _parse_start_test_log(start_test_log):
         while len(sub_test_lines) > 0:
             test_start, test_end = _get_block(
                 sub_test_lines,
-                '[test: ',
-                '[Elapsed time to compile and execute all versions of "')
+                "[test: ",
+                '[Elapsed time to compile and execute all versions of "',
+            )
             test_start_skip, test_end_skip = _get_block(
-                sub_test_lines,
-                '[test: ',
-                SKIP_MARKERS)
+                sub_test_lines, "[test: ", SKIP_MARKERS
+            )
 
             test_skipped = False
-            if test_end_skip != -1 and (test_end == -1 or test_end_skip < test_end):
+            if test_end_skip != -1 and (
+                test_end == -1 or test_end_skip < test_end
+            ):
                 test_start, test_end = test_start_skip, test_end_skip
                 test_skipped = True
 
                 noperf_start, noperf_end = _get_block(
-                    sub_test_lines,
-                    '[test: ',
-                    '[Skipping noperf test:')
+                    sub_test_lines, "[test: ", "[Skipping noperf test:"
+                )
 
                 # If the test was skipped because it did not have performance
                 # configuration files, drop the lines and continue. We don't
                 # care about these for performance tests (as opposed to real
                 # perf tests that are skipped due to environment/etc).
                 if noperf_end != -1:
-                    del sub_test_lines[noperf_start:noperf_end+1]
+                    del sub_test_lines[noperf_start : noperf_end + 1]
                     continue
 
             # If test_end is still -1 (i.e. not found), look for end of subtest
             # call (usually means subtest failed and did not tests).
             if test_start != -1 and test_end == -1:
                 test_start, test_end = _get_block(
-                    sub_test_lines,
-                    '[test: ',
-                    '[Finished subtest "')
+                    sub_test_lines, "[test: ", '[Finished subtest "'
+                )
                 if test_end == -1:
-                    raise ValueError('Failed to parse test case from: {0}'.format(
-                        sub_test_lines))
+                    raise ValueError(
+                        "Failed to parse test case from: {0}".format(
+                            sub_test_lines
+                        )
+                    )
 
             # No more test cases; delete remaining lines and finish up.
             if test_start == -1:
@@ -195,8 +205,8 @@ def _parse_start_test_log(start_test_log):
 
             # Copy test lines into new list for further processing and delete
             # from sub_test_lines.
-            test_case_lines = sub_test_lines[test_start:test_end+1:1]
-            del sub_test_lines[:test_end+1]
+            test_case_lines = sub_test_lines[test_start : test_end + 1 : 1]
+            del sub_test_lines[: test_end + 1]
 
             # Extract test name from "[test: <path to .chpl file>]" line.
             classname, test_name = _get_test_name(test_case_lines)
@@ -206,15 +216,15 @@ def _parse_start_test_log(start_test_log):
             else:
                 test_time = _get_test_time(test_case_lines)
                 error = _get_test_error(test_case_lines)
-            test_content = ''.join(test_case_lines)
+            test_content = "".join(test_case_lines)
 
             test_case = {
-                'name': test_name,
-                'classname': classname,
-                'time': test_time,
-                'error': error,
-                'skipped': test_skipped,
-                'system-out': test_content,
+                "name": test_name,
+                "classname": classname,
+                "time": test_time,
+                "error": error,
+                "skipped": test_skipped,
+                "system-out": test_content,
             }
 
             test_cases.append(test_case)
@@ -223,17 +233,23 @@ def _parse_start_test_log(start_test_log):
         # subtest as output from a "test" that failed to run (the subtest itself).
         if subtest_error is not None:
             test_case = {
-                'name': 'subtest script',
-                'classname': subtest_file,
-                'time': 0.0,
-                'error': {'message': 'Error running subtest script', 'content': subtest_error},
-                'skipped': False,
-                'system-out': "\n".join(lines_after_no_more_tests),
+                "name": "subtest script",
+                "classname": subtest_file,
+                "time": 0.0,
+                "error": {
+                    "message": "Error running subtest script",
+                    "content": subtest_error,
+                },
+                "skipped": False,
+                "system-out": "\n".join(lines_after_no_more_tests),
             }
             test_cases.append(test_case)
 
-    logging.info('Parsed {0} test cases from "{1}".'.format(
-        len(test_cases), start_test_log))
+    logging.info(
+        'Parsed {0} test cases from "{1}".'.format(
+            len(test_cases), start_test_log
+        )
+    )
     return test_cases
 
 
@@ -252,11 +268,15 @@ def _remove_prefixes(test_cases, prefix):
     if prefix is None:
         return
 
-    logging.debug('Removing prefix "{0}" from {1} test cases.'.format(
-        prefix, len(test_cases)))
+    logging.debug(
+        'Removing prefix "{0}" from {1} test cases.'.format(
+            prefix, len(test_cases)
+        )
+    )
 
     # Remove the prefix, including a trailing slash.
-    prefix_len = len(prefix.rstrip('/')) + 1
+    prefix_len = len(prefix.rstrip("/")) + 1
+
     def remove_prefix(class_name):
         if class_name.startswith(prefix):
             return class_name[prefix_len:]
@@ -264,9 +284,9 @@ def _remove_prefixes(test_cases, prefix):
             return class_name
 
     for i, test_case in enumerate(test_cases):
-        classname = test_case['classname']
+        classname = test_case["classname"]
         updated_classname = remove_prefix(classname)
-        test_cases[i]['classname'] = updated_classname
+        test_cases[i]["classname"] = updated_classname
 
 
 def _find_line(lines, prefix):
@@ -322,13 +342,16 @@ def _get_test_name(test_case_lines):
     :rtype: (str, str)
     :returns: tuple with classname and test name
     """
-    pattern = re.compile(r'\[test: (?P<test_name>[^\]]+)\]')
+    pattern = re.compile(r"\[test: (?P<test_name>[^\]]+)\]")
     match = pattern.search(test_case_lines[0])
     if match is None:
-        raise ValueError('Could not find test name in: {0}'.format(
-            test_case_lines[0].strip()))
+        raise ValueError(
+            "Could not find test name in: {0}".format(
+                test_case_lines[0].strip()
+            )
+        )
 
-    test_file = match.group('test_name')
+    test_file = match.group("test_name")
     classname = os.path.dirname(test_file)
     base_file = os.path.basename(test_file)
     test_name, _ = os.path.splitext(base_file)
@@ -336,7 +359,6 @@ def _get_test_name(test_case_lines):
 
 
 def _get_test_time(test_case_lines):
-
     """Return the total compile and execution time in seconds for single test
     case. Finds the "[Elapsed time to compile and execute all versions of ..." line
     and extracts the time from it.
@@ -349,26 +371,26 @@ def _get_test_time(test_case_lines):
     """
     time_line_idx = _find_line(
         test_case_lines,
-        '[Elapsed time to compile and execute all versions of "')
+        '[Elapsed time to compile and execute all versions of "',
+    )
     if time_line_idx == -1:
-        msg = 'Could not find elapsed time line in: {0}'.format(
-            test_case_lines)
+        msg = "Could not find elapsed time line in: {0}".format(test_case_lines)
         logging.warning(msg)
         if DEBUG:
             raise ValueError(msg)
     time_line = test_case_lines[time_line_idx]
 
-    pattern = re.compile(r' - (?P<time>-?\d+\.\d+) seconds\]$')
+    pattern = re.compile(r" - (?P<time>-?\d+\.\d+) seconds\]$")
     match = pattern.search(time_line)
     if match:
-        time = match.group('time')
+        time = match.group("time")
     else:
-        time = '0.0'
-        msg = 'Could not find time in: {0}'.format(time_line)
+        time = "0.0"
+        msg = "Could not find time in: {0}".format(time_line)
         logging.warning(msg)
         if DEBUG:
             raise ValueError(msg)
-    return max(float(time),0.0)
+    return max(float(time), 0.0)
 
 
 def _get_test_error(test_case_lines):
@@ -381,10 +403,10 @@ def _get_test_error(test_case_lines):
     :rtype: dict
     :returns: error dict with 'message' and 'content' keys, None if no errors
     """
-    error_pattern = re.compile(r'^\[Error.*$', re.IGNORECASE | re.MULTILINE)
-    warn_pattern = re.compile(r'^\[Warning.*$', re.IGNORECASE | re.MULTILINE)
+    error_pattern = re.compile(r"^\[Error.*$", re.IGNORECASE | re.MULTILINE)
+    warn_pattern = re.compile(r"^\[Warning.*$", re.IGNORECASE | re.MULTILINE)
 
-    whole_test = ''.join(test_case_lines)
+    whole_test = "".join(test_case_lines)
     errors = error_pattern.findall(whole_test)
     warnings = warn_pattern.findall(whole_test)
 
@@ -395,14 +417,14 @@ def _get_test_error(test_case_lines):
     # Use the first error or warning line as the message. The full test output
     # will be included in system-out.
     if errors:
-        message = errors[0].strip().strip('[]')
+        message = errors[0].strip().strip("[]")
     else:
-        message = warnings[0].strip().strip('[]')
-    content = '\n'.join(errors) + '\n'.join(warnings)
+        message = warnings[0].strip().strip("[]")
+    content = "\n".join(errors) + "\n".join(warnings)
 
     return {
-        'message': message,
-        'content': content,
+        "message": message,
+        "content": content,
     }
 
 
@@ -415,52 +437,72 @@ def _clean_xml(xml_string):
     :rtype: str
     :returns: valid XML string
     """
-    invalid_chars = re.compile(r'[\000-\010\013\014\016-\037]')
-    return invalid_chars.sub('?', xml_string)
+    invalid_chars = re.compile(r"[\000-\010\013\014\016-\037]")
+    return invalid_chars.sub("?", xml_string)
 
 
 def _parse_args():
     """Parse and return cli arguments."""
     parser = optparse.OptionParser(
-        usage='usage: %prog [options] args',
-        description=__doc__)
-    parser.add_option('-v', '--verbose', action='store_true',
-                      help='Enable verbose output. (default: %default)')
-    parser.add_option('-l', '--start-test-log',
-                      default=_start_test_default_log(),
-                      help='start_test log file. (default: %default)')
-    parser.add_option('-o', '--junit-xml', default=_junit_xml_default(),
-                      help='jUnit XML output file. (default: %default)')
-    parser.add_option('-p', '--remove-prefix',
-                      help=('Remove this prefix from all tests '
-                            '(default: %default)'))
-    parser.add_option('--debug', action='store_true',
-                      help=('Throw exceptions when invalid data is '
-                            'encountered. (default: %default)'))
+        usage="usage: %prog [options] args", description=__doc__
+    )
+    parser.add_option(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output. (default: %default)",
+    )
+    parser.add_option(
+        "-l",
+        "--start-test-log",
+        default=_start_test_default_log(),
+        help="start_test log file. (default: %default)",
+    )
+    parser.add_option(
+        "-o",
+        "--junit-xml",
+        default=_junit_xml_default(),
+        help="jUnit XML output file. (default: %default)",
+    )
+    parser.add_option(
+        "-p",
+        "--remove-prefix",
+        help=("Remove this prefix from all tests " "(default: %default)"),
+    )
+    parser.add_option(
+        "--debug",
+        action="store_true",
+        help=(
+            "Throw exceptions when invalid data is "
+            "encountered. (default: %default)"
+        ),
+    )
     opts, _ = parser.parse_args()
     return opts
 
 
 def _chpl_home():
     """Calculate and return $CHPL_HOME defaulting to root of repo/install."""
-    repo_root = os.path.abspath(os.path.join(
-        os.path.dirname(__file__), '../..'))
-    return os.environ.get('CHPL_HOME', repo_root)
+    repo_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../..")
+    )
+    return os.environ.get("CHPL_HOME", repo_root)
 
 
 def _start_test_default_log():
     """Calculate default Logs/ dir (just like start_test)."""
-    test_dir = os.path.join(_chpl_home(), 'test')
-    logs_dir = os.path.join(test_dir, 'Logs')
-    log_filename = '{user}.{target_platform}.log'.format(
-        user=getpass.getuser(), target_platform=chpl_platform.get('target'))
+    test_dir = os.path.join(_chpl_home(), "test")
+    logs_dir = os.path.join(test_dir, "Logs")
+    log_filename = "{user}.{target_platform}.log".format(
+        user=getpass.getuser(), target_platform=chpl_platform.get("target")
+    )
     log_file = os.path.join(logs_dir, log_filename)
     return log_file
 
 
 def _junit_xml_default():
     """Calculate default jUnit XML output file as $CHPL_HOME/chapel-tests.xml."""
-    return os.path.join(_chpl_home(), 'chapel-tests.xml')
+    return os.path.join(_chpl_home(), "chapel-tests.xml")
 
 
 def _setup_logging(verbose):
@@ -470,10 +512,11 @@ def _setup_logging(verbose):
     :arg verbose: When True, set log level to DEBUG.
     """
     log_level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s',
-                        level=log_level)
-    logging.debug('Verbose output enabled.')
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)s] %(message)s", level=log_level
+    )
+    logging.debug("Verbose output enabled.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/util/test/execution_limiter.py
+++ b/util/test/execution_limiter.py
@@ -1,5 +1,5 @@
-""" Execution limiter implementations to help limit the number of concurrently
-running chpl executables """
+"""Execution limiter implementations to help limit the number of concurrently
+running chpl executables"""
 
 import getpass
 import os
@@ -10,43 +10,49 @@ import py3_compat
 try:
     import filelock
 except ImportError:
-    sys.stdout.write('[Warning: {0}]\n'.format("could not import filelock"))
+    sys.stdout.write("[Warning: {0}]\n".format("could not import filelock"))
     pass
 
-class NoLock():
-    """ Empty class that can be used with a context manager. Does not limit how
-        many executables can run at once. """
+
+class NoLock:
+    """Empty class that can be used with a context manager. Does not limit how
+    many executables can run at once."""
+
     def __enter__(self):
         pass
+
     def __exit__(self, exc_type, exc_value, traceback):
         pass
 
 
-class FileLock():
-    """ Simple wrapper over filelock that will only let one executable run per
-        user, per machine.
+class FileLock:
+    """Simple wrapper over filelock that will only let one executable run per
+    user, per machine.
 
-        filelock is a platform independent lock that uses 1 of 3 platform
-        dependent implementations. It will use `fcntl.flock` on unix systems
-        (including mac and cygwin) to create a hard lock, `msvcrt.locking` on
-        windows systems, and a soft file-based lock otherwise. fcntl and msvcrt
-        don't have issues with 'stale' locks because the lock is held on the
-        file descriptor and gets dropped by the OS even if the program crashes.
-        The soft file-based lock can cause stale locks, so if we ever run into
-        a platform where fcntl/msvcrt aren't supported we should re-add our own
-        implementation that can deal with stale lock files.
+    filelock is a platform independent lock that uses 1 of 3 platform
+    dependent implementations. It will use `fcntl.flock` on unix systems
+    (including mac and cygwin) to create a hard lock, `msvcrt.locking` on
+    windows systems, and a soft file-based lock otherwise. fcntl and msvcrt
+    don't have issues with 'stale' locks because the lock is held on the
+    file descriptor and gets dropped by the OS even if the program crashes.
+    The soft file-based lock can cause stale locks, so if we ever run into
+    a platform where fcntl/msvcrt aren't supported we should re-add our own
+    implementation that can deal with stale lock files.
 
-        Also note that fcntl/msvcrt will leave the actual file used for locking
-        around. Removing the file would "unlock" the lock, so there'd be a race
-        between unlocking/removing and locking (we'd effectively have a double
-        unlock). This is a common problem for file-based locks including
-        "fasteners" (https://github.com/harlowja/fasteners/issues/26) """
-    lock_file = ''
+    Also note that fcntl/msvcrt will leave the actual file used for locking
+    around. Removing the file would "unlock" the lock, so there'd be a race
+    between unlocking/removing and locking (we'd effectively have a double
+    unlock). This is a common problem for file-based locks including
+    "fasteners" (https://github.com/harlowja/fasteners/issues/26)"""
+
+    lock_file = ""
     lock = None
 
     def __init__(self):
-        lock_name = '{0}-chpl_program_executing'.format(getpass.getuser())
-        lock_dir = os.getenv('CHPL_TEST_LIMIT_RUNNING_EXECUTABLES_DIR', tempfile.gettempdir())
+        lock_name = "{0}-chpl_program_executing".format(getpass.getuser())
+        lock_dir = os.getenv(
+            "CHPL_TEST_LIMIT_RUNNING_EXECUTABLES_DIR", tempfile.gettempdir()
+        )
         py3_compat.makedirs(lock_dir, exist_ok=True)
 
         self.lock_file = os.path.join(lock_dir, lock_name)

--- a/util/test/fileReadHelp.py
+++ b/util/test/fileReadHelp.py
@@ -3,28 +3,30 @@
 # Utility routines to help with reading files
 #
 def IsCommentOrBlank(line):
-    l=line.strip()
-    if l == '':
+    l = line.strip()
+    if l == "":
         return True
-    if l[0] == '#':
+    if l[0] == "#":
         return True
     return False
+
 
 # Ignore blank lines and commented line
 # Strip trailing white space and new line
 def ReadNextNonCommentLine(f):
     l = f.readline()
-    if l == '':
+    if l == "":
         return None
     while IsCommentOrBlank(l):
         l = f.readline()
-        if l == '':
+        if l == "":
             return None
     return l.rstrip()
 
+
 def ReadFileWithComments(filename):
     try:
-        f= open(filename, 'r')
+        f = open(filename, "r")
     except IOError:
         return None
 

--- a/util/test/find_slow_tests.py
+++ b/util/test/find_slow_tests.py
@@ -1,47 +1,69 @@
 #!/usr/bin/env python3
 
-'''
+"""
 Report or reason about chpl test (compilation, execution, directory) times.
-'''
+"""
 
 import re
 import argparse
 
-def create_parser():
-    ''' Create argument parser '''
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--timefile', help='file with test/dir timings', required=True)
-    parser.add_argument('-n', type=int, default=10, help='number of tests/dirs to report')
-    parser.add_argument('--sort-list', nargs='+', help='sort list of tests/dirs based on times from timefile')
 
-    parser.set_defaults(mode='execution')
-    parser.add_argument('--compilation', action='store_const', dest='mode', const='compilation')
-    parser.add_argument('--execution',   action='store_const', dest='mode', const='execution')
-    parser.add_argument('--directory',   action='store_const', dest='mode', const='directory')
+def create_parser():
+    """Create argument parser"""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--timefile", help="file with test/dir timings", required=True
+    )
+    parser.add_argument(
+        "-n", type=int, default=10, help="number of tests/dirs to report"
+    )
+    parser.add_argument(
+        "--sort-list",
+        nargs="+",
+        help="sort list of tests/dirs based on times from timefile",
+    )
+
+    parser.set_defaults(mode="execution")
+    parser.add_argument(
+        "--compilation", action="store_const", dest="mode", const="compilation"
+    )
+    parser.add_argument(
+        "--execution", action="store_const", dest="mode", const="execution"
+    )
+    parser.add_argument(
+        "--directory", action="store_const", dest="mode", const="directory"
+    )
 
     return parser
 
 
 def get_pattern(mode):
-    ''' Get regex pattern used to extract (test/dir, time) data '''
-    if mode =='directory':
+    """Get regex pattern used to extract (test/dir, time) data"""
+    if mode == "directory":
         pattern = re.compile(r'\[Finished subtest "(.*)" - (.*) seconds')
     else:
-        pattern = re.compile(r'\[Elapsed {} time for "(.*)" - (.*) seconds'.format(mode))
+        pattern = re.compile(
+            r'\[Elapsed {} time for "(.*)" - (.*) seconds'.format(mode)
+        )
     return pattern
 
 
 def sort_chpl_tests(tests, timing_file, mode):
-    '''
+    """
     Sort a lists of tests (comp, exec, or dir according to mode) using
     historical data in the timing file
-    '''
+    """
     try:
         # Pull timings into dict, use to sort tests, put unknown tests early
         pattern = get_pattern(mode)
-        with open(timing_file, 'r') as f:
-            times = {m.group(1): float(m.group(2)) for m in pattern.finditer(f.read())}
-        tests.sort(reverse=True, key=lambda test: times.get(test.lstrip('./'), 1000.0))
+        with open(timing_file, "r") as f:
+            times = {
+                m.group(1): float(m.group(2))
+                for m in pattern.finditer(f.read())
+            }
+        tests.sort(
+            reverse=True, key=lambda test: times.get(test.lstrip("./"), 1000.0)
+        )
     except FileNotFoundError:
         pass
 
@@ -52,19 +74,22 @@ def _main():
     args = create_parser().parse_args()
 
     if args.sort_list:
-        print(' '.join(sort_chpl_tests(args.sort_list, args.timefile, args.mode)))
+        print(
+            " ".join(sort_chpl_tests(args.sort_list, args.timefile, args.mode))
+        )
     else:
-        with open(args.timefile, 'r') as f:
+        with open(args.timefile, "r") as f:
             pattern = get_pattern(args.mode)
-            res = [(float(m.group(2)), m.group(1)) for m in pattern.finditer(f.read())]
+            res = [
+                (float(m.group(2)), m.group(1))
+                for m in pattern.finditer(f.read())
+            ]
             res.sort(reverse=True)
 
-        print('Top {} {}:'.format(args.n, args.mode))
-        for r in res[:args.n]:
+        print("Top {} {}:".format(args.n, args.mode))
+        for r in res[: args.n]:
             print(r)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     _main()
-
-
-

--- a/util/test/genGraphs.py
+++ b/util/test/genGraphs.py
@@ -6,63 +6,126 @@ from optparse import OptionParser
 import datetime
 import fileReadHelp
 import json
+
 try:
     import annotate
 except ImportError:
-    sys.stdout.write('[Warning: "annotate" import failed, no annotations will be generated]\n')
+    sys.stdout.write(
+        '[Warning: "annotate" import failed, no annotations will be generated]\n'
+    )
     annotate = None
 
-usage =  '%prog [options] <graphfiles>'
+usage = "%prog [options] <graphfiles>"
 parser = OptionParser(usage=usage)
-parser.add_option('-g', '--graphlist', dest='graphlist',
-                  help='file with list of graphfiles', metavar='FILE')
-parser.add_option('-t', '--testdir', dest='testdir',
-                  help='test directory', metavar='DIR',
-                  default='.')
-parser.add_option('-o', '--outdir', dest='outdir',
-                  help='output directory', metavar='DIR',
-                  default=None)
-parser.add_option('-p', '--perfdir', dest='perfdir',
-                  help='performance data directory', metavar='DIR',
-                  default=None)
-parser.add_option('-n', '--name', dest='name',
-                  help='Test platform name', metavar='NAME',
-                  default=None)
-parser.add_option('-s', '--startdate', dest='startdate',
-                  help='graph start date', metavar='DATE')
-parser.add_option('-e', '--enddate', dest='enddate',
-                  help='graph end date', metavar='DATE')
-parser.add_option('-a', '--alttitle', dest='alttitle', 
-                  help='alternate/custom site title', 
-                  metavar='NAME', default=None)
-parser.add_option('-v', '--verbose', dest='verbose',
-                  action='store_true', default=False)
-parser.add_option('-d', '--debug', dest='debug',
-                  action='store_true', default=False)
-parser.add_option('-r', '--reduce', dest='g_reduce', type='choice',
-                  metavar='STRATEGY', default='avg',
-                  choices=['avg', 'med', 'min', 'max'])
-parser.add_option('-x', '--no-bounds', dest='g_display_bounds',
-                  action='store_false', default=True)
-parser.add_option('-u', '--numericX', dest='numericX',
-                  help='expect numbers (e.g. revisions), not dates,' +
-                       ' for the X axis',
-                  action='store_true', default=False)
-parser.add_option('-m', '--configs', dest='multiConf',
-                  help='comma separated list of configurations. ":v" after a '
-                       'configuration makes it visible by default. e.g '
-                       '"local:v,--no-local:v" will create graphs with series '
-                       'duplicated for local and --no-local both of which will '
-                       'be visible by default on the web page.',
-                  default='')
-parser.add_option('-f', '--addfile', dest='addfile',
-                  help='comma-separated paths to files that should be copied '
-                       'into the html directory.',
-                  default='')
+parser.add_option(
+    "-g",
+    "--graphlist",
+    dest="graphlist",
+    help="file with list of graphfiles",
+    metavar="FILE",
+)
+parser.add_option(
+    "-t",
+    "--testdir",
+    dest="testdir",
+    help="test directory",
+    metavar="DIR",
+    default=".",
+)
+parser.add_option(
+    "-o",
+    "--outdir",
+    dest="outdir",
+    help="output directory",
+    metavar="DIR",
+    default=None,
+)
+parser.add_option(
+    "-p",
+    "--perfdir",
+    dest="perfdir",
+    help="performance data directory",
+    metavar="DIR",
+    default=None,
+)
+parser.add_option(
+    "-n",
+    "--name",
+    dest="name",
+    help="Test platform name",
+    metavar="NAME",
+    default=None,
+)
+parser.add_option(
+    "-s",
+    "--startdate",
+    dest="startdate",
+    help="graph start date",
+    metavar="DATE",
+)
+parser.add_option(
+    "-e", "--enddate", dest="enddate", help="graph end date", metavar="DATE"
+)
+parser.add_option(
+    "-a",
+    "--alttitle",
+    dest="alttitle",
+    help="alternate/custom site title",
+    metavar="NAME",
+    default=None,
+)
+parser.add_option(
+    "-v", "--verbose", dest="verbose", action="store_true", default=False
+)
+parser.add_option(
+    "-d", "--debug", dest="debug", action="store_true", default=False
+)
+parser.add_option(
+    "-r",
+    "--reduce",
+    dest="g_reduce",
+    type="choice",
+    metavar="STRATEGY",
+    default="avg",
+    choices=["avg", "med", "min", "max"],
+)
+parser.add_option(
+    "-x",
+    "--no-bounds",
+    dest="g_display_bounds",
+    action="store_false",
+    default=True,
+)
+parser.add_option(
+    "-u",
+    "--numericX",
+    dest="numericX",
+    help="expect numbers (e.g. revisions), not dates," + " for the X axis",
+    action="store_true",
+    default=False,
+)
+parser.add_option(
+    "-m",
+    "--configs",
+    dest="multiConf",
+    help='comma separated list of configurations. ":v" after a '
+    "configuration makes it visible by default. e.g "
+    '"local:v,--no-local:v" will create graphs with series '
+    "duplicated for local and --no-local both of which will "
+    "be visible by default on the web page.",
+    default="",
+)
+parser.add_option(
+    "-f",
+    "--addfile",
+    dest="addfile",
+    help="comma-separated paths to files that should be copied "
+    "into the html directory.",
+    default="",
+)
 
 if annotate:
-    parser.add_option('-j', '--annotate', dest='annotation_file',
-                      default=None)
+    parser.add_option("-j", "--annotate", dest="annotation_file", default=None)
 
 debug = False
 verbose = False
@@ -70,24 +133,28 @@ numericX = False
 multiConf = []
 defaultMultiConf = []
 
+
 def try_parse_float(value):
     try:
         # removes any trailing characters (units)
-        return float(re.sub(r'[^\d,.]+$', '', value))
+        return float(re.sub(r"[^\d,.]+$", "", value))
     except ValueError:
         return value
 
-def parse_date(value, dateformat='%m/%d/%y'):
+
+def parse_date(value, dateformat="%m/%d/%y"):
     if numericX:
         return value
     else:
         return time.strptime(value.strip(), dateformat)
 
+
 def show_date(value=time.localtime()):
     if numericX:
         return value
     else:
-        return time.strftime('%Y-%m-%d', value)
+        return time.strftime("%Y-%m-%d", value)
+
 
 # converts a csv file to json. Converts the csv file to json where the json
 # object has two members: the labels and the actual data formatted as required
@@ -97,8 +164,8 @@ def csv_to_json(csvFile, ginfo):
     os.unlink(csvFile)
 
     # rename the csv file to indicate that it's a json file
-    jsonFile = os.path.splitext(csvFile)[0]+'.json'
-    ginfo.datfname = os.path.splitext(ginfo.datfname)[0]+'.json'
+    jsonFile = os.path.splitext(csvFile)[0] + ".json"
+    ginfo.datfname = os.path.splitext(ginfo.datfname)[0] + ".json"
 
     # each label is stored in a single element array because of how it is
     # parsed, get rid of that array so labels is now a simple array of strings
@@ -118,10 +185,10 @@ def csv_to_json(csvFile, ginfo):
         # false) then our val will come in as ['val'] but we just want to store
         # the single value, not the single value in an array
         for seriesArr in dataForCurDate:
-            if len(seriesArr) == 1 and seriesArr[0] == '':
+            if len(seriesArr) == 1 and seriesArr[0] == "":
                 curLine.append(None)
             else:
-                if (ginfo.displayrange):
+                if ginfo.displayrange:
                     curLine.append([try_parse_float(x) for x in seriesArr])
                 else:
                     curLine.append(try_parse_float(seriesArr[0]))
@@ -135,9 +202,10 @@ def csv_to_json(csvFile, ginfo):
         line[0] = show_date()
         lines.append(line)
 
-    jsonObj = {'labels': labels, 'data': lines}
-    with open(jsonFile, 'w') as f:
+    jsonObj = {"labels": labels, "data": lines}
+    with open(jsonFile, "w") as f:
         f.write(json.dumps(jsonObj))
+
 
 # Helper functions to parse/write/sort a dygraphs compatible csv file.
 #
@@ -161,6 +229,7 @@ def csv_to_json(csvFile, ginfo):
 # high) as strings, or the empty string if there was no value for that key for
 # that date
 
+
 def parse_csv(csvFile):
     lines = fileReadHelp.ReadFileWithComments(csvFile)
 
@@ -168,24 +237,26 @@ def parse_csv(csvFile):
     for line in lines:
         line = line.rstrip()
         if len(line) > 0:
-            valuesString = line.split(',')
+            valuesString = line.split(",")
             values = []
             for valueString in valuesString:
-                 values.append(valueString.split(';'))
+                values.append(valueString.split(";"))
             data.append(values)
 
     return data
+
 
 def data_to_csv(data, csvFile):
     lines = []
     for values in data:
         line = []
         for value in values:
-            line.append(';'.join(value))
-        lines.append(','.join(line)+'\n')
+            line.append(";".join(value))
+        lines.append(",".join(line) + "\n")
 
-    with open(csvFile, 'w') as f:
+    with open(csvFile, "w") as f:
         f.writelines(lines)
+
 
 # sorts a csv of the aforementioned form. Sorts a series' keys and it's
 # corresponding values (column) from greatest to least in terms of a series
@@ -217,9 +288,9 @@ def sort_csv(csvFile):
     # date, and grabs the middle value. returns -1 for empty values, so that
     # series with no recent data filter down to the bottom
     def parse_sortable_float(values):
-        mostRecentValues = values[len(values)-1]
-        value = mostRecentValues[len(mostRecentValues)//2]
-        if value == '':
+        mostRecentValues = values[len(values) - 1]
+        value = mostRecentValues[len(mostRecentValues) // 2]
+        if value == "":
             return -1.0
         return try_parse_float(value)
 
@@ -232,14 +303,16 @@ def sort_csv(csvFile):
 
     data_to_csv(data, csvFile)
 
-# Yield dateformat-ed dates in the range [start_date, end_date]
-def date_range(start_date, end_date, dateformat='%Y-%m-%d'):
-  cur_date = datetime.datetime.strptime(start_date, dateformat)
-  end_date = datetime.datetime.strptime(end_date, dateformat)
 
-  while cur_date <= end_date:
-    yield cur_date.strftime(dateformat)
-    cur_date += datetime.timedelta(days=1)
+# Yield dateformat-ed dates in the range [start_date, end_date]
+def date_range(start_date, end_date, dateformat="%Y-%m-%d"):
+    cur_date = datetime.datetime.strptime(start_date, dateformat)
+    end_date = datetime.datetime.strptime(end_date, dateformat)
+
+    while cur_date <= end_date:
+        yield cur_date.strftime(dateformat)
+        cur_date += datetime.timedelta(days=1)
+
 
 # Fill in missing dates in the csv file. Grabs the start and end date from the
 # file, and ensures that we have an entry for every date in the range.
@@ -259,9 +332,9 @@ def fill_sparse_csv(csvFile):
             # data (we'll sort later to get things in the right order)
             missing_dates = set(date_range(start_date, end_date)) - set(dates)
             for date in missing_dates:
-               # emptydate = [[date], [''], [''], ...]
-               emptydate = [[date]] + [['']]*(len(keys)-1)
-               data.append(emptydate)
+                # emptydate = [[date], [''], [''], ...]
+                emptydate = [[date]] + [[""]] * (len(keys) - 1)
+                data.append(emptydate)
 
         # sort our data, we don't need to convert our date strings to datetimes
         # because for ISO 8601 dates lexical order is also chronological order
@@ -286,14 +359,19 @@ def strip_series(csvFile, numseries):
     if multiConf:
         defaultConf = multiConf[0]
         for i in range(1, len(labels)):
-            if labels[i].endswith('(' + defaultConf + ')') and numFound < numseries:
-                numFound+=1
+            if (
+                labels[i].endswith("(" + defaultConf + ")")
+                and numFound < numseries
+            ):
+                numFound += 1
                 newData.append(data[i])
                 for conf in multiConf[1:]:
-                    confLabel = labels[i].replace('('+defaultConf+')','('+conf+')')
+                    confLabel = labels[i].replace(
+                        "(" + defaultConf + ")", "(" + conf + ")"
+                    )
                     newData.append(data[labels.index(confLabel)])
     else:
-        for i in range(1, numseries+1):
+        for i in range(1, numseries + 1):
             newData.append(data[i])
 
     # untranspose the data
@@ -314,35 +392,47 @@ def get_annotation_series(csvFile):
     if multiConf:
         defaultConf = multiConf[0]
         for label in labels:
-            if label.endswith('(' + defaultConf + ')'):
+            if label.endswith("(" + defaultConf + ")"):
                 annotation_series = label
                 break
 
     return annotation_series
 
 
-
 ############
+
 
 class CouldNotReadGraphFile(Exception):
     pass
 
+
 # Global info about generating graphs
 class GraphStuff:
-    def __init__(self, _name, _testdir, _perfdir, _outdir, _startdate, _enddate,
-                 _reduce, _display_bounds, _alttitle, _annotation_file):
+    def __init__(
+        self,
+        _name,
+        _testdir,
+        _perfdir,
+        _outdir,
+        _startdate,
+        _enddate,
+        _reduce,
+        _display_bounds,
+        _alttitle,
+        _annotation_file,
+    ):
         self.numGraphs = 0
         self.config_name = _name
         self.testdir = _testdir
         self.perfdir = _perfdir
         self.outdir = _outdir
-        self.datdir = self.outdir+'/'+'CSVfiles'
-        self.title = 'Chapel Performance Graphs'
-        if _alttitle: 
+        self.datdir = self.outdir + "/" + "CSVfiles"
+        self.title = "Chapel Performance Graphs"
+        if _alttitle:
             self.title = _alttitle
         if _name != None:
-            self.title += ' for '+_name
-        self.gfname = self.outdir+'/'+'graphdata.js'
+            self.title += " for " + _name
+        self.gfname = self.outdir + "/" + "graphdata.js"
         self.gfile = None
         self.suites = list()
         self.startdate = _startdate
@@ -354,79 +444,95 @@ class GraphStuff:
     def init(self):
         if os.path.exists(self.outdir):
             if verbose:
-                sys.stdout.write('Removing old directory %s...\n'%(self.outdir))
+                sys.stdout.write(
+                    "Removing old directory %s...\n" % (self.outdir)
+                )
             try:
                 shutil.rmtree(self.outdir)
             except OSError:
-                sys.stderr.write('Error: Could not clean up directory: %s\n'%(self.outdir))
+                sys.stderr.write(
+                    "Error: Could not clean up directory: %s\n" % (self.outdir)
+                )
                 raise
         if verbose:
-            sys.stdout.write('Creating directory %s...\n'%(self.outdir))
+            sys.stdout.write("Creating directory %s...\n" % (self.outdir))
         try:
             os.makedirs(self.outdir)
         except OSError:
-            sys.stderr.write('ERROR: Could not (re)create directory: %s\n'%(self.outdir))
+            sys.stderr.write(
+                "ERROR: Could not (re)create directory: %s\n" % (self.outdir)
+            )
             raise
         if verbose:
-            sys.stdout.write('Creating directory %s...\n'%(self.datdir))
+            sys.stdout.write("Creating directory %s...\n" % (self.datdir))
         try:
             os.makedirs(self.datdir)
         except OSError:
-            sys.stderr.write('ERROR: Could not create directory: %s\n'%(self.datdir))
+            sys.stderr.write(
+                "ERROR: Could not create directory: %s\n" % (self.datdir)
+            )
             raise
         try:
-            self.gfile = open(self.gfname, 'w')
+            self.gfile = open(self.gfname, "w")
         except IOError:
-            sys.stderr.write('ERROR: Could not open file: %s\n'%(self.gfname))
+            sys.stderr.write("ERROR: Could not open file: %s\n" % (self.gfname))
 
         if annotate and self.annotation_file:
             try:
                 self.all_annotations = annotate.load(self.annotation_file)
             except IOError:
-                sys.stderr.write('ERROR: Could not open file: %s\n'%(self.annotation_file))
+                sys.stderr.write(
+                    "ERROR: Could not open file: %s\n" % (self.annotation_file)
+                )
                 raise
         else:
             self.all_annotations = None
 
-        self.gfile.write('// AUTOMATICALLY GENERATED GRAPH DESCRIPTION\n')
-        self.gfile.write('document.title = "%s";\n'%(self.title))
-        self.gfile.write('var pageTitle = "%s";\n'%(self.title))
-        runDate = time.strftime('%Y-%m-%d', time.localtime())
-        self.gfile.write('var runDate= "%s";\n'%(runDate))
-        self.gfile.write('var numericX = %s;\n'%(str(numericX).lower()))
-        self.gfile.write('var configurations = [%s];\n' %(', '.join([ '" ('+conf+')"' for conf in multiConf])))
-        self.gfile.write('var configurationsVis = [%s];\n' %(', '.join([ '"('+conf+')"' for conf in defaultMultiConf])))
-        self.gfile.write('var allGraphs = [\n')
+        self.gfile.write("// AUTOMATICALLY GENERATED GRAPH DESCRIPTION\n")
+        self.gfile.write('document.title = "%s";\n' % (self.title))
+        self.gfile.write('var pageTitle = "%s";\n' % (self.title))
+        runDate = time.strftime("%Y-%m-%d", time.localtime())
+        self.gfile.write('var runDate= "%s";\n' % (runDate))
+        self.gfile.write("var numericX = %s;\n" % (str(numericX).lower()))
+        self.gfile.write(
+            "var configurations = [%s];\n"
+            % (", ".join(['" (' + conf + ')"' for conf in multiConf]))
+        )
+        self.gfile.write(
+            "var configurationsVis = [%s];\n"
+            % (", ".join(['"(' + conf + ')"' for conf in defaultMultiConf]))
+        )
+        self.gfile.write("var allGraphs = [\n")
         self.firstGraph = True
         return 0
 
     def __str__(self):
-        s = 'Number of unique graphs = '+str(self.numGraphs)
-        s += 'test dir = '+self.testdir
-        s += 'performance data dir = '+self.perfdir
-        s += 'output dir = '+self.outdir
-        s += 'start date = '+self.startdate
-        s += 'end date = '+self.enddate
-        s += ': '+str(len(self.dygarphs))+' dygraphs'
+        s = "Number of unique graphs = " + str(self.numGraphs)
+        s += "test dir = " + self.testdir
+        s += "performance data dir = " + self.perfdir
+        s += "output dir = " + self.outdir
+        s += "start date = " + self.startdate
+        s += "end date = " + self.enddate
+        s += ": " + str(len(self.dygarphs)) + " dygraphs"
         return s
 
     def finish(self):
         if self.gfile:
-            self.gfile.write('\n];\n')
+            self.gfile.write("\n];\n")
             first = True
-            self.gfile.write('var perfSuites = [\n')
+            self.gfile.write("var perfSuites = [\n")
             for s in self.suites:
                 if not first:
-                    self.gfile.write(',\n')
+                    self.gfile.write(",\n")
                 else:
                     first = False
-                self.gfile.write('{ "suite" : "%s" }'%(s))
-            self.gfile.write('\n];\n')
+                self.gfile.write('{ "suite" : "%s" }' % (s))
+            self.gfile.write("\n];\n")
             self.gfile.close()
 
     def genGraphInfo(self, ginfo):
         if not self.firstGraph:
-            self.gfile.write(',\n')
+            self.gfile.write(",\n")
         else:
             self.firstGraph = False
 
@@ -435,59 +541,71 @@ class GraphStuff:
         # generate the annotations for this graph
         if series and annotate and self.all_annotations and not numericX:
             ginfo.annotations = annotate.get(
-                self.all_annotations, ginfo.name, series,
-                parse_date(ginfo.startdate, '%Y-%m-%d'),
-                parse_date(ginfo.enddate,'%Y-%m-%d'), self.config_name)
+                self.all_annotations,
+                ginfo.name,
+                series,
+                parse_date(ginfo.startdate, "%Y-%m-%d"),
+                parse_date(ginfo.enddate, "%Y-%m-%d"),
+                self.config_name,
+            )
 
-        self.gfile.write('{\n')
-        if ginfo.title != '':
-            self.gfile.write('   "title" : "%s",\n'%(ginfo.title))
-        elif ginfo.graphname != '':
-            sys.stdout.write('WARNING: \'graphname\' is deprecated.  Use \'graphtitle\' instead.\n')
-            self.gfile.write('   "title" : "%s",\n'%(ginfo.graphname))
+        self.gfile.write("{\n")
+        if ginfo.title != "":
+            self.gfile.write('   "title" : "%s",\n' % (ginfo.title))
+        elif ginfo.graphname != "":
+            sys.stdout.write(
+                "WARNING: 'graphname' is deprecated.  Use 'graphtitle' instead.\n"
+            )
+            self.gfile.write('   "title" : "%s",\n' % (ginfo.graphname))
         else:
-            sys.stdout.write('WARNING: No graph title found.\n')
-            self.gfile.write('   "title" : "%s",\n'%(ginfo.name))
-        suites =  (', '.join('"' + s + '"' for s in ginfo.suites if s))
-        self.gfile.write('   "suites" : [%s],\n'%(suites))
-        self.gfile.write('   "datfname" : "%s",\n'%(ginfo.datfname))
-        self.gfile.write('   "ylabel" : "%s",\n'%(ginfo.ylabel))
-        self.gfile.write('   "startdate" : "%s",\n'%(ginfo.startdate))
-        self.gfile.write('   "enddate" : "%s",\n'%(ginfo.enddate))
-        self.gfile.write('   "displayrange" : %s,\n'%(str(ginfo.displayrange).lower()))
-        self.gfile.write('   "defaultexpand" : %s,\n'%(str(ginfo.expand).lower()))
+            sys.stdout.write("WARNING: No graph title found.\n")
+            self.gfile.write('   "title" : "%s",\n' % (ginfo.name))
+        suites = ", ".join('"' + s + '"' for s in ginfo.suites if s)
+        self.gfile.write('   "suites" : [%s],\n' % (suites))
+        self.gfile.write('   "datfname" : "%s",\n' % (ginfo.datfname))
+        self.gfile.write('   "ylabel" : "%s",\n' % (ginfo.ylabel))
+        self.gfile.write('   "startdate" : "%s",\n' % (ginfo.startdate))
+        self.gfile.write('   "enddate" : "%s",\n' % (ginfo.enddate))
+        self.gfile.write(
+            '   "displayrange" : %s,\n' % (str(ginfo.displayrange).lower())
+        )
+        self.gfile.write(
+            '   "defaultexpand" : %s,\n' % (str(ginfo.expand).lower())
+        )
         self.gfile.write('   "annotations" : [')
         if ginfo.annotations:
-          self.gfile.write('\n      ')
-          self.gfile.write(',\n      '.join(ginfo.annotations))
-          self.gfile.write('\n   ')
-        self.gfile.write(']\n')
-        self.gfile.write('}')
-
+            self.gfile.write("\n      ")
+            self.gfile.write(",\n      ".join(ginfo.annotations))
+            self.gfile.write("\n   ")
+        self.gfile.write("]\n")
+        self.gfile.write("}")
 
     def genGraphStuff(self, fname, suites):
         if os.path.isabs(fname):
             fullFname = fname
         else:
-            fullFname = self.testdir+'/'+fname
+            fullFname = self.testdir + "/" + fname
             if not os.path.exists(fullFname):
-                fullFname = './'+fname
+                fullFname = "./" + fname
         if verbose:
-            sys.stdout.write('Reading %s...\n'%(fullFname))
-        lines=fileReadHelp.ReadFileWithComments(fullFname)
-        if lines==None:
-            sys.stdout.write('WARNING: Could not read graph description from %s.  Ignoring.\n'%(fullFname))
+            sys.stdout.write("Reading %s...\n" % (fullFname))
+        lines = fileReadHelp.ReadFileWithComments(fullFname)
+        if lines == None:
+            sys.stdout.write(
+                "WARNING: Could not read graph description from %s.  Ignoring.\n"
+                % (fullFname)
+            )
             raise CouldNotReadGraphFile
 
         basename = os.path.splitext(os.path.basename(fname))[0]
 
-        graphs=list()
-        currgraph=-1
+        graphs = list()
+        currgraph = -1
         firstGraphNum = self.numGraphs
         for l in lines:
-            key = l.split(':')[0].strip()
-            rest = l[l.index(':')+1:].strip()
-            if key == 'perfkeys' :
+            key = l.split(":")[0].strip()
+            rest = l[l.index(":") + 1 :].strip()
+            if key == "perfkeys":
                 if currgraph != -1:
                     try:
                         graphs[currgraph].generateGraphData(self, currgraph)
@@ -495,80 +613,142 @@ class GraphStuff:
                         raise
                 # new graph
                 currgraph += 1
-                graphs.append(GraphClass(basename, firstGraphNum+currgraph,
-                    suites, self.startdate, self.enddate,
-                    self._reduce, self.display_bounds))
-                graphs[currgraph].perfkeys += [ s.strip() for s in rest.split(', ') ]
-            elif key == 'graphkeys' :
-                graphs[currgraph].graphkeys += [ s.strip() for s in rest.split(',') ]
+                graphs.append(
+                    GraphClass(
+                        basename,
+                        firstGraphNum + currgraph,
+                        suites,
+                        self.startdate,
+                        self.enddate,
+                        self._reduce,
+                        self.display_bounds,
+                    )
+                )
+                graphs[currgraph].perfkeys += [
+                    s.strip() for s in rest.split(", ")
+                ]
+            elif key == "graphkeys":
+                graphs[currgraph].graphkeys += [
+                    s.strip() for s in rest.split(",")
+                ]
             # files takes a list of the files to use per perfkey, while
             # repeat-files uses each of n files perkey/n times. So if you have
             # 10 perfkeys and 2 files listed, each file will be used 5 times
-            elif key == 'files' :
-                graphs[currgraph].datfilenames += [ s.strip() for s in rest.split(',') ]
-            elif key == 'repeat-files' :
-                dFiles = [ s.strip() for s in rest.split(',') ]
+            elif key == "files":
+                graphs[currgraph].datfilenames += [
+                    s.strip() for s in rest.split(",")
+                ]
+            elif key == "repeat-files":
+                dFiles = [s.strip() for s in rest.split(",")]
                 if len(graphs[currgraph].perfkeys) % len(dFiles) != 0:
-                    sys.stdout.write('[Warning: num .dat files did not evenly divide into num perfkeys for %s. Ignoring.]\n'%(fullFname))
+                    sys.stdout.write(
+                        "[Warning: num .dat files did not evenly divide into num perfkeys for %s. Ignoring.]\n"
+                        % (fullFname)
+                    )
                     return
-                keysRange = range(0, (len(graphs[currgraph].perfkeys) // len(dFiles)))
+                keysRange = range(
+                    0, (len(graphs[currgraph].perfkeys) // len(dFiles))
+                )
                 for dFile in dFiles:
-                    graphs[currgraph].datfilenames += [ dFile for i in keysRange ]
-            elif key == 'graphtitle':
+                    graphs[currgraph].datfilenames += [dFile for i in keysRange]
+            elif key == "graphtitle":
                 graphs[currgraph].title = rest.strip()
-            elif key == 'graphname':
+            elif key == "graphname":
                 # deprecated
                 graphs[currgraph].graphname = rest.strip()
-            elif key == 'ylabel':
+            elif key == "ylabel":
                 graphs[currgraph].ylabel = rest.strip()
-            elif key == 'startdate':
+            elif key == "startdate":
                 graphs[currgraph].startdate = parse_date(rest)
-            elif key == 'enddate':
+            elif key == "enddate":
                 graphs[currgraph].enddate = parse_date(rest)
-            elif key == 'generate':
-                graphs[currgraph].generate = [s if s != '' else self._reduce for s in re.sub(r'\s+', '', rest).split(',')]
+            elif key == "generate":
+                graphs[currgraph].generate = [
+                    s if s != "" else self._reduce
+                    for s in re.sub(r"\s+", "", rest).split(",")
+                ]
                 for strat in graphs[currgraph].generate:
-                    if strat not in parser.get_option('-r').choices:
-                        sys.stdout.write('WARNING: Invalid generate option {0} in {1}\n'.format(strat, fullFname))
-            elif key == 'displayrange':
-                graphs[currgraph].displayrange = rest.lower() in ('true', 't', '1', 'on', 'y', 'yes')
+                    if strat not in parser.get_option("-r").choices:
+                        sys.stdout.write(
+                            "WARNING: Invalid generate option {0} in {1}\n".format(
+                                strat, fullFname
+                            )
+                        )
+            elif key == "displayrange":
+                graphs[currgraph].displayrange = rest.lower() in (
+                    "true",
+                    "t",
+                    "1",
+                    "on",
+                    "y",
+                    "yes",
+                )
             # expansion is used to turn a single graph with multiple series into
             # multiple graphs where the first one is all the series combined and
-            # the subsequent ones contain each series individually. -1 means 
-            # expand all. Other numbers indicate the number of series to expand 
-            elif key == 'defaultexpand':
-                graphs[currgraph].expand = rest.lower() in ('true', 't', '1', 'on', 'y', 'yes')
-            elif key == 'numseries':
+            # the subsequent ones contain each series individually. -1 means
+            # expand all. Other numbers indicate the number of series to expand
+            elif key == "defaultexpand":
+                graphs[currgraph].expand = rest.lower() in (
+                    "true",
+                    "t",
+                    "1",
+                    "on",
+                    "y",
+                    "yes",
+                )
+            elif key == "numseries":
                 graphs[currgraph].numseries = int(rest.strip())
-            elif key == 'sort':
-                graphs[currgraph].sort = rest.lower() in ('true', 't', '1', 'on', 'y', 'yes')
+            elif key == "sort":
+                graphs[currgraph].sort = rest.lower() in (
+                    "true",
+                    "t",
+                    "1",
+                    "on",
+                    "y",
+                    "yes",
+                )
             else:
-                sys.stdout.write('WARNING: Invalid graph file key {0} in {1}\n'.format(key, fullFname))
+                sys.stdout.write(
+                    "WARNING: Invalid graph file key {0} in {1}\n".format(
+                        key, fullFname
+                    )
+                )
 
         try:
             graphs[currgraph].generateGraphData(self, currgraph)
         except (ValueError, IOError, OSError):
             raise
 
-        return (currgraph+1)
+        return currgraph + 1
 
 
 ############
 
+
 # graph class
 class GraphClass:
     gid = 1
-    def __init__(self, _name, _graphNum, _suites=[], _startdate=None,
-                 _enddate=None, _reduce='avg', _displayrange=True, 
-                 _expand=False, _sort=True):
+
+    def __init__(
+        self,
+        _name,
+        _graphNum,
+        _suites=[],
+        _startdate=None,
+        _enddate=None,
+        _reduce="avg",
+        _displayrange=True,
+        _expand=False,
+        _sort=True,
+    ):
         self.id = GraphClass.gid
         GraphClass.gid += 1
         self.name = _name.strip()
-        self.srcdatfname = self.name+'.dat'
-        self.title = ''
+        self.srcdatfname = self.name + ".dat"
+        self.title = ""
         self.suites = _suites
-        self.graphname = ''
-        self.ylabel = ''
+        self.graphname = ""
+        self.ylabel = ""
         self.startdate = _startdate
         self.enddate = _enddate
         self.graphNum = _graphNum
@@ -585,26 +765,26 @@ class GraphClass:
         self.annotationSeries = ""
 
     def __str__(self):
-        l  = 'Graph: '+str(self.name)+' (id='+str(self.id)+')\n'
-        l += '\ttitle: '+self.title+'\n'
+        l = "Graph: " + str(self.name) + " (id=" + str(self.id) + ")\n"
+        l += "\ttitle: " + self.title + "\n"
         if self.suites == None or self.suites == [] or self.suites == [None]:
-            l += '\tsuites: none\n'
+            l += "\tsuites: none\n"
         else:
-            l += '\tsuites: ['+','.join(self.suites)+']\n'
-        l += '\tgraphname: '+self.graphname+'\n'
-        l += '\tylabel: '+self.ylabel+'\n'
+            l += "\tsuites: [" + ",".join(self.suites) + "]\n"
+        l += "\tgraphname: " + self.graphname + "\n"
+        l += "\tylabel: " + self.ylabel + "\n"
         if self.startdate != None:
-            l += '\tstartdate: '+show_date(self.startdate)+'\n'
+            l += "\tstartdate: " + show_date(self.startdate) + "\n"
         else:
-            l += '\tstartdate: Not specified\n'
+            l += "\tstartdate: Not specified\n"
         if self.enddate != None:
-            l += '\tenddate: '+show_date(self.enddate)+'\n'
+            l += "\tenddate: " + show_date(self.enddate) + "\n"
         else:
-            l += '\tenddate: Not specified\n'
-        l += '\tperfkeys: '+list.__str__(self.perfkeys)+'\n'
-        l += '\tgraphkeys: '+list.__str__(self.graphkeys)+'\n'
-        l += '\tdatfilenames: '+list.__str__(self.datfilenames)+'\n'
-        l += '\tdisplayrange:'+str(self.displayrange).lower()+'\n'
+            l += "\tenddate: Not specified\n"
+        l += "\tperfkeys: " + list.__str__(self.perfkeys) + "\n"
+        l += "\tgraphkeys: " + list.__str__(self.graphkeys) + "\n"
+        l += "\tdatfilenames: " + list.__str__(self.datfilenames) + "\n"
+        l += "\tdisplayrange:" + str(self.displayrange).lower() + "\n"
         return l
 
     # For each unique data file
@@ -616,10 +796,12 @@ class GraphClass:
             self.lines = []
             self.mykeys = {}
             try:
-                self.dfile = open(_filename, 'r')
+                self.dfile = open(_filename, "r")
                 # First line must be a comment and must be a tab separated list
                 #  of the performance keys
-                self.perfkeys = [ l.strip() for l in self.dfile.readline()[1:].split('\t') ]
+                self.perfkeys = [
+                    l.strip() for l in self.dfile.readline()[1:].split("\t")
+                ]
             except IOError:
                 pass
                 # Allows some performance tests to be graphed when you aren't
@@ -632,12 +814,12 @@ class GraphClass:
             self.mykeys[_i] = self.perfkeys.index(_k)
 
         def __str__(self):
-            l  = '\tperfkeys: '+list.__str__(self.perfkeys)+'\n'
-            l += '\tmykeys: '+dict.__str__(self.mykeys)+'\n'
+            l = "\tperfkeys: " + list.__str__(self.perfkeys) + "\n"
+            l += "\tmykeys: " + dict.__str__(self.mykeys) + "\n"
             return l
 
         def __del__(self):
-            if hasattr(self, 'dfile'):
+            if hasattr(self, "dfile"):
                 self.dfile.close()
 
     # Generate the new data file inline in CSV format
@@ -647,19 +829,19 @@ class GraphClass:
         # potentially multiple data files and read thru them and look
         # at every line for the appropriate date, I opted for
         # regenerating.
-        fname = graphInfo.datdir+'/'+self.datfname
-        f = open(fname, 'w')
-        f.write('Date,')
+        fname = graphInfo.datdir + "/" + self.datfname
+        f = open(fname, "w")
+        f.write("Date,")
         for i in range(len(self.graphkeys)):
             f.write(self.graphkeys[i])
-            if i < len(self.graphkeys)-1:
-                f.write(',')
+            if i < len(self.graphkeys) - 1:
+                f.write(",")
             else:
-                f.write('\n')
+                f.write("\n")
 
         numKeys = len(self.perfkeys)
         # currLines stores the current merged line number of each dat file
-        currLines = [0]*numKeys
+        currLines = [0] * numKeys
         startdate = self.startdate
         enddate = self.enddate
         minDate = None
@@ -674,10 +856,10 @@ class GraphClass:
                 df = datfiles[self.datfilenames[i]]
                 for line in sorted(df.dfile):
                     line = line.strip()
-                    if line == '' or line[0] == '#':
+                    if line == "" or line[0] == "#":
                         continue
                     fields = line.split()
-                    myDate=parse_date(fields[0])
+                    myDate = parse_date(fields[0])
                     fields[0] = myDate
                     fields[1:] = [try_parse_float(x) for x in fields[1:]]
                     if df.lines and myDate == df.lines[-1][0][0]:
@@ -703,10 +885,10 @@ class GraphClass:
                 if currLines[i] < len(df.lines):
                     done = False
                     myDate = df.lines[currLines[i]][0][0]
-                    if minDate==None or myDate<minDate:
+                    if minDate == None or myDate < minDate:
                         minDate = myDate
 
-            if startdate==None:
+            if startdate == None:
                 startdate = minDate
 
             if done:
@@ -715,7 +897,7 @@ class GraphClass:
             # We didn't print anything last iteration if there was no data
             # found, so skip the new line in that case
             if not first and found_data:
-                f.write('\n')
+                f.write("\n")
             else:
                 first = False
 
@@ -732,8 +914,11 @@ class GraphClass:
                         myDate = fields[0][0]
                         if myDate == minDate:
                             # consume this line
-                            line_to_write += ','
-                            if len(fields)>df.mykeys[i] and '-' not in fields[df.mykeys[i]]:
+                            line_to_write += ","
+                            if (
+                                len(fields) > df.mykeys[i]
+                                and "-" not in fields[df.mykeys[i]]
+                            ):
                                 fieldId = df.mykeys[i]
                                 value = fields[fieldId][0]
                                 if self.generate:
@@ -741,47 +926,58 @@ class GraphClass:
                                 else:
                                     method = self._reduce
 
-                                if method == 'avg':
-                                    value = math.fsum(fields[fieldId])/len(fields[fieldId])
-                                elif method == 'med':
+                                if method == "avg":
+                                    value = math.fsum(fields[fieldId]) / len(
+                                        fields[fieldId]
+                                    )
+                                elif method == "med":
                                     slist = sorted(fields[fieldId])
                                     if len(fields[fieldId]) % 2 == 0:
-                                        value = (slist[len(slist)/2]+slist[len(slist)/2-1])/2
+                                        value = (
+                                            slist[len(slist) / 2]
+                                            + slist[len(slist) / 2 - 1]
+                                        ) / 2
                                     else:
-                                        value = slist[len(slist)/2]
-                                elif method == 'min':
+                                        value = slist[len(slist) / 2]
+                                elif method == "min":
                                     value = min(fields[fieldId])
-                                elif method == 'max':
+                                elif method == "max":
                                     value = max(fields[fieldId])
 
                                 if self.displayrange:
                                     minval = min(fields[fieldId])
                                     maxval = max(fields[fieldId])
-                                    line_to_write += "{0};{1};{2}".format(minval, value, maxval)
+                                    line_to_write += "{0};{1};{2}".format(
+                                        minval, value, maxval
+                                    )
                                 else:
                                     line_to_write += "{0}".format(value)
                                 found_data = True
                             currLines[i] += 1
                         else:
                             # no data for this date
-                            line_to_write += ','
+                            line_to_write += ","
                     else:
                         # no data for this date
-                        line_to_write += ','
+                        line_to_write += ","
                 except:
-                    print('[Error parsing .dat file: {0}'.format(self.datfilenames[i]))
+                    print(
+                        "[Error parsing .dat file: {0}".format(
+                            self.datfilenames[i]
+                        )
+                    )
                     raise
 
             if found_data:
-              f.write(line_to_write)
+                f.write(line_to_write)
 
-            if self.enddate==None:
+            if self.enddate == None:
                 enddate = minDate
             else:
                 enddate = self.enddate
             minDate = None
 
-        f.write('\n')
+        f.write("\n")
         f.close()
 
         # sort the csv if sorting is enabled for this graph. This happens after
@@ -815,52 +1011,57 @@ class GraphClass:
         elif enddate != None:
             self.enddate = show_date(enddate)
 
-
-
     def generateGraphData(self, graphInfo, gnum):
         if debug:
-            print('===')
+            print("===")
             print(self)
 
         if verbose:
-            sys.stdout.write('Generating graph data for %s (graph #%d)\n'%(self.name, gnum))
+            sys.stdout.write(
+                "Generating graph data for %s (graph #%d)\n" % (self.name, gnum)
+            )
 
-        self.datfname = self.name+str(gnum)+'.txt'
+        self.datfname = self.name + str(gnum) + ".txt"
 
         nperfkeys = len(self.perfkeys)
         if nperfkeys != len(self.graphkeys):
             start = len(self.graphkeys)
-            for i in range(start,nperfkeys):
+            for i in range(start, nperfkeys):
                 self.graphkeys.append(self.perfkeys[i])
 
         # strip trailing colons, equals, spaces, and dashes so graphkeys are
         # cleaner. We have a lot of them when graph keys come from perfkeys
-        self.graphkeys = [key.rstrip(':= -') for key in self.graphkeys]
+        self.graphkeys = [key.rstrip(":= -") for key in self.graphkeys]
 
         for i in range(nperfkeys):
             for j in range(nperfkeys):
-                if (i != j) and (self.graphkeys[i]==self.graphkeys[j]):
-                    sys.stdout.write('WARNING: Duplicate graph keys (%s)\n'%(self.graphkeys[i]))
+                if (i != j) and (self.graphkeys[i] == self.graphkeys[j]):
+                    sys.stdout.write(
+                        "WARNING: Duplicate graph keys (%s)\n"
+                        % (self.graphkeys[i])
+                    )
 
         defaultFilename = self.srcdatfname
         if nperfkeys != len(self.datfilenames):
             start = len(self.datfilenames)
-            for i in range(start,nperfkeys):
+            for i in range(start, nperfkeys):
                 self.datfilenames.append(defaultFilename)
 
         # fix path to dat files
         for i in range(nperfkeys):
             fn = self.datfilenames[i]
-            idx = fn.rfind('/')
+            idx = fn.rfind("/")
             if idx != -1:
-                if graphInfo.perfdir[0] == '/':
+                if graphInfo.perfdir[0] == "/":
                     # absolute path (prepend path and strip relative path)
-                    self.datfilenames[i] = graphInfo.perfdir+fn[idx:]
+                    self.datfilenames[i] = graphInfo.perfdir + fn[idx:]
                 else:
                     # relative path (find .dat file in the subdir)
-                    self.datfilenames[i] = './'+fn[0:idx]+'/'+graphInfo.perfdir+fn[idx:]
+                    self.datfilenames[i] = (
+                        "./" + fn[0:idx] + "/" + graphInfo.perfdir + fn[idx:]
+                    )
             else:
-                self.datfilenames[i] = graphInfo.perfdir+'/'+fn
+                self.datfilenames[i] = graphInfo.perfdir + "/" + fn
 
         # this is the 'magic' for multiple configurations. It takes the info
         # for a graph and creates copies for each configuration.
@@ -873,11 +1074,13 @@ class GraphClass:
             self.perfkeys = []
             self.graphkeys = []
 
-            graphConfs = [ ' ('+conf+')' for conf in multiConf if conf ]
-            for dat, perf, graph in zip(tempdatfilenames, tempperfkeys, tempgraphkeys):
+            graphConfs = [" (" + conf + ")" for conf in multiConf if conf]
+            for dat, perf, graph in zip(
+                tempdatfilenames, tempperfkeys, tempgraphkeys
+            ):
                 for conf, graphconf in zip(multiConf, graphConfs):
-                    if conf == 'default':
-                        conf = ''
+                    if conf == "default":
+                        conf = ""
 
                     datpath = os.path.dirname(dat)
                     datfile = os.path.basename(dat)
@@ -896,21 +1099,26 @@ class GraphClass:
                     # series for each configuration even if there's no data.
                     else:
                         for otherConf in multiConf:
-                            if otherConf == 'default':
-                                otherConf = ''
-                            otherFullDatFile = os.path.join(datpath, otherConf, datfile)
+                            if otherConf == "default":
+                                otherConf = ""
+                            otherFullDatFile = os.path.join(
+                                datpath, otherConf, datfile
+                            )
                             if os.path.exists(otherFullDatFile):
-                                firstline = ''
-                                with open(otherFullDatFile, 'r') as f:
+                                firstline = ""
+                                with open(otherFullDatFile, "r") as f:
                                     firstline = f.readline()
                                 if firstline:
-                                    with open(fullDatFile, 'w') as f:
+                                    with open(fullDatFile, "w") as f:
                                         f.write(firstline)
                     # if we still didn't find the file, it might be a test that
                     # doesn't really have multi-configurations (misc stats for
                     # compiler perf.) If there's a file not in a conf directory
                     # use it and don't append the conf to the graph key
-                    if not os.path.exists(fullDatFile) and not 'default' in multiConf:
+                    if (
+                        not os.path.exists(fullDatFile)
+                        and not "default" in multiConf
+                    ):
                         myDatFile = os.path.join(datpath, datfile)
                         if os.path.exists(myDatFile):
                             self.datfilenames.append(myDatFile)
@@ -931,7 +1139,7 @@ class GraphClass:
             if d not in datfiles:
                 datfiles[d] = self.DatFileClass(d)
             try:
-                if hasattr(datfiles[d], 'dfile'):
+                if hasattr(datfiles[d], "dfile"):
                     # May not have a dfile if the specific performance test
                     # was not previously run and dumped into this folder
                     # Should distinguish this case from cases where there are
@@ -942,7 +1150,10 @@ class GraphClass:
                     # created DatFileClass so it doesn't mess us up
                     del datfiles[d]
             except ValueError:
-                sys.stderr.write('ERROR: Could not find perfkey \'%s\' in %s\n'%(self.perfkeys[i], self.datfilenames[i]))
+                sys.stderr.write(
+                    "ERROR: Could not find perfkey '%s' in %s\n"
+                    % (self.perfkeys[i], self.datfilenames[i])
+                )
                 raise
 
         # generate the new data files
@@ -955,9 +1166,10 @@ class GraphClass:
 
 ####################
 
+
 def main():
-    (options, args) = parser.parse_args()
-    sys.stdout.write('Running genGraphs with %s\n'%(' '.join(sys.argv)))
+    options, args = parser.parse_args()
+    sys.stdout.write("Running genGraphs with %s\n" % (" ".join(sys.argv)))
     global debug
     debug = options.debug
     global verbose
@@ -968,12 +1180,12 @@ def main():
     if options.perfdir != None:
         perfdir = options.perfdir
     else:
-        perfdir = './perfdat/'+os.uname()[1]
+        perfdir = "./perfdat/" + os.uname()[1]
 
     if options.outdir != None:
         outdir = options.outdir
     else:
-        outdir = perfdir+'/html'
+        outdir = perfdir + "/html"
 
     if options.startdate != None:
         startdate = parse_date(options.startdate)
@@ -983,10 +1195,10 @@ def main():
     if options.enddate != None:
         enddate = parse_date(options.enddate)
     else:
-       if numericX:
-           enddate = None
-       else:
-           enddate = time.localtime()
+        if numericX:
+            enddate = None
+        else:
+            enddate = time.localtime()
 
     global multiConf
     global defaultMultiConf
@@ -996,12 +1208,12 @@ def main():
     # visible by default. If 'v' isn't specified for any series, the first conf
     # will be visible by default
     if options.multiConf:
-        tempConf = options.multiConf.split(',')
+        tempConf = options.multiConf.split(",")
         for confAndDefaultVis in tempConf:
-            temp = confAndDefaultVis.split(':')
+            temp = confAndDefaultVis.split(":")
             conf = temp[0]
             multiConf.append(conf)
-            if len(temp) > 1 and temp[1] == 'v':
+            if len(temp) > 1 and temp[1] == "v":
                 defaultMultiConf.append(conf)
         if len(defaultMultiConf) == 0:
             defaultMultiConf.append(multiConf[0])
@@ -1013,20 +1225,29 @@ def main():
         if options.annotation_file is not None:
             annotation_file = options.annotation_file
         else:
-            af = os.path.join(options.testdir, 'ANNOTATIONS.yaml')
+            af = os.path.join(options.testdir, "ANNOTATIONS.yaml")
             if os.path.exists(af):
                 annotation_file = af
 
     # This allows the graph webpage to have an alternate title. The default is
-    # Chapel Performance Graphs, which is not always appropriate 
+    # Chapel Performance Graphs, which is not always appropriate
     if options.alttitle != None:
         alttitle = options.alttitle
     else:
         alttitle = None
 
-    graphInfo = GraphStuff(options.name, options.testdir, perfdir, outdir,
-        startdate, enddate, options.g_reduce, options.g_display_bounds,
-        alttitle, annotation_file)
+    graphInfo = GraphStuff(
+        options.name,
+        options.testdir,
+        perfdir,
+        outdir,
+        startdate,
+        enddate,
+        options.g_reduce,
+        options.g_display_bounds,
+        alttitle,
+        annotation_file,
+    )
     graphInfo.init()
 
     # get the list of .graph files
@@ -1038,92 +1259,97 @@ def main():
     graphlist = options.graphlist
     if graphlist != None:
         try:
-            f = open(graphlist, 'r')
+            f = open(graphlist, "r")
             try:
                 lines += f.readlines()
             finally:
                 f.close()
         except IOError:
-            sys.stderr.write('ERROR: Could not open graph file: %s\n'%(graphlist))
+            sys.stderr.write(
+                "ERROR: Could not open graph file: %s\n" % (graphlist)
+            )
             return -1
-    
+
     currSuite = None
     numSuites = 0
     numGraphfiles = 0
     graphList = list()
-    # determine the suite(s) for each graph 
+    # determine the suite(s) for each graph
     for line in lines:
         l = line.strip()
-        if l != '':
-            if l[0] != '#':
+        if l != "":
+            if l[0] != "#":
                 # if a graph has already been seen, just append to the list of
                 # suites it belongs to, else add it add it to the graphList
                 graphnames = [x[0] for x in graphList]
                 if graphnames.count(l):
                     if currSuite in graphList[graphnames.index(l)][1]:
-                        sys.stdout.write('[Warning: duplicate graph "{0}" '
-                            'found in suite "{1}"]\n'.format(l, currSuite))
+                        sys.stdout.write(
+                            '[Warning: duplicate graph "{0}" '
+                            'found in suite "{1}"]\n'.format(l, currSuite)
+                        )
                     graphList[graphnames.index(l)][1].append(currSuite)
                     # the suites at the top of our list our more often 'meta'
                     # suites that contains graphs from various suites. To keep
                     # the graphs that are logically related next to each other
-                    # we push this graph to the end of the list 
+                    # we push this graph to the end of the list
                     tempGraph = graphList.pop(graphnames.index(l))
                     graphList.append(tempGraph)
-                else: 
+                else:
                     graphList.append((l, [currSuite]))
             else:
                 # parse for suite name
-                ls = l[1:].split(': ')
-                if ls[0].strip() == 'suite':
+                ls = l[1:].split(": ")
+                if ls[0].strip() == "suite":
                     currSuite = ls[1].rstrip()
                     graphInfo.suites.append(currSuite)
                     numSuites += 1
                     if verbose:
-                        sys.stdout.write('suite: %s\n'%(currSuite))
-  
-    # generate the graphs 
-    for graph in graphList: 
+                        sys.stdout.write("suite: %s\n" % (currSuite))
+
+    # generate the graphs
+    for graph in graphList:
         try:
             graphInfo.genGraphStuff(graph[0], graph[1])
             numGraphfiles += 1
-        except (CouldNotReadGraphFile):
+        except CouldNotReadGraphFile:
             pass  # do not increment numGraphfiles
         except (ValueError, IOError, OSError):
             print("Error generating graph", graph)
             raise
 
-
     # Copy the index.html and support css and js files
-    auxdir = os.path.dirname(os.path.realpath(__file__))+'/perf'
+    auxdir = os.path.dirname(os.path.realpath(__file__)) + "/perf"
     copiedAllFiles = True
     try:
-        shutil.copy(auxdir+'/index.html', outdir)
+        shutil.copy(auxdir + "/index.html", outdir)
     except IOError:
-        sys.stderr.write('WARNING: Could not copy index.html\n')
+        sys.stderr.write("WARNING: Could not copy index.html\n")
         copiedAllFiles = False
     try:
-        shutil.copy(auxdir+'/perfgraph.css', outdir)
+        shutil.copy(auxdir + "/perfgraph.css", outdir)
     except IOError:
-        sys.stderr.write('WARNING: Could not copy perfgraph.css\n')
+        sys.stderr.write("WARNING: Could not copy perfgraph.css\n")
         copiedAllFiles = False
     try:
-        shutil.copy(auxdir+'/perfgraph.js', outdir)
+        shutil.copy(auxdir + "/perfgraph.js", outdir)
     except IOError:
-        sys.stderr.write('WARNING: Could not copy perfgraph.js\n')
+        sys.stderr.write("WARNING: Could not copy perfgraph.js\n")
         copiedAllFiles = False
 
     graphInfo.finish()
 
-    sys.stdout.write('Read %d graph files in %d suites\n'%(numGraphfiles, numSuites))
+    sys.stdout.write(
+        "Read %d graph files in %d suites\n" % (numGraphfiles, numSuites)
+    )
 
     if copiedAllFiles:
-        with open(outdir + "/SUCCESS", 'w') as f:
+        with open(outdir + "/SUCCESS", "w") as f:
             # do nothing, we just want to create the file so we know that no
             # errors that we currently detect occurred and all the requires
             # files were copied over. This is used to see if we should sync the
             # files over to the website.
-            sys.stdout.write('Created SUCCESS file\n')
+            sys.stdout.write("Created SUCCESS file\n")
 
         #
         # recursively chmod the html/ directory for access via web servers
@@ -1131,20 +1357,36 @@ def main():
         #  - for directories, chmod go+r
         #
         for root, dirs, files in os.walk(outdir):
-            os.chmod(root, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+            os.chmod(
+                root,
+                stat.S_IRWXU
+                | stat.S_IRGRP
+                | stat.S_IXGRP
+                | stat.S_IROTH
+                | stat.S_IXOTH,
+            )
             for momo in dirs:
-                os.chmod(os.path.join(root, momo), stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+                os.chmod(
+                    os.path.join(root, momo),
+                    stat.S_IRWXU
+                    | stat.S_IRGRP
+                    | stat.S_IXGRP
+                    | stat.S_IROTH
+                    | stat.S_IXOTH,
+                )
             for momo in files:
-                os.chmod(os.path.join(root, momo), stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+                os.chmod(
+                    os.path.join(root, momo),
+                    stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH,
+                )
 
         if len(options.addfile) > 0:
-            for file in options.addfile.split(','):
+            for file in options.addfile.split(","):
                 shutil.copy(file, outdir)
-                sys.stdout.write('Copied %s into %s\n'%(file, outdir))
-
+                sys.stdout.write("Copied %s into %s\n" % (file, outdir))
 
     return 0
 
-if __name__ == '__main__':
-    sys.exit(main())
 
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/test/merge_junit_xmls.py
+++ b/util/test/merge_junit_xmls.py
@@ -9,6 +9,7 @@ import sys
 
 from junitparser import JUnitXml, TestCase, TestSuite
 
+
 def merge_junit_xmls(xml_files):
     if not xml_files:
         return
@@ -16,11 +17,13 @@ def merge_junit_xmls(xml_files):
     merged = sum((JUnitXml.fromfile(xml) for xml in xml_files), JUnitXml())
     merged.write(xml_files[0])
 
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('xml_files', nargs='+', help='JUnit XML files to merge')
+    parser.add_argument("xml_files", nargs="+", help="JUnit XML files to merge")
     args = parser.parse_args()
     merge_junit_xmls(args.xml_files)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/util/test/py3_compat.py
+++ b/util/test/py3_compat.py
@@ -15,27 +15,31 @@ import sys
 import os
 import errno
 
+
 def instance_or_none(val, val_type):
     return val is None or isinstance(val, val_type)
+
 
 def bytes_to_str(byte_string):
     if sys.version_info[0] >= 3 and not instance_or_none(byte_string, str):
         try:
-            return str(byte_string, 'utf-8')
+            return str(byte_string, "utf-8")
         except UnicodeDecodeError as e:
             pass
         return byte_string
     else:
         return byte_string
 
+
 def str_to_bytes(str_string):
     if sys.version_info[0] >= 3 and not instance_or_none(str_string, bytes):
-        return bytes(str_string, 'utf-8')
+        return bytes(str_string, "utf-8")
     else:
         return str_string
 
+
 def concat_streams(stdout, stderr):
-    """ Concats stderr to stdout. Returns str if both are utf-8 strings, bytes otherwise """
+    """Concats stderr to stdout. Returns str if both are utf-8 strings, bytes otherwise"""
     if sys.version_info[0] >= 3:
         str_stdout = bytes_to_str(stdout)
         str_stderr = bytes_to_str(stderr)
@@ -46,11 +50,12 @@ def concat_streams(stdout, stderr):
 
     return stdout + stderr
 
+
 class Py3CompatPopen(object):
-    """ Popen wrapper where communicate will convert input to bytes, and try to
-        convert output to str. Note that communicate() will try to stderr and
-        strerr to str independently (so you could end up with 1 being str and
-        the other being bytes)"""
+    """Popen wrapper where communicate will convert input to bytes, and try to
+    convert output to str. Note that communicate() will try to stderr and
+    strerr to str independently (so you could end up with 1 being str and
+    the other being bytes)"""
 
     def __init__(self, popen):
         self._popen = popen
@@ -70,6 +75,7 @@ def Popen(*args, **kwargs):
     p = subprocess.Popen(*args, **kwargs)
     return Py3CompatPopen(p)
 
+
 def makedirs(path, mode=0o777, exist_ok=False):
     if sys.version_info[0] >= 3:
         os.makedirs(path, mode, exist_ok)
@@ -78,6 +84,6 @@ def makedirs(path, mode=0o777, exist_ok=False):
             os.makedirs(path, mode)
         except OSError as e:
             if exist_ok and e.errno == errno.EEXIST:
-                pass # Ignore directory already existing error
+                pass  # Ignore directory already existing error
             else:
                 raise

--- a/util/test/re2_supports_valgrind.py
+++ b/util/test/re2_supports_valgrind.py
@@ -2,19 +2,25 @@
 import os
 import sys
 
-chplenv_dir = os.path.join(os.path.dirname(__file__), '..', 'chplenv')
+chplenv_dir = os.path.join(os.path.dirname(__file__), "..", "chplenv")
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 
 import chpl_home_utils
 import chpl_re2
 
+
 def get():
-    """ Detects if re2 was built with CHPL_RE2_VALGRIND_SUPPORT set by checking
-        for a sentinel file in the install dir """
+    """Detects if re2 was built with CHPL_RE2_VALGRIND_SUPPORT set by checking
+    for a sentinel file in the install dir"""
     third_party = chpl_home_utils.get_chpl_third_party()
     uniq_cfg_path = chpl_re2.get_uniq_cfg_path()
-    re2_valgrind = os.path.join(third_party, 're2', 'install',
-                                uniq_cfg_path, 'CHPL_RE2_VALGRIND_SUPPORT')
+    re2_valgrind = os.path.join(
+        third_party,
+        "re2",
+        "install",
+        uniq_cfg_path,
+        "CHPL_RE2_VALGRIND_SUPPORT",
+    )
     return os.path.exists(re2_valgrind)
 
 
@@ -23,5 +29,5 @@ def _main():
     sys.stdout.write("{0}\n".format(re2_supports_valgrind))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _main()

--- a/util/test/send_email.py
+++ b/util/test/send_email.py
@@ -20,18 +20,37 @@ try:
 except NameError:
     basestring = str
 
+
 def main():
     """Parse command line arguments and send email!"""
     args = _parse_args()
     _setup_logging(args.verbose)
     body = sys.stdin.read()
     # Send the email!
-    send_email(args.recipients, body, args.subject, args.header, args.sender, args.smtp_host,
-        args.smtp_user, args.smtp_password, args.smtp_password_file)
+    send_email(
+        args.recipients,
+        body,
+        args.subject,
+        args.header,
+        args.sender,
+        args.smtp_host,
+        args.smtp_user,
+        args.smtp_password,
+        args.smtp_password_file,
+    )
 
 
-def send_email(recipients, body, subject=None, headers=None, sender=None, smtp_host=None,
-        smtp_user=None, smtp_password=None, smtp_password_file=None):
+def send_email(
+    recipients,
+    body,
+    subject=None,
+    headers=None,
+    sender=None,
+    smtp_host=None,
+    smtp_user=None,
+    smtp_password=None,
+    smtp_password_file=None,
+):
     """Send email!
 
     :arg recipients: list of recipients. If only one, may be a string.
@@ -47,36 +66,45 @@ def send_email(recipients, body, subject=None, headers=None, sender=None, smtp_h
     if isinstance(recipients, basestring):
         recipients = [recipients]
     sender = sender or _default_sender()
-    subject = subject or ''
+    subject = subject or ""
     smtp_host = smtp_host or _default_smtp_host()
 
     msg = email.mime.text.MIMEText(body)
 
-    msg['Subject'] = subject
-    msg['From'] = sender
-    msg['To'] = ','.join(recipients)
+    msg["Subject"] = subject
+    msg["From"] = sender
+    msg["To"] = ",".join(recipients)
 
     if headers:
         for key, value in headers.items():
             msg[key] = value
 
-    if not os.environ.get('CHPL_TEST_NOMAIL', ''):
-        logging.debug('Opening connection to: {0}'.format(smtp_host))
+    if not os.environ.get("CHPL_TEST_NOMAIL", ""):
+        logging.debug("Opening connection to: {0}".format(smtp_host))
         with smtplib.SMTP(smtp_host) as smtp:
             if smtp_user:
-                logging.debug('Login with user={0}'.format(smtp_user))
+                logging.debug("Login with user={0}".format(smtp_user))
                 smtp.starttls()
-                smtp.login(smtp_user,
-                           _get_smtp_password(smtp_user, smtp_password,
-                                              smtp_password_file))
-            logging.info('Sending email to: {0} from: {1} subject: {2}'.format(
-                ','.join(recipients), sender, subject))
-            logging.debug('Email headers: {0}'.format(headers))
-            logging.debug('Email body length: {0}'.format(len(body)))
+                smtp.login(
+                    smtp_user,
+                    _get_smtp_password(
+                        smtp_user, smtp_password, smtp_password_file
+                    ),
+                )
+            logging.info(
+                "Sending email to: {0} from: {1} subject: {2}".format(
+                    ",".join(recipients), sender, subject
+                )
+            )
+            logging.debug("Email headers: {0}".format(headers))
+            logging.debug("Email body length: {0}".format(len(body)))
             smtp.sendmail(sender, recipients, msg.as_string())
     else:
-        logging.info('CHPL_TEST_NOMAIL: no email to: {0} from: {1} subject: {2}'.format(
-            ','.join(recipients), sender, subject))
+        logging.info(
+            "CHPL_TEST_NOMAIL: no email to: {0} from: {1} subject: {2}".format(
+                ",".join(recipients), sender, subject
+            )
+        )
 
 
 def _parse_headers(option, opt, value, parser, *args, **kwargs):
@@ -91,9 +119,9 @@ def _parse_headers(option, opt, value, parser, *args, **kwargs):
     value_dict = getattr(parser.values, option.dest, None) or {}
 
     # Split the value provided.
-    parsed_vals = value.split(',')
+    parsed_vals = value.split(",")
     for v in parsed_vals:
-        key, value = v.split('=')
+        key, value = v.split("=")
         value_dict[key] = value
 
     # Set the updated dict to the oiption value.
@@ -104,33 +132,42 @@ def _default_sender():
     """Return default sender address, which is <user>@<hostname> unless
     CHPL_UTIL_SMTP_SENDER is set in environment.
     """
-    return os.environ.get('CHPL_UTIL_SMTP_SENDER', '{0}@{1}'.format(getpass.getuser(), socket.getfqdn()))
+    return os.environ.get(
+        "CHPL_UTIL_SMTP_SENDER",
+        "{0}@{1}".format(getpass.getuser(), socket.getfqdn()),
+    )
+
 
 def _default_smtp_host():
     """Return default smtp host, which is localhost unless CHPL_UTIL_SMTP_HOST is
     set in environment.
     """
-    return os.environ.get('CHPL_UTIL_SMTP_HOST', 'localhost')
+    return os.environ.get("CHPL_UTIL_SMTP_HOST", "localhost")
+
 
 def _default_smtp_user():
-    """Return default smtp user from environment variable CHPL_UTIL_SMTP_USER.
-    """
-    return os.environ.get('CHPL_UTIL_SMTP_USER')
+    """Return default smtp user from environment variable CHPL_UTIL_SMTP_USER."""
+    return os.environ.get("CHPL_UTIL_SMTP_USER")
+
 
 def _default_smtp_password():
-    """Return default password for smtp user from environment variable CHPL_UTIL_SMTP_PASSWORD.
-    """
-    return os.environ.get('CHPL_UTIL_SMTP_PASSWORD')
+    """Return default password for smtp user from environment variable CHPL_UTIL_SMTP_PASSWORD."""
+    return os.environ.get("CHPL_UTIL_SMTP_PASSWORD")
+
 
 def _default_smtp_password_file():
-    """Return default password file for smtp user from env var CHPL_UTIL_SMTP_PASSWORD_FILE.
-    """
-    password_file = os.environ.get('CHPL_UTIL_SMTP_PASSWORD_FILE')
+    """Return default password file for smtp user from env var CHPL_UTIL_SMTP_PASSWORD_FILE."""
+    password_file = os.environ.get("CHPL_UTIL_SMTP_PASSWORD_FILE")
     if not password_file:
-        password_file = os.path.expanduser(os.path.join('~', '.ssh', 'chpl_util_smtp_password.txt'))
+        password_file = os.path.expanduser(
+            os.path.join("~", ".ssh", "chpl_util_smtp_password.txt")
+        )
     return password_file
 
-def _get_smtp_password(smtp_user=None, smtp_password=None, smtp_password_file=None):
+
+def _get_smtp_password(
+    smtp_user=None, smtp_password=None, smtp_password_file=None
+):
     """Return the smtp password based on available info.
 
     :arg smtp_user: smtp_user to login to smtp_host
@@ -139,90 +176,107 @@ def _get_smtp_password(smtp_user=None, smtp_password=None, smtp_password_file=No
     """
 
     if smtp_password:
-        logging.debug('Using --smtp-password')
+        logging.debug("Using --smtp-password")
         return smtp_password
 
     password = None
     if smtp_password_file:
-        logging.debug('Reading --smtp-password-file={0}'.format(smtp_password_file))
+        logging.debug(
+            "Reading --smtp-password-file={0}".format(smtp_password_file)
+        )
         if os.path.isfile(smtp_password_file):
-            with open(smtp_password_file, 'r') as fp:
+            with open(smtp_password_file, "r") as fp:
                 password = fp.readline(80)
         else:
-            raise ValueError('--smtp-password-file={0} not found'.format(smtp_password_file))
+            raise ValueError(
+                "--smtp-password-file={0} not found".format(smtp_password_file)
+            )
 
     if password:
-        logging.debug('Using password from file')
+        logging.debug("Using password from file")
         return password.strip()
     else:
-        raise ValueError('--smtp-user={0} requires valid --smtp-password or --smtp-password-file'.format(smtp_user))
+        raise ValueError(
+            "--smtp-user={0} requires valid --smtp-password or --smtp-password-file".format(
+                smtp_user
+            )
+        )
+
 
 def _parse_args():
     """Parse and return command line arguments."""
+
     class NoWrapHelpFormatter(optparse.IndentedHelpFormatter):
         """Help formatter that does not wrap the description text."""
 
         def _format_text(self, text):
             return text
 
-    show_default_text = lambda value: ' (default: %default)' if value else ''
-    hide_default_text = lambda value: ' (default: ********)' if value else ''
+    show_default_text = lambda value: " (default: %default)" if value else ""
+    hide_default_text = lambda value: " (default: ********)" if value else ""
 
     parser = optparse.OptionParser(
-        usage='usage: %prog [options] recipient_email [...]',
+        usage="usage: %prog [options] recipient_email [...]",
         description=__doc__,
-        formatter=NoWrapHelpFormatter()
+        formatter=NoWrapHelpFormatter(),
     )
 
     parser.add_option(
-        '-v', '--verbose',
-        action='store_true',
-        help='Verbose output.'
+        "-v", "--verbose", action="store_true", help="Verbose output."
     )
 
-    mail_group = optparse.OptionGroup(parser, 'Mail Options')
+    mail_group = optparse.OptionGroup(parser, "Mail Options")
 
     mail_group.add_option(
-        '-s', '--subject',
-        default=None,
-        help='Email subject.'
+        "-s", "--subject", default=None, help="Email subject."
     )
     mail_group.add_option(
-        '-H', '--header',
-        action='callback', type='string',
+        "-H",
+        "--header",
+        action="callback",
+        type="string",
         callback=_parse_headers,
-        help=('Email header(s) of form NAME=VALUE. '
-              'Specify more than one with comma delimited list.')
+        help=(
+            "Email header(s) of form NAME=VALUE. "
+            "Specify more than one with comma delimited list."
+        ),
     )
     mail_group.add_option(
-        '-S', '--sender',
-        metavar='CHPL_UTIL_SMTP_SENDER',
+        "-S",
+        "--sender",
+        metavar="CHPL_UTIL_SMTP_SENDER",
         default=_default_sender(),
-        help='Sender email address. (default: %default)'
+        help="Sender email address. (default: %default)",
     )
     mail_group.add_option(
-        '--smtp-host',
-        metavar='CHPL_UTIL_SMTP_HOST',
+        "--smtp-host",
+        metavar="CHPL_UTIL_SMTP_HOST",
         default=_default_smtp_host(),
-        help='SMTP host to use when sending email. (default: %default)'
+        help="SMTP host to use when sending email. (default: %default)",
     )
     mail_group.add_option(
-        '-u', '--smtp-user', metavar='CHPL_UTIL_SMTP_USER',
+        "-u",
+        "--smtp-user",
+        metavar="CHPL_UTIL_SMTP_USER",
         default=_default_smtp_user(),
-        help='Optional user for SMTP login. Also requests TLS connection.' +
-            show_default_text(_default_smtp_user())
+        help="Optional user for SMTP login. Also requests TLS connection."
+        + show_default_text(_default_smtp_user()),
     )
     mail_group.add_option(
-        '-p', '--smtp-password', metavar='CHPL_UTIL_SMTP_PASSWORD',
+        "-p",
+        "--smtp-password",
+        metavar="CHPL_UTIL_SMTP_PASSWORD",
         default=_default_smtp_password(),
-        help='Password for --smtp-user.' +
-            hide_default_text(_default_smtp_password())
+        help="Password for --smtp-user."
+        + hide_default_text(_default_smtp_password()),
     )
     mail_group.add_option(
-        '-P', '--smtp-password-file', metavar='CHPL_UTIL_SMTP_PASSWORD_FILE',
+        "-P",
+        "--smtp-password-file",
+        metavar="CHPL_UTIL_SMTP_PASSWORD_FILE",
         default=_default_smtp_password_file(),
-        help='Path to a file containing the password for --smtp-user.' +
-            show_default_text(_default_smtp_password_file())
+        help="Path to a file containing the password for --smtp-user."
+        + show_default_text(_default_smtp_password_file()),
     )
 
     parser.add_option_group(mail_group)
@@ -241,10 +295,11 @@ def _setup_logging(verbose=False):
     :arg verbose: When True, set log level to DEBUG.
     """
     log_level = logging.DEBUG if verbose else logging.WARN
-    logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s',
-                        level=log_level)
-    logging.debug('Verbose output enabled.')
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)s] %(message)s", level=log_level
+    )
+    logging.debug("Verbose output enabled.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -22,9 +22,9 @@ import time
 
 # need to be able to find the util and chplenv dir even when start_test
 # doesn't live in $CHPL_HOME/util (such as for the release tarball)
-util_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'util')
-chplenv_dir = os.path.join(util_dir, 'chplenv')
-config_dir = os.path.join(util_dir, 'config')
+util_dir = os.path.join(os.path.dirname(__file__), "..", "..", "util")
+chplenv_dir = os.path.join(util_dir, "chplenv")
+config_dir = os.path.join(util_dir, "config")
 sys.path.insert(0, os.path.abspath(util_dir))
 sys.path.insert(0, os.path.abspath(chplenv_dir))
 sys.path.insert(0, os.path.abspath(config_dir))
@@ -34,6 +34,7 @@ sys.path.insert(0, os.path.abspath(config_dir))
 # because the test venv is built inside of CHPL_HOME.
 # We do this so tests/prediffs can use the system python instead of the venv
 import fixpath
+
 fixpath.update_path_env()
 
 from chplenv import *
@@ -44,10 +45,12 @@ import re2_supports_valgrind
 import check_perf_graphs
 
 import argparse
+
 try:
     import argcomplete
 except ImportError:
     argcomplete = None
+
 
 # PROGRAM ENTRY POINT
 def main():
@@ -81,13 +84,14 @@ def run_tests(tests):
     dirs = []
     had_invalid_file = False
     for i in tests:
-        if os.path.isdir(i): # a directory (also get absolute path)
+        if os.path.isdir(i):  # a directory (also get absolute path)
             dirs.append(os.path.abspath(i))
-        elif os.path.isfile(i): # a file
+        elif os.path.isfile(i):  # a file
             files.append(os.path.abspath(i))
         else:
-            logger.write("[Error: {0} is not a valid file or directory]"
-                    .format(i))
+            logger.write(
+                "[Error: {0} is not a valid file or directory]".format(i)
+            )
             had_invalid_file = True
 
     if had_invalid_file and len(files) == 0 and len(dirs) == 0:
@@ -96,13 +100,13 @@ def run_tests(tests):
     # set up
     set_up_environment()
     set_up_general()
-    set_up_performance_testing_A() # A and B are separate in order to keep
-                                   # output the same from old start_test
+    set_up_performance_testing_A()  # A and B are separate in order to keep
+    # output the same from old start_test
     set_up_executables()
     set_up_performance_testing_B()
 
     # autogenerate tests from spec if no tests were given
-    if len(files) == 0 and len(dirs) == 0: # no tests specified
+    if len(files) == 0 and len(dirs) == 0:  # no tests specified
         auto_generate_tests()
         if os.getcwd() == home:
             dirs = [test_dir]
@@ -114,11 +118,19 @@ def run_tests(tests):
     if args.recurse:
         logger.write('[directories: "{0}"]'.format(" ".join(dirs)))
     else:
-        logger.write('[directories: (nonrecursive): "{0}"]'
-                .format(" ".join(dirs)))
+        logger.write(
+            '[directories: (nonrecursive): "{0}"]'.format(" ".join(dirs))
+        )
 
     # check for duplicate .graph and .dat files
-    check_perf_graphs.check_for_duplicates(logger, finish, test_dir, args.perflabel, args.performance, args.gen_graphs or args.comp_performance)
+    check_perf_graphs.check_for_duplicates(
+        logger,
+        finish,
+        test_dir,
+        args.perflabel,
+        args.performance,
+        args.gen_graphs or args.comp_performance,
+    )
 
     # print out Chapel environment
     print_chapel_environment()
@@ -169,6 +181,7 @@ def run_tests(tests):
 
 # ESCAPE ROUTINES AND CLEAN-UP
 
+
 def finish():
     # summarize
     if not args.clean_only:
@@ -196,11 +209,12 @@ def finish():
 
 # MAIN ROUTINES AND TESTING
 
+
 def test_file(test):
     path_to_test = os.path.relpath(test)
     test_name = os.path.basename(test)
 
-    with cd(os.path.dirname(test)): # cd into dir, and cd out later
+    with cd(os.path.dirname(test)):  # cd into dir, and cd out later
         # clean executables, etc
         logger.write()
         logger.write("[Cleaning file {0}]".format(test))
@@ -214,8 +228,11 @@ def test_file(test):
 
             # check for errors:
             if error != 0:
-                logger.write("[Error running sub_test (code {1}) for {0}]"
-                        .format(path_to_test, error))
+                logger.write(
+                    "[Error running sub_test (code {1}) for {0}]".format(
+                        path_to_test, error
+                    )
+                )
 
             if args.progress:
                 sys.stderr.write("[done]\n")
@@ -232,8 +249,9 @@ def test_directory(test, test_type):
     # recurse through directory
     for root, dirs, files in os.walk(test):
         if not os.access(root, os.X_OK):
-            logger.write("[Warning: Cannot cd into {0} skipping directory]"
-                    .format(root))
+            logger.write(
+                "[Warning: Cannot cd into {0} skipping directory]".format(root)
+            )
             continue
         else:
             dir = os.path.abspath(root)
@@ -256,7 +274,7 @@ def test_directory(test, test_type):
 
         # ignore skipifs for --clean-only run
         if not args.clean_only:
-            with cd(dir): # cd into dir, and cd out later
+            with cd(dir):  # cd into dir, and cd out later
                 # SKIP IF IMPLEMENTATIONS
                 test_env = os.path.join(util_dir, "test", "testEnv")
 
@@ -268,8 +286,9 @@ def test_directory(test, test_type):
 
                 # Skip this directory and child directories
                 # if there is a <dir>.notest file
-                notest_file_name = os.path.join(root, "..",
-                        "{0}.notest".format(os.path.basename(root)))
+                notest_file_name = os.path.join(
+                    root, "..", "{0}.notest".format(os.path.basename(root))
+                )
                 notest_file_name = os.path.normpath(notest_file_name)
                 if os.path.isfile(notest_file_name):
                     del dirs[:]
@@ -278,17 +297,23 @@ def test_directory(test, test_type):
                 # Skip this directory and child directories
                 # if there is a <dir>.skipif file returning true
                 prune_if = False
-                skip_file_name = os.path.join(root, "..",
-                        "{0}.skipif".format(os.path.basename(root)))
+                skip_file_name = os.path.join(
+                    root, "..", "{0}.skipif".format(os.path.basename(root))
+                )
                 skip_file_name = os.path.normpath(skip_file_name)
                 if os.path.isfile(skip_file_name):
                     try:
-                        prune_if = process_skipif_output(run_command([test_env, skip_file_name]).strip())
+                        prune_if = process_skipif_output(
+                            run_command([test_env, skip_file_name]).strip()
+                        )
                         # check output and skip if true
                         if prune_if == "1" or prune_if == "True":
-                            logger.write("[Skipping directory and children bas"
-                                    "ed on .skipif environment settings in {0}]"
-                                    .format(skip_file_name))
+                            logger.write(
+                                "[Skipping directory and children bas"
+                                "ed on .skipif environment settings in {0}]".format(
+                                    skip_file_name
+                                )
+                            )
                             del dirs[:]
                             continue
                     except:
@@ -299,12 +324,16 @@ def test_directory(test, test_type):
                 skip_test = False
                 if os.path.isfile("SKIPIF"):
                     try:
-                        logger.write('[Checking SKIPIF]')
-                        skip_test = process_skipif_output(run_command([test_env, "SKIPIF"]).strip())
+                        logger.write("[Checking SKIPIF]")
+                        skip_test = process_skipif_output(
+                            run_command([test_env, "SKIPIF"]).strip()
+                        )
                         # check output and skip if true
                         if skip_test == "1" or skip_test == "True":
-                            logger.write("[Skipping directory based on SKIPIF "
-                                    "environment settings]")
+                            logger.write(
+                                "[Skipping directory based on SKIPIF "
+                                "environment settings]"
+                            )
                             continue
                     except:
                         logger.write("[Warning: SKIPIF error.]")
@@ -321,8 +350,15 @@ def test_directory(test, test_type):
             are_tests = False
             for f in files:
                 if not test_type == "performance":
-                    if f.endswith((".chpl", ".test.c", ".ml-test.c",
-                                   ".test.cpp", ".ml-test.cpp")) :
+                    if f.endswith(
+                        (
+                            ".chpl",
+                            ".test.c",
+                            ".ml-test.c",
+                            ".test.cpp",
+                            ".ml-test.cpp",
+                        )
+                    ):
                         are_tests = True
                         break
                     # this directory may generate test files
@@ -337,7 +373,9 @@ def test_directory(test, test_type):
             # don't run local 'sub_test's on --performance or --gen-graphs runs
             run_local_sub_test = False
             if test_type == "run":
-                run_local_sub_test = os.access(os.path.join(dir, "sub_test"), os.X_OK)
+                run_local_sub_test = os.access(
+                    os.path.join(dir, "sub_test"), os.X_OK
+                )
 
             # check a lot of stuff before continuing
             if are_tests or run_local_sub_test:
@@ -351,8 +389,11 @@ def test_directory(test, test_type):
                         error = run_sub_test()
                         # check for errors:
                         if not error == 0:
-                            logger.write("[Error running sub_test (code {1}) in {0}]"
-                                    .format(root, error))
+                            logger.write(
+                                "[Error running sub_test (code {1}) in {0}]".format(
+                                    root, error
+                                )
+                            )
 
             # let user know no tests were found
             else:
@@ -382,14 +423,15 @@ def summarize():
         else:
             success_marker = r"\[Success matching"
     warning_marker = r"^\[Warning"
-    passing_suppressions_marker = ("{0}.*{1}"
-            .format(suppress_marker, success_marker))
+    passing_suppressions_marker = "{0}.*{1}".format(
+        suppress_marker, success_marker
+    )
     passing_futures_marker = "{0}.*{1}".format(future_marker, success_marker)
     success_marker = "^" + success_marker
     skip_stdin_redirect_marker = r"^\[Skipping test with .stdin input"
 
     # setup counts and blank strings to hold summaries
-    global failures # for exit codes later
+    global failures  # for exit codes later
     failures = 0
     successes = 0
     futures = 0
@@ -433,15 +475,20 @@ def summarize():
     summary += warning_summary
 
     if skip_stdin_redirects > 0:
-        logger.write("[Skipped {0} tests with .stdin input]"
-                .format(skip_stdin_redirects))
+        logger.write(
+            "[Skipped {0} tests with .stdin input]".format(skip_stdin_redirects)
+        )
 
-    summary += ("[Summary: #Successes = {0} | #Failures = {1} | #Futures = {2} "
-            "| #Warnings = {3} ]\n"
-            .format(successes, failures, futures, warnings))
-    summary += ("[Summary: #Passing Suppressions = {0} | "
-            "#Passing Futures = {1} ]\n"
-            .format(passing_suppressions, passing_futures))
+    summary += (
+        "[Summary: #Successes = {0} | #Failures = {1} | #Futures = {2} "
+        "| #Warnings = {3} ]\n".format(successes, failures, futures, warnings)
+    )
+    summary += (
+        "[Summary: #Passing Suppressions = {0} | "
+        "#Passing Futures = {1} ]\n".format(
+            passing_suppressions, passing_futures
+        )
+    )
     summary += "[END]\n"
 
     # log summary, and write it to its own .summary file
@@ -453,15 +500,17 @@ def summarize():
 
     # Note: Log file & summary copied tmp_log_file to log_file in cleanup
 
+
 def clean(test=False):
     date_str = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 
     # clean executables, tmps, etc.
     sub_clean = os.path.join(util_dir, "test", "sub_clean")
     try:
-        if test: # single test
-            logger.write("[Starting {0} {1} {2}]"
-                    .format(sub_clean, test, date_str))
+        if test:  # single test
+            logger.write(
+                "[Starting {0} {1} {2}]".format(sub_clean, test, date_str)
+            )
             out = run_command([sub_clean, test])
         else:
             out = run_command([sub_clean])
@@ -476,7 +525,7 @@ def run_sub_test(test=False):
 
     # run test
     logger.write()
-    if test: # single test
+    if test:  # single test
         logger.write("[Working on file {0}]".format(os.path.relpath(test)))
         os.environ["CHPL_ONETEST"] = os.path.basename(test)
 
@@ -501,7 +550,7 @@ def generate_graphs(test=False):
         remove_dot = remove_dot.replace(".ml-test.c", "")
         remove_dot = remove_dot.replace(".test.cpp", "")
         remove_dot = remove_dot.replace(".test.c", "")
-        graph_files = [(remove_dot + ".graph")]
+        graph_files = [remove_dot + ".graph"]
         # exit if it isn't actually a file
         if not os.path.isfile(graph_files[0]):
             return
@@ -512,8 +561,11 @@ def generate_graphs(test=False):
         if len(graph_files) == 0 or os.environ.get("CHPL_TEST_PERF_DIR"):
             return
 
-    logger.write("[Executing genGraphs for graph_files in {0} in {1}]"
-            .format(basedir, perf_html_dir))
+    logger.write(
+        "[Executing genGraphs for graph_files in {0} in {1}]".format(
+            basedir, perf_html_dir
+        )
+    )
 
     cmd = [create_graphs]
     cmd += args.gen_graph_opts.split(" ")
@@ -524,11 +576,17 @@ def generate_graphs(test=False):
     status = run_and_log(cmd)
 
     if status == 0:
-        logger.write("[Success generating graphs for graph_files in {0} in {1}]"
-                .format(basedir, perf_html_dir))
+        logger.write(
+            "[Success generating graphs for graph_files in {0} in {1}]".format(
+                basedir, perf_html_dir
+            )
+        )
     else:
-        logger.write("[Error generating graphs for graph_files in {0} in {1}]"
-                .format(basedir, perf_html_dir))
+        logger.write(
+            "[Error generating graphs for graph_files in {0} in {1}]".format(
+                basedir, perf_html_dir
+            )
+        )
 
 
 def compiler_performance():
@@ -540,9 +598,17 @@ def compiler_performance():
     # combine smaller .dat files
     try:
         logger.write("[Combining dat files now]")
-        out = run_command([combine_comp_perf, "--tempDatDir",
-            temp_dat_dir,"--elapsedTestTime", str(elapsed), "--outDir",
-            comp_perf_dir])
+        out = run_command(
+            [
+                combine_comp_perf,
+                "--tempDatDir",
+                temp_dat_dir,
+                "--elapsedTestTime",
+                str(elapsed),
+                "--outDir",
+                comp_perf_dir,
+            ]
+        )
         logger.write(out)
         logger.write("[Success combining compiler performance dat files]")
     except:
@@ -554,54 +620,91 @@ def compiler_performance():
 
     cmd = [create_graphs]
     cmd += args.gen_graph_opts.split(" ")
-    cmd += ["-p", comp_perf_dir, "-o", comp_perf_html_dir, "-a", title, "-n",
-            compperf_test_name]
+    cmd += [
+        "-p",
+        comp_perf_dir,
+        "-o",
+        comp_perf_html_dir,
+        "-a",
+        title,
+        "-n",
+        compperf_test_name,
+    ]
     cmd += start_date_t.split(" ")
     cmd += ["-g", comp_graph_list, "-t", test_dir]
     cmd += "-m all:v,examples:v -x".split(" ")
     status = run_and_log(cmd)
     if status == 0:
-        logger.write("[Success generating compiler performance graphs from "
-                "{0} in {1}]".format(comp_graph_list, comp_perf_html_dir))
+        logger.write(
+            "[Success generating compiler performance graphs from "
+            "{0} in {1}]".format(comp_graph_list, comp_perf_html_dir)
+        )
     else:
-        logger.write("[Error generating compiler performance graphs from "
-            "{0} in {1}]".format(comp_graph_list, comp_perf_html_dir))
+        logger.write(
+            "[Error generating compiler performance graphs from "
+            "{0} in {1}]".format(comp_graph_list, comp_perf_html_dir)
+        )
 
     # delete temp files
     shutil.rmtree(temp_dat_dir)
 
 
 def generate_graph_files_graphs():
-    graphfiles_prefix = ''
+    graphfiles_prefix = ""
     if args.perflabel != "perf":
         graphfiles_prefix = args.perflabel.upper()
 
-    exec_graph_list = os.path.join(test_dir, "{0}GRAPHFILES".format(graphfiles_prefix))
+    exec_graph_list = os.path.join(
+        test_dir, "{0}GRAPHFILES".format(graphfiles_prefix)
+    )
 
-    logger.write("[Executing genGraphs for {0} in {1}]"
-            .format(exec_graph_list, perf_html_dir))
+    logger.write(
+        "[Executing genGraphs for {0} in {1}]".format(
+            exec_graph_list, perf_html_dir
+        )
+    )
 
     cmd = [create_graphs]
     cmd += args.gen_graph_opts.split(" ")
-    cmd += ["-p", perf_dir, "-o", perf_html_dir, "-t", test_dir, "-n",
-            perf_test_name]
+    cmd += [
+        "-p",
+        perf_dir,
+        "-o",
+        perf_html_dir,
+        "-t",
+        test_dir,
+        "-n",
+        perf_test_name,
+    ]
     cmd += start_date_t.split(" ")
-    cmd += [args.graphs_disp_range, "-r", args.graphs_gen_default, "-g",
-        exec_graph_list]
+    cmd += [
+        args.graphs_disp_range,
+        "-r",
+        args.graphs_gen_default,
+        "-g",
+        exec_graph_list,
+    ]
     status = run_and_log(cmd)
 
     if status == 0:
-        logger.write("[Success generating graphs from {0} in {1}]"
-                .format(exec_graph_list, perf_html_dir))
+        logger.write(
+            "[Success generating graphs from {0} in {1}]".format(
+                exec_graph_list, perf_html_dir
+            )
+        )
     else:
-        logger.write("[Error generating graphs from {0} in {1}]"
-                .format(exec_graph_list, perf_html_dir))
+        logger.write(
+            "[Error generating graphs from {0} in {1}]".format(
+                exec_graph_list, perf_html_dir
+            )
+        )
 
 
 # SET UP ROUTINES
 
+
 def check_environment():
-    if "CHPL_DEVELOPER" in os.environ: # unset CHPL_DEVELOPER
+    if "CHPL_DEVELOPER" in os.environ:  # unset CHPL_DEVELOPER
         del os.environ["CHPL_DEVELOPER"]
 
     if "CHPL_EXE_NAME" in os.environ:  # unset CHPL_EXE_NAME
@@ -636,6 +739,7 @@ def check_environment():
             print("Error: Cannot find {0}.".format(util_dir))
             sys.exit(1)
 
+
 def check_environment_with_args():
     # find test dir and check for access
     global test_dir, auto_gen_spec_tests
@@ -646,16 +750,25 @@ def check_environment_with_args():
         test_dir = str(args.test_root_dir)
     else:
         test_dir = os.path.join(home, "test")
-        if (not os.access(test_dir, os.F_OK) or not os.access(test_dir, os.W_OK)
-            or not os.access(test_dir, os.X_OK)):
+        if (
+            not os.access(test_dir, os.F_OK)
+            or not os.access(test_dir, os.W_OK)
+            or not os.access(test_dir, os.X_OK)
+        ):
             test_dir = os.path.join(home, "examples")
             auto_gen_spec_tests = False
-            if (not os.access(test_dir, os.F_OK) or not os.access(test_dir, os.W_OK)
-                or not os.access(test_dir, os.X_OK)):
+            if (
+                not os.access(test_dir, os.F_OK)
+                or not os.access(test_dir, os.W_OK)
+                or not os.access(test_dir, os.X_OK)
+            ):
                 test_dir = os.getcwd()
 
-    if (not os.access(test_dir, os.F_OK) or not os.access(test_dir, os.W_OK)
-        or not os.access(test_dir, os.X_OK)):
+    if (
+        not os.access(test_dir, os.F_OK)
+        or not os.access(test_dir, os.W_OK)
+        or not os.access(test_dir, os.X_OK)
+    ):
         print("Cannot write to test directory {0}".format(test_dir))
         sys.exit(-1)
 
@@ -685,10 +798,15 @@ def check_environment_with_args():
 
     global log_file
     global tmp_log_file
-    log_file = os.path.join(logs_dir, "{0}.{1}.log"
-            .format(getpass.getuser(), tgt_platform))
-    tmp_log_file = os.path.join(logs_dir, "{0}.{1}.pid{2}.log"
-            .format(getpass.getuser(), tgt_platform, os.getpid()))
+    log_file = os.path.join(
+        logs_dir, "{0}.{1}.log".format(getpass.getuser(), tgt_platform)
+    )
+    tmp_log_file = os.path.join(
+        logs_dir,
+        "{0}.{1}.pid{2}.log".format(
+            getpass.getuser(), tgt_platform, os.getpid()
+        ),
+    )
 
 
 # Strip quotes that might have been added by preprocess_options()
@@ -697,6 +815,7 @@ def strip_preprocessing(arg):
         return arg[1:-1]
     else:
         return arg
+
 
 def set_up_tmpdir():
     # create temporary directory
@@ -737,12 +856,19 @@ def set_up_environment():
         memleaksfile = os.path.abspath(args.mem_leaks_log)
         args.execopts += " --memLeaksLog=" + memleaksfile
         if os.path.isfile(memleaksfile):
-            logger.write("[Removing memory leaks log file with duplicate name {0}]"
-                         .format(memleaksfile))
+            logger.write(
+                "[Removing memory leaks log file with duplicate name {0}]".format(
+                    memleaksfile
+                )
+            )
             os.remove(memleaksfile)
 
     # performance (linking flags to each other)
-    if args.performance or args.performance_description or args.perflabel != "perf":
+    if (
+        args.performance
+        or args.performance_description
+        or args.perflabel != "perf"
+    ):
         args.performance = True
         args.gen_graphs = True
         args.compopts = "--fast " + args.compopts
@@ -801,8 +927,11 @@ def set_up_logger():
 
     log_file_dir = os.path.dirname(log_file)
     if not os.access(log_file_dir, os.X_OK):
-        print("[Permission denied for log_file directory: {0}]"
-                .format(log_file_dir))
+        print(
+            "[Permission denied for log_file directory: {0}]".format(
+                log_file_dir
+            )
+        )
         sys.exit(1)
 
     # Remove log file and summary file
@@ -823,8 +952,11 @@ def set_up_general():
     if args.comp_performance:
         start_time = int(time.time())
 
-    logger.write("[Starting Chapel regression tests - {0}]"
-            .format(time.strftime("%y%m%d.%H%M%S")))
+    logger.write(
+        "[Starting Chapel regression tests - {0}]".format(
+            time.strftime("%y%m%d.%H%M%S")
+        )
+    )
 
     branch = run_git_command(["rev-parse", "--abbrev-ref", "HEAD"])
     sha = run_git_command(["rev-parse", "--short", "HEAD"])
@@ -832,11 +964,13 @@ def set_up_general():
 
     # check to see if we are in subdir of CHPL_HOME
     if args.chpl_home_warn:
-        norm_cwd  = os.path.normpath(os.path.realpath(os.getcwd()))
+        norm_cwd = os.path.normpath(os.path.realpath(os.getcwd()))
         norm_home = os.path.normpath(os.path.realpath(home))
         if norm_cwd.find(norm_home) < 0:
-            print ("[Warning: start_test not invoked from a subdirectory of "
-                    "$CHPL_HOME]")
+            print(
+                "[Warning: start_test not invoked from a subdirectory of "
+                "$CHPL_HOME]"
+            )
 
     # log some messages
     logger.write('[starting directory: "{0}"]'.format(os.getcwd()))
@@ -855,7 +989,6 @@ def set_up_general():
         except:
             logger.write("[Error: Could not find valgrind.]")
             finish()
-
 
         # get first line of output
         try:
@@ -880,7 +1013,9 @@ def set_up_general():
         if not "CHPL_RT_NUM_THREADS_PER_LOCALE" in os.environ:
             os.environ["CHPL_RT_NUM_THREADS_PER_LOCALE"] = "450"
         else:
-            logger.write("[Warning: Deadlock is possible since you set CHPL_RT_NUM_THREADS_PER_LOCALE]")
+            logger.write(
+                "[Warning: Deadlock is possible since you set CHPL_RT_NUM_THREADS_PER_LOCALE]"
+            )
 
         # Squash the warning about the potential for deadlock when setting
         # the number of threads, or all tests will fail with that warning
@@ -889,21 +1024,27 @@ def set_up_general():
         # Additionally, fail with an error if valgrind testing is running without
         # tasks=fifo, mem=cstdlib, or with re2 built w/o valgrind support
         if chpl_tasks.get() != "fifo":
-            logger.write("[Error: valgrind requires tasks=fifo - try quickstart]")
+            logger.write(
+                "[Error: valgrind requires tasks=fifo - try quickstart]"
+            )
             finish()
-        if chpl_mem.get('target') != "cstdlib":
-            logger.write("[Error: valgrind requires mem=cstdlib - try quickstart]")
+        if chpl_mem.get("target") != "cstdlib":
+            logger.write(
+                "[Error: valgrind requires mem=cstdlib - try quickstart]"
+            )
             finish()
-        if chpl_re2.get() != 'none' and not re2_supports_valgrind.get():
-            logger.write("[Error: valgrind requires re2=none or re2 built with CHPL_RE2_VALGRIND_SUPPORT]")
+        if chpl_re2.get() != "none" and not re2_supports_valgrind.get():
+            logger.write(
+                "[Error: valgrind requires re2=none or re2 built with CHPL_RE2_VALGRIND_SUPPORT]"
+            )
             finish()
-
 
     # compiler
     global compiler
     if not args.compiler:
-        compiler = os.path.expandvars("$CHPL_HOME/bin/{0}/chpl"
-                .format(host_bin_subdir))
+        compiler = os.path.expandvars(
+            "$CHPL_HOME/bin/{0}/chpl".format(host_bin_subdir)
+        )
     else:
         compiler = args.compiler
 
@@ -927,8 +1068,9 @@ def set_up_performance_testing_A():
         logger.write("[compiler performance tests: OFF]")
 
     # this is here and not in setupexecutables for legacy compatibility reasons
-    logger.write("[number of trials: {0}]"
-            .format(os.environ["CHPL_TEST_NUM_TRIALS"]))
+    logger.write(
+        "[number of trials: {0}]".format(os.environ["CHPL_TEST_NUM_TRIALS"])
+    )
 
     # graphs
     if args.gen_graphs:
@@ -939,8 +1081,11 @@ def set_up_performance_testing_A():
         else:
             logger.write("[performance graph ranges: OFF]")
             args.graphs_disp_range = "--no-bounds"
-        logger.write("[performance graph data reduction: {0}]"
-                .format(args.graphs_gen_default))
+        logger.write(
+            "[performance graph data reduction: {0}]".format(
+                args.graphs_gen_default
+            )
+        )
     else:
         logger.write("[performance graph generation: OFF]")
 
@@ -951,23 +1096,26 @@ def set_up_performance_testing_B():
         # set global variables for later access and use
         global perf_dir, perf_html_dir, perf_test_name
 
-        perf_test_name = os.environ.get('CHPL_TEST_PERF_CONFIG_NAME',
-                                        platform.node().split(".")[0].lower())
+        perf_test_name = os.environ.get(
+            "CHPL_TEST_PERF_CONFIG_NAME", platform.node().split(".")[0].lower()
+        )
 
         if not os.environ.get("CHPL_TEST_PERF_DIR"):
-            perf_dir = os.path.expandvars("$CHPL_HOME/test/perfdat/"
-                    + perf_test_name)
+            perf_dir = os.path.expandvars(
+                "$CHPL_HOME/test/perfdat/" + perf_test_name
+            )
             os.environ["CHPL_TEST_PERF_DIR"] = perf_dir
-            logger.write("[Warning: CHPL_TEST_PERF_DIR must be set for gener"
-                    "ating performance graphs, using default {0}]"
-                    .format(perf_dir))
+            logger.write(
+                "[Warning: CHPL_TEST_PERF_DIR must be set for gener"
+                "ating performance graphs, using default {0}]".format(perf_dir)
+            )
         else:
             perf_dir = os.environ["CHPL_TEST_PERF_DIR"]
 
         perf_desc = args.performance_description
         perf_html_dir = os.path.join(perf_dir, perf_desc, "html")
 
-        if (perf_desc != "" and perf_desc != "default"):
+        if perf_desc != "" and perf_desc != "default":
             os.environ["CHPL_TEST_PERF_DESCRIPTION"] = perf_desc
 
     global perf_keys
@@ -979,29 +1127,38 @@ def set_up_performance_testing_B():
         global compperf_test_name, comp_perf_dir, temp_dat_dir, comp_perf_html_dir
         global combine_comp_perf
 
-        compperf_test_name = os.environ.get('CHPL_TEST_PERF_CONFIG_NAME',
-                                            platform.node().split(".")[0].lower())
+        compperf_test_name = os.environ.get(
+            "CHPL_TEST_PERF_CONFIG_NAME", platform.node().split(".")[0].lower()
+        )
 
         if "CHPL_TEST_COMP_PERF_DIR" in os.environ:
             comp_perf_dir = os.environ["CHPL_TEST_COMP_PERF_DIR"]
         else:
-            comp_perf_dir = os.path.join(home, "test", "compperfdat",
-                                         compperf_test_name)
-            logger.write("[Warning: CHPL_COMP_TEST_PERF DIR must be set for "
-                    "generating compiler performance graphs, using default {0}]"
-                    .format(comp_perf_dir))
+            comp_perf_dir = os.path.join(
+                home, "test", "compperfdat", compperf_test_name
+            )
+            logger.write(
+                "[Warning: CHPL_COMP_TEST_PERF DIR must be set for "
+                "generating compiler performance graphs, using default {0}]".format(
+                    comp_perf_dir
+                )
+            )
 
         compperf_test_name += args.comp_performance_description
 
-        temp_dat_dir = os.path.join(chpl_test_tmp_dir, "tempCompPerfDatFiles", "")
+        temp_dat_dir = os.path.join(
+            chpl_test_tmp_dir, "tempCompPerfDatFiles", ""
+        )
         os.environ["CHPL_TEST_COMP_PERF_TEMP_DAT_DIR"] = temp_dat_dir
-        #remove it if it wasn't cleaned up last time
+        # remove it if it wasn't cleaned up last time
         if os.path.isdir(temp_dat_dir):
             shutil.rmtree(temp_dat_dir)
 
         comp_perf_html_dir = os.path.join(comp_perf_dir, "html")
 
-        combine_comp_perf = os.path.join(util_dir, "test", "combineCompPerfData")
+        combine_comp_perf = os.path.join(
+            util_dir, "test", "combineCompPerfData"
+        )
 
     # for any performance testing
     if args.performance or args.comp_performance or args.gen_graphs:
@@ -1040,19 +1197,31 @@ def set_up_performance_testing_B():
                 pass
 
         sha_dat_file_name = "perfSha"
-        sha_dat_file_path = os.path.join(dat_dir, "{0}.dat"
-                .format(sha_dat_file_name))
+        sha_dat_file_path = os.path.join(
+            dat_dir, "{0}.dat".format(sha_dat_file_name)
+        )
 
-        logger.write("[Saving current git sha to {0}]"
-                .format(sha_dat_file_path))
+        logger.write(
+            "[Saving current git sha to {0}]".format(sha_dat_file_path)
+        )
         try:
             cmd = os.path.join(util_dir, "test", "computePerfStats")
-            out = run_command([cmd, sha_dat_file_name, dat_dir,
-                sha_pef_keys_name, sha_out_name])
+            out = run_command(
+                [
+                    cmd,
+                    sha_dat_file_name,
+                    dat_dir,
+                    sha_pef_keys_name,
+                    sha_out_name,
+                ]
+            )
             logger.write(out)
         except:
-            logger.write("[Error: Failed to save current sha to {0}]"
-                    .format(sha_dat_file_path))
+            logger.write(
+                "[Error: Failed to save current sha to {0}]".format(
+                    sha_dat_file_path
+                )
+            )
 
 
 def set_up_executables():
@@ -1063,22 +1232,23 @@ def set_up_executables():
 
         logger.write('[compiler: "{0}"]'.format(compiler))
     else:
-        logger.write("[Error: Cannot find or execute compiler: {0}]"
-                .format(compiler))
+        logger.write(
+            "[Error: Cannot find or execute compiler: {0}]".format(compiler)
+        )
         finish()
 
     # log more options
     logger.write('[compopts: "{0}"]'.format(args.compopts))
-    os.environ['COMPOPTS'] = args.compopts
+    os.environ["COMPOPTS"] = args.compopts
 
     logger.write('[execopts: "{0}"]'.format(args.execopts))
-    os.environ['EXECOPTS'] = args.execopts
+    os.environ["EXECOPTS"] = args.execopts
 
     logger.write('[launchcmd: "{0}"]'.format(args.launch_cmd))
-    os.environ['LAUNCHCMD'] = os.path.expandvars(args.launch_cmd)
+    os.environ["LAUNCHCMD"] = os.path.expandvars(args.launch_cmd)
 
     comm = chpl_comm.get()
-    network_atomics = chpl_atomics.get('network')
+    network_atomics = chpl_atomics.get("network")
     comm_substrate = chpl_comm_substrate.get()
     launcher = chpl_launcher.get()
     locale_model = chpl_locale_model.get()
@@ -1098,16 +1268,23 @@ def set_up_executables():
     os.environ["CHPL_TASKS"] = chpl_tasks.get()
 
     # skip stdin tests for most custom launchers, except for amdprun and slurm
-    if (launcher != "none" and launcher != "amudprun" and launcher !=
-        "slurm-srun" and not os.environ.get("CHPL_NO_STDIN_REDIRECT")
-        and not os.environ.get("CHPL_TEST_FORCE_STDIN_REDIRECT")):
-        print ("[Info: assuming stdin redirection is not supported, skipping "
-            "tests with stdin]")
+    if (
+        launcher != "none"
+        and launcher != "amudprun"
+        and launcher != "slurm-srun"
+        and not os.environ.get("CHPL_NO_STDIN_REDIRECT")
+        and not os.environ.get("CHPL_TEST_FORCE_STDIN_REDIRECT")
+    ):
+        print(
+            "[Info: assuming stdin redirection is not supported, skipping "
+            "tests with stdin]"
+        )
         os.environ["CHPL_NO_STDIN_REDIRECT"] = "true"
 
     # launcher timeout
-    if (not os.environ.get("CHPL_LAUNCHER_TIMEOUT")
-        and not os.environ.get("CHPL_TEST_DONT_SET_LAUNCHER_TIMEOUT")):
+    if not os.environ.get("CHPL_LAUNCHER_TIMEOUT") and not os.environ.get(
+        "CHPL_TEST_DONT_SET_LAUNCHER_TIMEOUT"
+    ):
         if "slurm" in launcher:
             os.environ["CHPL_LAUNCHER_TIMEOUT"] = "slurm"
         if "pbs" in launcher or "qsub" in launcher:
@@ -1135,7 +1312,9 @@ def set_up_executables():
         if comm != "none":
             os.environ["CHPL_TEST_MULTILOCALE_ONLY"] = "true"
         else:
-            logger.write("[Warning: Ignoring --multilocale-only for CHPL_COMM=none]")
+            logger.write(
+                "[Warning: Ignoring --multilocale-only for CHPL_COMM=none]"
+            )
 
     # pre-exec
     if args.preexec:
@@ -1145,11 +1324,13 @@ def set_up_executables():
                 preexec = os.path.abspath(preexec)
                 logger.write("[system-wide preexec: {0}]".format(preexec))
             else:
-                logger.write("[Error: Cannot find or execute system-wide preexec: "
-                        "{0}".format(preexec))
+                logger.write(
+                    "[Error: Cannot find or execute system-wide preexec: "
+                    "{0}".format(preexec)
+                )
                 finish()
             chpl_system_preexec.append(preexec)
-        os.environ["CHPL_SYSTEM_PREEXEC"] = ','.join(chpl_system_preexec)
+        os.environ["CHPL_SYSTEM_PREEXEC"] = ",".join(chpl_system_preexec)
 
     # pre-diff
     chpl_system_prediff = []
@@ -1159,8 +1340,10 @@ def set_up_executables():
                 prediff = os.path.abspath(prediff)
                 logger.write("[system-wide prediff: {0}]".format(prediff))
             else:
-                logger.write("[Error: Cannot find or execute system-wide prediff: "
-                        "{0}".format(prediff))
+                logger.write(
+                    "[Error: Cannot find or execute system-wide prediff: "
+                    "{0}".format(prediff)
+                )
                 finish()
             chpl_system_prediff.append(prediff)
     if "slurm" in launcher:
@@ -1168,12 +1351,12 @@ def set_up_executables():
         prediff_for_slurm = os.path.join(util_dir, "test", "prediff-for-slurm")
         if prediff_for_slurm not in chpl_system_prediff:
             chpl_system_prediff.append(prediff_for_slurm)
-    if 'lsf-' in launcher:
+    if "lsf-" in launcher:
         # With lsf-based launcher, auto-run prediff-for-lsf.
         prediff_for_lsf = os.path.join(util_dir, "test", "prediff-for-lsf")
         if prediff_for_lsf not in chpl_system_prediff:
             chpl_system_prediff.append(prediff_for_lsf)
-    if 'ucx' in comm_substrate:
+    if "ucx" in comm_substrate:
         # With ucx-based launcher, auto-run prediff-for-ucx.
         prediff_for_ucx = os.path.join(util_dir, "test", "prediff-for-ucx")
         if prediff_for_ucx not in chpl_system_prediff:
@@ -1181,13 +1364,14 @@ def set_up_executables():
 
     # TODO: remove this when
     # https://github.com/chapel-lang/chapel/issues/27262 is resolved
-    if 'darwin' == host_platform:
+    if "darwin" == host_platform:
         prediff_for_debug = os.path.join(util_dir, "test", "prediff-for-debug")
         if prediff_for_debug not in chpl_system_prediff:
             chpl_system_prediff.append(prediff_for_debug)
 
-    if ("qthreads" == chpl_tasks.get() and
-        "none" != chpl_sanitizers.get(flag="exe")):
+    if "qthreads" == chpl_tasks.get() and "none" != chpl_sanitizers.get(
+        flag="exe"
+    ):
         prediff_for_qthreads_asan = os.path.join(
             util_dir, "test", "prediff-for-qthreads-asan"
         )
@@ -1195,7 +1379,7 @@ def set_up_executables():
             chpl_system_prediff.append(prediff_for_qthreads_asan)
 
     if chpl_system_prediff:
-        os.environ["CHPL_SYSTEM_PREDIFF"] = ','.join(chpl_system_prediff)
+        os.environ["CHPL_SYSTEM_PREDIFF"] = ",".join(chpl_system_prediff)
 
 
 def auto_generate_tests():
@@ -1205,13 +1389,16 @@ def auto_generate_tests():
     with cd(home):
         if path == home or path == test_dir and not args.clean_only:
             if not args.gen_graphs:
-                logger.write("[Generating tests from the Chapel Spec in "
-                        "{0}/spec".format(home))
+                logger.write(
+                    "[Generating tests from the Chapel Spec in "
+                    "{0}/spec".format(home)
+                )
                 returncode = subprocess.call(["make", "spectests"])
                 if returncode != 0:
-                    logger.write("[Error: Failed to generate Spec tests. Run "
-                            "'make spectests' in {0} for more info]"
-                            .format(home))
+                    logger.write(
+                        "[Error: Failed to generate Spec tests. Run "
+                        "'make spectests' in {0} for more info]".format(home)
+                    )
                     finish()
 
 
@@ -1219,13 +1406,17 @@ def print_chapel_environment():
     logger.write()
     logger.write("### Chapel Environment ###")
     try:
-        out = run_command([os.path.join(util_dir, "printchplenv"), "--all", "--no-tidy"])
+        out = run_command(
+            [os.path.join(util_dir, "printchplenv"), "--all", "--no-tidy"]
+        )
         logger.write(out)
     except:
         pass
     logger.write("##########################")
 
+
 # END STUFF
+
 
 # Execute 'cmd' and return its exit code.
 # Print its output to the console in real-time and log it too.
@@ -1234,6 +1425,7 @@ def run_and_log(cmd):
     printout(p.stdout)
     p.wait()
     return p.returncode
+
 
 def cleanup():
     # move the log from the temp log
@@ -1249,7 +1441,7 @@ def cleanup():
             os.remove(tmp_summary_file)
 
     if os.path.isdir(chpl_test_tmp_dir):
-      shutil.rmtree(chpl_test_tmp_dir)
+        shutil.rmtree(chpl_test_tmp_dir)
 
 
 def jUnit():
@@ -1259,13 +1451,15 @@ def jUnit():
 
     if args.junit_remove_prefix:
         junit_args.append(
-                "--remove-prefix={0}".format(args.junit_remove_prefix))
+            "--remove-prefix={0}".format(args.junit_remove_prefix)
+        )
     elif args.test_root_dir:
         # if --test-root was thrown, remove it from junit report
         junit_args.append("--remove-prefix={0}".format(args.test_root_dir))
 
-    cmd = [os.path.join(util_dir, "test",
-            "convert_start_test_log_to_junit_xml.py")]
+    cmd = [
+        os.path.join(util_dir, "test", "convert_start_test_log_to_junit_xml.py")
+    ]
 
     try:
         run_command(cmd + junit_args)
@@ -1288,180 +1482,432 @@ def help_all(help_msg):
 def parser_setup():
     parser = argparse.ArgumentParser(description="Test Chapel code.")
     # main args
-    p = parser.add_argument("tests", nargs="*", help="test files or directories")
+    p = parser.add_argument(
+        "tests", nargs="*", help="test files or directories"
+    )
     if argcomplete:
-        p.completer = argcomplete.completers.FilesCompleter([".chpl", ".test.c", ".test.cpp", ".ml-test.c", ".ml-test.cpp"])
+        p.completer = argcomplete.completers.FilesCompleter(
+            [".chpl", ".test.c", ".test.cpp", ".ml-test.c", ".ml-test.cpp"]
+        )
 
     # executing options
-    parser.add_argument("-execopts", "--execopts", action="append",
-            dest="execopts", help="set options for executing tests")
+    parser.add_argument(
+        "-execopts",
+        "--execopts",
+        action="append",
+        dest="execopts",
+        help="set options for executing tests",
+    )
     # lame hack to prevent abbreviations from not getting preprocessed in
     # preprocess_options() (makes things like --execop ambiguous)
-    parser.add_argument("-execopts ", "--execopts ", action="append",
-            dest="execopts", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "-execopts ",
+        "--execopts ",
+        action="append",
+        dest="execopts",
+        help=argparse.SUPPRESS,
+    )
     # compiler
-    parser.add_argument("-compiler", "--compiler", action="store",
-            dest="compiler", help=help_all("set alternate compiler"))
+    parser.add_argument(
+        "-compiler",
+        "--compiler",
+        action="store",
+        dest="compiler",
+        help=help_all("set alternate compiler"),
+    )
     # program launch utility
-    parser.add_argument("-launchcmd", "--launchcmd", action="store",
-            dest="launch_cmd", default=os.getenv("CHPL_TEST_LAUNCHCMD", ""),
-            help="set a program to launch generated executables")
+    parser.add_argument(
+        "-launchcmd",
+        "--launchcmd",
+        action="store",
+        dest="launch_cmd",
+        default=os.getenv("CHPL_TEST_LAUNCHCMD", ""),
+        help="set a program to launch generated executables",
+    )
     # compiler options
-    parser.add_argument("-compopts", "--compopts", action="append",
-            dest="compopts", help="set options for the compiler")
+    parser.add_argument(
+        "-compopts",
+        "--compopts",
+        action="append",
+        dest="compopts",
+        help="set options for the compiler",
+    )
     # lame hack to prevent abbreviations from not getting preprocessed in
     # preprocess_options() (makes things like --compop ambiguous)
-    parser.add_argument("-compopts ", "--compopts ", action="append",
-            dest="compopts", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "-compopts ",
+        "--compopts ",
+        action="append",
+        dest="compopts",
+        help=argparse.SUPPRESS,
+    )
     # log_file
-    parser.add_argument("-logfile", "--logfile", action="store",
-            dest="log_file", help="set alternate log file")
+    parser.add_argument(
+        "-logfile",
+        "--logfile",
+        action="store",
+        dest="log_file",
+        help="set alternate log file",
+    )
     # mem leaks
-    parser.add_argument("-memleaks", "--memleaks", "-memLeaks", "--memLeaks",
-            action="store_true", dest="mem_leaks", help="run with --memLeaks")
+    parser.add_argument(
+        "-memleaks",
+        "--memleaks",
+        "-memLeaks",
+        "--memLeaks",
+        action="store_true",
+        dest="mem_leaks",
+        help="run with --memLeaks",
+    )
     # mem leaks log
-    parser.add_argument("-memleakslog", "--memleakslog", "-memLeaksLog",
-            "--memLeaksLog", action="store", dest="mem_leaks_log", help=("set"
-            " location for memLeaks log, and run with --memLeaksLog"))
+    parser.add_argument(
+        "-memleakslog",
+        "--memleakslog",
+        "-memLeaksLog",
+        "--memLeaksLog",
+        action="store",
+        dest="mem_leaks_log",
+        help=("set" " location for memLeaks log, and run with --memLeaksLog"),
+    )
     # valgrind
-    parser.add_argument("-valgrind", "--valgrind", action="store_true",
-            dest="valgrind", help="run everything using valgrind")
-    parser.add_argument("-valgrindexe", "--valgrindexe", action="store_true",
-            dest="valgrind_exe", help="execute tests using valgrind")
+    parser.add_argument(
+        "-valgrind",
+        "--valgrind",
+        action="store_true",
+        dest="valgrind",
+        help="run everything using valgrind",
+    )
+    parser.add_argument(
+        "-valgrindexe",
+        "--valgrindexe",
+        action="store_true",
+        dest="valgrind_exe",
+        help="execute tests using valgrind",
+    )
     # pre exec, pre- etc....
-    parser.add_argument("-syspreexec", "--syspreexec", action="append",
-                        dest="preexec",
-                        help="set a PREEXEC script to run before execution"
-                             ", may be given more than once")
-    parser.add_argument("-sysprediff", "--sysprediff", action="append",
-                        dest="prediff",
-                        help="set a PREDIFF script to run on test output"
-                             ", may be given more than once")
+    parser.add_argument(
+        "-syspreexec",
+        "--syspreexec",
+        action="append",
+        dest="preexec",
+        help="set a PREEXEC script to run before execution"
+        ", may be given more than once",
+    )
+    parser.add_argument(
+        "-sysprediff",
+        "--sysprediff",
+        action="append",
+        dest="prediff",
+        help="set a PREDIFF script to run on test output"
+        ", may be given more than once",
+    )
     # future mode args
     futures_mode = 0
-    parser.add_argument("-futures", "--futures", action="store_const", const=1,
-            default=futures_mode, dest="futures_mode", help="run future tests")
-    parser.add_argument("-futuresonly", "--futuresonly", "-futures-only",
-            "--futures-only", action="store_const", const=2, default=
-            futures_mode, dest="futures_mode", help="only run future tests")
-    parser.add_argument("-futuresskipif", "--futuresskipif", "-futures-skipif",
-            "--futures-skipif", action="store_const", const=3, default=
-            futures_mode, dest="futures_mode", help="run future-skipif tests")
-    parser.add_argument("-futures-mode", "--futures-mode", action="store",
-            default=futures_mode, dest="futures_mode",
-            help=argparse.SUPPRESS)
+    parser.add_argument(
+        "-futures",
+        "--futures",
+        action="store_const",
+        const=1,
+        default=futures_mode,
+        dest="futures_mode",
+        help="run future tests",
+    )
+    parser.add_argument(
+        "-futuresonly",
+        "--futuresonly",
+        "-futures-only",
+        "--futures-only",
+        action="store_const",
+        const=2,
+        default=futures_mode,
+        dest="futures_mode",
+        help="only run future tests",
+    )
+    parser.add_argument(
+        "-futuresskipif",
+        "--futuresskipif",
+        "-futures-skipif",
+        "--futures-skipif",
+        action="store_const",
+        const=3,
+        default=futures_mode,
+        dest="futures_mode",
+        help="run future-skipif tests",
+    )
+    parser.add_argument(
+        "-futures-mode",
+        "--futures-mode",
+        action="store",
+        default=futures_mode,
+        dest="futures_mode",
+        help=argparse.SUPPRESS,
+    )
     # cleaning
-    parser.add_argument("-clean-only", "-cleanonly", "--clean-only",
-            "--cleanonly", action="store_true", dest="clean_only",
-            help="only clean files specified in CLEANFILES")
+    parser.add_argument(
+        "-clean-only",
+        "-cleanonly",
+        "--clean-only",
+        "--cleanonly",
+        action="store_true",
+        dest="clean_only",
+        help="only clean files specified in CLEANFILES",
+    )
     # recurse
-    parser.add_argument("-norecurse", "-no-recurse", "--norecurse",
-            "--no-recurse", action="store_false", dest="recurse",
-            help="don't recurse down through directories")
+    parser.add_argument(
+        "-norecurse",
+        "-no-recurse",
+        "--norecurse",
+        "--no-recurse",
+        action="store_false",
+        dest="recurse",
+        help="don't recurse down through directories",
+    )
     # performance
-    parser.add_argument("-performance", "--performance", action="store_true",
-            dest="performance", help="run performance tests")
-    p = parser.add_argument("-perflabel", "--perflabel", action="store",
-               default="perf", dest="perflabel",
-               help="set alternate performance test label")
+    parser.add_argument(
+        "-performance",
+        "--performance",
+        action="store_true",
+        dest="performance",
+        help="run performance tests",
+    )
+    p = parser.add_argument(
+        "-perflabel",
+        "--perflabel",
+        action="store",
+        default="perf",
+        dest="perflabel",
+        help="set alternate performance test label",
+    )
     if argcomplete:
-        p.completer = argcomplete.completers.ChoicesCompleter(('ml-', ))
+        p.completer = argcomplete.completers.ChoicesCompleter(("ml-",))
 
-    parser.add_argument("-performance-description",
-            "--performance-description", action="store", default="",
-            dest="performance_description", help=help_all(""))
-    parser.add_argument("-performance-configs", "--performance-configs",
-            "-performance-configurations", "--performance-configurations",
-            action="store", dest="performance_configs",
-            help=help_all("set performance configurations"))
-    parser.add_argument("-compperformance", "--compperformance",
-            action="store_true", dest="comp_performance",
-            help=help_all("test compiler performance"))
-    parser.add_argument("-compperformance-description",
-            "--compperformance-description", action="store", default="",
-            dest="comp_performance_description", help=help_all(""))
-    parser.add_argument("-numtrials", "--numtrials", "-num-trials",
-        "--num-trials", action="store", dest="num_trials",
+    parser.add_argument(
+        "-performance-description",
+        "--performance-description",
+        action="store",
+        default="",
+        dest="performance_description",
+        help=help_all(""),
+    )
+    parser.add_argument(
+        "-performance-configs",
+        "--performance-configs",
+        "-performance-configurations",
+        "--performance-configurations",
+        action="store",
+        dest="performance_configs",
+        help=help_all("set performance configurations"),
+    )
+    parser.add_argument(
+        "-compperformance",
+        "--compperformance",
+        action="store_true",
+        dest="comp_performance",
+        help=help_all("test compiler performance"),
+    )
+    parser.add_argument(
+        "-compperformance-description",
+        "--compperformance-description",
+        action="store",
+        default="",
+        dest="comp_performance_description",
+        help=help_all(""),
+    )
+    parser.add_argument(
+        "-numtrials",
+        "--numtrials",
+        "-num-trials",
+        "--num-trials",
+        action="store",
+        dest="num_trials",
         default=os.getenv("CHPL_TEST_NUM_TRIALS", "1"),
-        help="the number of times to run the performance tests")
+        help="the number of times to run the performance tests",
+    )
     # graphing
-    parser.add_argument("-gen-graphs", "--gen-graphs", "-generate-graphs",
-            "--generate-graphs", action="store_true", dest="gen_graphs",
-            help=help_all("only generate graphs, don't run tests"))
-    parser.add_argument("-nodisplaygraphrange", "--nodisplaygraphrange",
-            "-no-display-graph-range", "--no-display-graph-range",
-            action="store_false", dest="graphs_disp_range",
-            help=help_all("don't display trial range envelopes ongraphs"))
-    parser.add_argument("-graphsgendefault", "--graphsgendefault",
-            "-graphs-gen-default", "--graphs-gen-default", action="store",
-            choices=["avg", "min", "max", "med"], default="avg",
-            dest="graphs_gen_default",
-            help=help_all("set default method to reduce multiple trials"))
-    parser.add_argument("-startdate", "--startdate", action="store",
-            dest="start_date", metavar="<MM/DD/YY>",
-            help="set graph start date")
-    parser.add_argument("-gengraphopts", "--gengraphopts", "-genGraphOpts",
-            "--genGraphOpts", action="store", dest="gen_graph_opts",
-            default="", help=help_all("set additional graph gen options"))
+    parser.add_argument(
+        "-gen-graphs",
+        "--gen-graphs",
+        "-generate-graphs",
+        "--generate-graphs",
+        action="store_true",
+        dest="gen_graphs",
+        help=help_all("only generate graphs, don't run tests"),
+    )
+    parser.add_argument(
+        "-nodisplaygraphrange",
+        "--nodisplaygraphrange",
+        "-no-display-graph-range",
+        "--no-display-graph-range",
+        action="store_false",
+        dest="graphs_disp_range",
+        help=help_all("don't display trial range envelopes ongraphs"),
+    )
+    parser.add_argument(
+        "-graphsgendefault",
+        "--graphsgendefault",
+        "-graphs-gen-default",
+        "--graphs-gen-default",
+        action="store",
+        choices=["avg", "min", "max", "med"],
+        default="avg",
+        dest="graphs_gen_default",
+        help=help_all("set default method to reduce multiple trials"),
+    )
+    parser.add_argument(
+        "-startdate",
+        "--startdate",
+        action="store",
+        dest="start_date",
+        metavar="<MM/DD/YY>",
+        help="set graph start date",
+    )
+    parser.add_argument(
+        "-gengraphopts",
+        "--gengraphopts",
+        "-genGraphOpts",
+        "--genGraphOpts",
+        action="store",
+        dest="gen_graph_opts",
+        default="",
+        help=help_all("set additional graph gen options"),
+    )
     # only compile
-    parser.add_argument("-comp-only", "--comp-only", action="store_true",
-            dest="comp_only", help="only compile the tests, don't run")
+    parser.add_argument(
+        "-comp-only",
+        "--comp-only",
+        action="store_true",
+        dest="comp_only",
+        help="only compile the tests, don't run",
+    )
     # keep executables
-    parser.add_argument("-keep-executable", "--keep-executable", "--keep", action="store_true", dest="keep_executable", help="don't clean the generated executable after running")
+    parser.add_argument(
+        "-keep-executable",
+        "--keep-executable",
+        "--keep",
+        action="store_true",
+        dest="keep_executable",
+        help="don't clean the generated executable after running",
+    )
     # num locales
-    parser.add_argument("-numlocales", "--numlocales", action="store",
-            dest="num_locales", default="0",
-            help="set the number of locales to run on")
+    parser.add_argument(
+        "-numlocales",
+        "--numlocales",
+        action="store",
+        dest="num_locales",
+        default="0",
+        help="set the number of locales to run on",
+    )
     # run tests that specify numlocales > 1
-    parser.add_argument("-max-locales", "--max-locales",
-            action="store", dest="max_locales", default="0",
-            help="Maximum number of locales to use")
+    parser.add_argument(
+        "-max-locales",
+        "--max-locales",
+        action="store",
+        dest="max_locales",
+        default="0",
+        help="Maximum number of locales to use",
+    )
     # run tests that specify numlocales > 1
-    parser.add_argument("-multilocale-only", "--multilocale-only",
-            action="store_true", dest="multilocale_only",
-            help="Only run multilocale test (ignored for comm none)")
+    parser.add_argument(
+        "-multilocale-only",
+        "--multilocale-only",
+        action="store_true",
+        dest="multilocale_only",
+        help="Only run multilocale test (ignored for comm none)",
+    )
     # stdin redirect
-    parser.add_argument("-nostdinredirect", "--nostdinredirect",
-            action="store_true", dest="no_stdin_redirect",
-            help=help_all("don't redirect stdin from /dev/null"))
-    parser.add_argument("-stdinredirect", "--stdinredirect",
-            action="store_true", dest="stdin_redirect",
-            help=help_all("force stdin redirection from /dev/null"))
+    parser.add_argument(
+        "-nostdinredirect",
+        "--nostdinredirect",
+        action="store_true",
+        dest="no_stdin_redirect",
+        help=help_all("don't redirect stdin from /dev/null"),
+    )
+    parser.add_argument(
+        "-stdinredirect",
+        "--stdinredirect",
+        action="store_true",
+        dest="stdin_redirect",
+        help=help_all("force stdin redirection from /dev/null"),
+    )
     # launcher timeout
-    parser.add_argument("-launchertimeout", "--launchertimeout",
-            action="store", dest="launcher_timeout",
-            help=help_all("rely on the launcher to enforce the timeout"))
+    parser.add_argument(
+        "-launchertimeout",
+        "--launchertimeout",
+        action="store",
+        dest="launcher_timeout",
+        help=help_all("rely on the launcher to enforce the timeout"),
+    )
     # no chpl home warning
-    parser.add_argument("-no-chpl-home-warn", "--no-chpl-home-warn",
-            action="store_false", dest="chpl_home_warn",
-            help=help_all("don't warn about not starting in CHPL_HOME"))
+    parser.add_argument(
+        "-no-chpl-home-warn",
+        "--no-chpl-home-warn",
+        action="store_false",
+        dest="chpl_home_warn",
+        help=help_all("don't warn about not starting in CHPL_HOME"),
+    )
     # progress
-    parser.add_argument("-progress", "--progress", action="store_true",
-            dest="progress", help=help_all("Log pass/fail for each test"))
+    parser.add_argument(
+        "-progress",
+        "--progress",
+        action="store_true",
+        dest="progress",
+        help=help_all("Log pass/fail for each test"),
+    )
     # test root
-    parser.add_argument("-test-root", "--test-root", action="store",
-        dest="test_root_dir", help=help_all("set abs path to test directory"))
+    parser.add_argument(
+        "-test-root",
+        "--test-root",
+        action="store",
+        dest="test_root_dir",
+        help=help_all("set abs path to test directory"),
+    )
     # jUnit
-    parser.add_argument("-junit-xml", "--junit-xml", action="store_true",
-            dest="junit_xml", help=help_all("create jUnit XML report"))
-    parser.add_argument("-junit-xml-file", "--junit-xml-file", action="store",
-            dest="junit_xml_file", metavar="<file>",
-            help=help_all("set the path to store the jUnit XML report"))
-    parser.add_argument("-junit-remove-prefix", "--junit-remove-prefix",
-            action="store", dest="junit_remove_prefix", metavar="<prefix>",
-            help=help_all("<prefix> to remove from tests in jUnit report"))
+    parser.add_argument(
+        "-junit-xml",
+        "--junit-xml",
+        action="store_true",
+        dest="junit_xml",
+        help=help_all("create jUnit XML report"),
+    )
+    parser.add_argument(
+        "-junit-xml-file",
+        "--junit-xml-file",
+        action="store",
+        dest="junit_xml_file",
+        metavar="<file>",
+        help=help_all("set the path to store the jUnit XML report"),
+    )
+    parser.add_argument(
+        "-junit-remove-prefix",
+        "--junit-remove-prefix",
+        action="store",
+        dest="junit_remove_prefix",
+        metavar="<prefix>",
+        help=help_all("<prefix> to remove from tests in jUnit report"),
+    )
     # respect skipifs
-    parser.add_argument("-respect-skipifs", "--respect-skipifs",
-            action="store_true", dest="respect_skipifs",
-            help="respect '.skipif' files even when testing individual files")
+    parser.add_argument(
+        "-respect-skipifs",
+        "--respect-skipifs",
+        action="store_true",
+        dest="respect_skipifs",
+        help="respect '.skipif' files even when testing individual files",
+    )
     # respect notests
-    parser.add_argument("-respect-notests", "--respect-notests",
-            action="store_true", dest="respect_notests",
-            help="respect '.notest' files even when testing individual files")
+    parser.add_argument(
+        "-respect-notests",
+        "--respect-notests",
+        action="store_true",
+        dest="respect_notests",
+        help="respect '.notest' files even when testing individual files",
+    )
     # extra help
     parser.add_argument("-help", action="help", help=argparse.SUPPRESS)
-    parser.add_argument("--help-all", action="help",
-            help="show all options, including ones meant for other scripts")
+    parser.add_argument(
+        "--help-all",
+        action="help",
+        help="show all options, including ones meant for other scripts",
+    )
 
     return parser
 
@@ -1473,22 +1919,24 @@ def parser_setup():
 def preprocess_options():
     index = 0
     for arg in sys.argv:
-        arg = arg.replace('\"', '').replace('\'', '')
+        arg = arg.replace('"', "").replace("'", "")
         if arg in ["-compopts", "--compopts", "-execopts", "--execopts"]:
             escape_next_argument(sys.argv, index)
         index += 1
 
+
 def escape_next_argument(args, index):
     if index + 1 < len(args):
         next = args[index + 1].strip()
-        if next and next[0] == "-": # single argument, not escaped
+        if next and next[0] == "-":  # single argument, not escaped
             args[index + 1] = "'{0}'".format(next)
         print(args)
 
 
 # UTILITY ROUTINES AND CLASSES
 
-class Logger():
+
+class Logger:
     def __init__(self):
         self.logger = logging.getLogger("start_test")
         self.logger.setLevel(logging.DEBUG)
@@ -1524,6 +1972,7 @@ class Logger():
 # missing log messages are not very important to the application.
 # In this program, however, the logging provides an essential function.
 
+
 class StreamHandlerWithException(logging.StreamHandler):
     """
     Same as StreamHandler except it raises an exception.
@@ -1532,6 +1981,7 @@ class StreamHandlerWithException(logging.StreamHandler):
     def handleError(self, record):
         logging.StreamHandler.handleError(self, record)
         raise OSError("fatal error, logging.StreamHandler")
+
 
 class FileHandlerWithException(logging.FileHandler):
     """
@@ -1542,13 +1992,19 @@ class FileHandlerWithException(logging.FileHandler):
         logging.FileHandler.handleError(self, record)
         raise OSError("fatal error, logging.FileHandler")
 
+
 class CommandError(Exception):
     def __init__(self, retcode, cmd, output=None):
         self.retcode = retcode
         self.cmd = cmd
         self.output = output
+
     def __str__(self):
-        return "Command '{0}' returned non-zero exit status {1}".format(self.cmd, self.retcode)
+        return "Command '{0}' returned non-zero exit status {1}".format(
+            self.cmd, self.retcode
+        )
+
+
 def run_command(cmd, stderr=None):
     """
     check_output like wrapper, but we're still committed to 2.6 so can't rely
@@ -1561,25 +2017,30 @@ def run_command(cmd, stderr=None):
         raise CommandError(retcode, cmd, output)
 
     if sys.version_info[0] >= 3 and not isinstance(output, str):
-        output = str(output, 'utf-8')
+        output = str(output, "utf-8")
 
     return output
+
 
 def process_skipif_output(output):
     lines = output.splitlines()
     if len(lines) == 0:
-      return output
+        return output
     elif len(lines) > 1:
-      print("\n".join(lines[:-1]))
+        print("\n".join(lines[:-1]))
     output = lines[-1]
     return output
 
+
 def run_git_command(command):
     try:
-        output = run_command(["git"]+command, stderr=subprocess.STDOUT).strip()
+        output = run_command(
+            ["git"] + command, stderr=subprocess.STDOUT
+        ).strip()
     except:
         output = None
     return output
+
 
 def printout(so):
     while True:
@@ -1587,9 +2048,10 @@ def printout(so):
         if not line:
             break
         if sys.version_info[0] >= 3 and not isinstance(line, str):
-            line = str(line, 'utf-8')
-        logger.write(line) # strip default newline
+            line = str(line, "utf-8")
+        logger.write(line)  # strip default newline
         logger.flush()
+
 
 @contextlib.contextmanager
 def cd(path):

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -151,36 +151,44 @@ import errno
 from functools import reduce, cache
 import atexit
 
+
 def elapsed_sub_test_time():
     """Print elapsed time for sub_test call to console."""
     global sub_test_start_time, localdir
     elapsed_sec = time.time() - sub_test_start_time
 
     test_name = localdir
-    if 'CHPL_ONETEST' in os.environ:
-        chpl_name = os.environ.get('CHPL_ONETEST')
+    if "CHPL_ONETEST" in os.environ:
+        chpl_name = os.environ.get("CHPL_ONETEST")
         base_name = os.path.splitext(chpl_name)[0]
         test_name = os.path.join(test_name, base_name)
     print_elapsed_sub_test_time(test_name, elapsed_sec)
 
+
 def print_elapsed_sub_test_time(test_name, elapsed_sec):
-    print('[Finished subtest "{0}" - {1:.3f} seconds]\n'.format(test_name, elapsed_sec))
+    print(
+        '[Finished subtest "{0}" - {1:.3f} seconds]\n'.format(
+            test_name, elapsed_sec
+        )
+    )
+
 
 def run_process(*args, **kwargs):
     p = subprocess.Popen(*args, **kwargs)
-    (stdout, stderr) = p.communicate()
+    stdout, stderr = p.communicate()
 
     if stdout is not None:
-        stdout_str = str(stdout, encoding='utf-8', errors='surrogateescape')
+        stdout_str = str(stdout, encoding="utf-8", errors="surrogateescape")
     else:
         stdout_str = ""
 
     if stderr is not None:
-        stderr_str = str(stderr, encoding='utf-8', errors='surrogateescape')
+        stderr_str = str(stderr, encoding="utf-8", errors="surrogateescape")
     else:
         stderr_str = ""
 
     return (p.returncode, stdout_str, stderr_str)
+
 
 def get_process_env(testenv):
     process_env = dict(list(os.environ.items()) + list(testenv.items()))
@@ -190,12 +198,14 @@ def get_process_env(testenv):
             del process_env[var]
     return process_env
 
+
 #
 # Time out class:  Read from a stream until time out
 #  A little ugly but sending SIGALRM (or any other signal) to Python
 #   can be unreliable (will not respond if holding certain locks).
 #
-class ReadTimeoutException(Exception): pass
+class ReadTimeoutException(Exception):
+    pass
 
 
 def SetNonBlock(stream):
@@ -203,90 +213,108 @@ def SetNonBlock(stream):
     flags |= os.O_NONBLOCK
     fcntl.fcntl(stream.fileno(), fcntl.F_SETFL, flags)
 
+
 def SuckOutputWithTimeout(stream, timeout):
     SetNonBlock(stream)
-    buffer = b''
+    buffer = b""
     end_time = time.time() + timeout
     while True:
         now = time.time()
         if end_time <= now:
             # Maybe return partial result instead?
-            raise ReadTimeoutException('Teh tiem iz out!')
+            raise ReadTimeoutException("Teh tiem iz out!")
         ready_set = select.select([stream], [], [], end_time - now)[0]
         if stream in ready_set:
             bytes = stream.read()
             if len(bytes) == 0:
-                break           # EOF
-            buffer += bytes     # Inefficient way to accumulate bytes.
+                break  # EOF
+            buffer += bytes  # Inefficient way to accumulate bytes.
             # len(ready_set) == 0 is also an indication of timeout. However,
             # if we relied on that, we would require no data ready in order
             # to timeout  which doesn't seem quite right either.
     return buffer
 
+
 def LauncherTimeoutArgs(seconds):
-    if useLauncherTimeout == 'pbs' or useLauncherTimeout == 'slurm':
+    if useLauncherTimeout == "pbs" or useLauncherTimeout == "slurm":
         # --walltime=hh:mm:ss
         m, s = divmod(seconds, 60)
         h, m = divmod(m, 60)
-        fmttime = '--walltime={0:02d}:{1:02d}:{2:02d}'.format(h, m, s)
+        fmttime = "--walltime={0:02d}:{1:02d}:{2:02d}".format(h, m, s)
         return [fmttime]
     else:
-        Fatal('LauncherTimeoutArgs encountered an unknown format spec: ' + \
-              useLauncherTimeout)
+        Fatal(
+            "LauncherTimeoutArgs encountered an unknown format spec: "
+            + useLauncherTimeout
+        )
 
 
 #
 # Auxiliary functions
 #
 
+
 # Escape all special characters
 def ShellEscape(arg):
-    return re.sub(r'([\\!@#$%^&*()?;\'"|<>[\]{} ])', r'\\\1', arg)
+    return re.sub(r'([\\!@#$%^&*()?;\'"|<>[\]{} ])', r"\\\1", arg)
+
 
 # Escape all special characters but leave spaces alone
 def ShellEscapeCommand(arg):
-    return re.sub(r'([\\!@#$%^&*()?;\'"|<>[\]{}])', r'\\\1', arg)
+    return re.sub(r'([\\!@#$%^&*()?;\'"|<>[\]{}])', r"\\\1", arg)
 
 
 # Grabs the start and end of the output and replaces non-printable chars with ~
 def trim_output(output):
-    max_size = 256*1024 # ~1/4 MB
+    max_size = 256 * 1024  # ~1/4 MB
     if len(output) > max_size:
-        new_output = output[:max_size//2]
-        new_output += output[-max_size//2:]
+        new_output = output[: max_size // 2]
+        new_output += output[-max_size // 2 :]
         output = new_output
 
-    return ''.join(s if s in string.printable else "~" for s in output)
+    return "".join(s if s in string.printable else "~" for s in output)
 
 
 # return True if f has .chpl, .test.c or .ml-test.c extension
 def hasTestableExtension(f):
-    if f.endswith(('.chpl',
-                   '.test.c', '.test.cpp',
-                   '.ml-test.c', '.ml-test.cpp')):
+    if f.endswith(
+        (".chpl", ".test.c", ".test.cpp", ".ml-test.c", ".ml-test.cpp")
+    ):
         return True
     else:
         return False
 
-perflabel = '' # declare it for the following functions
+
+perflabel = ""  # declare it for the following functions
+
 
 # file suffix: 'keys' -> '.perfkeys' etc.
 def PerfSfx(s):
-    return '.' + perflabel + s
+    return "." + perflabel + s
+
 
 # directory-wide file: 'COMPOPTS' or 'compopts' -> './PERFCOMPOPTS' etc.
 def PerfDirFile(s):
-    return './' + perflabel.upper() + s.upper()
+    return "./" + perflabel.upper() + s.upper()
+
 
 # test-specific file: (foo,keys) -> foo.perfkeys etc.
 def PerfTFile(test_filename, sfx):
-    return test_filename + '.' + perflabel + sfx
+    return test_filename + "." + perflabel + sfx
+
 
 def get_chplenv():
-    env_cmd = [os.path.join(utildir, 'printchplenv'), '--all', '--simple', '--no-tidy', '--internal']
+    env_cmd = [
+        os.path.join(utildir, "printchplenv"),
+        "--all",
+        "--simple",
+        "--no-tidy",
+        "--internal",
+    ]
     chpl_env = run_process(env_cmd, stdout=subprocess.PIPE)[1]
-    chpl_env = dict(map(lambda l: l.split('=', 1), chpl_env.splitlines()))
+    chpl_env = dict(map(lambda l: l.split("=", 1), chpl_env.splitlines()))
     return chpl_env
+
 
 # Similar to os.path.expandvars but stuff chplenv into it too
 def expandvars_chpl(path):
@@ -294,14 +322,18 @@ def expandvars_chpl(path):
     expand_env.update(get_chplenv())
     return string.Template(path).safe_substitute(expand_env)
 
+
 # Wait up to timeout seconds for files to exist. Useful on systems where file
 # IO may only complete after the launcher returns
-def WaitForFiles(files, timeout=int(os.getenv('CHPL_TEST_WAIT_FOR_FILES_TIMEOUT', '10'))):
+def WaitForFiles(
+    files, timeout=int(os.getenv("CHPL_TEST_WAIT_FOR_FILES_TIMEOUT", "10"))
+):
     waited = 0
     for f in files:
         while not os.path.exists(f) and waited < timeout:
             time.sleep(1)
             waited += 1
+
 
 # If CHPL_TEST_LIMIT_RUNNING_EXECUTABLES is set, use a file lock to serialize
 # process execution.
@@ -332,79 +364,95 @@ def ReadFileWithComments(f, ignoreLeadingSpace=True, args=None):
             tmp_args = [os.path.abspath(f)]
             if args != None:
                 tmp_args += args
-            output = run_process(tmp_args, stdout=subprocess.PIPE, env=file_env)[1]
+            output = run_process(
+                tmp_args, stdout=subprocess.PIPE, env=file_env
+            )[1]
             mylines = output.splitlines()
 
         except OSError as e:
             global localdir
             f_name = os.path.join(localdir, f)
-            sys.stdout.write("[Error trying to execute '{0}': {1}]\n".format(f_name, str(e)))
+            sys.stdout.write(
+                "[Error trying to execute '{0}': {1}]\n".format(f_name, str(e))
+            )
 
     # otherwise, just read the file
     else:
-        with open(f, 'r') as myfile:
+        with open(f, "r") as myfile:
             mylines = myfile.readlines()
 
-    mylist=list()
+    mylist = list()
     for line in mylines:
         line = line.rstrip()
         # ignore blank lines
-        if not line.strip(): continue
+        if not line.strip():
+            continue
         # ignore comments
         if ignoreLeadingSpace:
-            if line.lstrip()[0] == '#': continue
+            if line.lstrip()[0] == "#":
+                continue
         else:
-            if line[0] == '#': continue
+            if line[0] == "#":
+                continue
         # expand shell variables
         line = expandvars_chpl(line)
         mylist.append(line)
     return mylist
 
+
 # diff 2 files
 def DiffFiles(f1, f2):
-    sys.stdout.write('[Executing diff %s %s]\n'%(f1, f2))
-    (returncode, myoutput, _) = run_process(['diff',f1,f2],
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.PIPE)
+    sys.stdout.write("[Executing diff %s %s]\n" % (f1, f2))
+    returncode, myoutput, _ = run_process(
+        ["diff", f1, f2], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     if returncode != 0:
         sys.stdout.write(trim_output(myoutput))
     return returncode
 
+
 def DiffBinaryFiles(f1, f2):
-    sys.stdout.write('[Executing binary diff %s %s]\n'%(f1, f2))
+    sys.stdout.write("[Executing binary diff %s %s]\n" % (f1, f2))
     # Output is communicate()'d even though it's not needed, to avoid deadlock
-    (returncode, _, _) = run_process(['diff', '-a', f1,f2],
-                                      stdout=subprocess.PIPE,
-                                      stderr=subprocess.PIPE)
+    returncode, _, _ = run_process(
+        ["diff", "-a", f1, f2], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     if returncode != 0:
-        sys.stdout.write('Binary files differed\n')
+        sys.stdout.write("Binary files differed\n")
     return returncode
+
 
 # diff output vs. .bad file, filtering line numbers out of error messages that arise
 # in module files.
 def DiffBadFiles(f1, f2):
-    sys.stdout.write('[Executing diff-ignoring-module-line-numbers %s %s]\n'%(f1, f2))
+    sys.stdout.write(
+        "[Executing diff-ignoring-module-line-numbers %s %s]\n" % (f1, f2)
+    )
     # Output is communicate()'d even though it's not needed, to avoid deadlock
-    (returncode, myoutput, _) = run_process([utildir+'/test/diff-ignoring-module-line-numbers', f1, f2],
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.PIPE)
+    returncode, myoutput, _ = run_process(
+        [utildir + "/test/diff-ignoring-module-line-numbers", f1, f2],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     if returncode != 0:
         sys.stdout.write(myoutput)
     return returncode
 
+
 # kill process
 def KillProc(p, timeout):
-    k = subprocess.Popen(['kill',str(p.pid)])
+    k = subprocess.Popen(["kill", str(p.pid)])
     k.wait()
     now = time.time()
-    end_time = now + timeout # give it a little time
+    end_time = now + timeout  # give it a little time
     while end_time > now:
         if p.poll():
             return
         now = time.time()
     # use the big hammer (and don't bother waiting)
-    subprocess.Popen(['kill','-9', str(p.pid)])
+    subprocess.Popen(["kill", "-9", str(p.pid)])
     return
+
 
 # clean up after the test has been built
 def cleanup(execname, test_ran_and_more_compopts=False):
@@ -414,14 +462,16 @@ def cleanup(execname, test_ran_and_more_compopts=False):
         if execname is not None:
             if os.path.isfile(execname):
                 os.unlink(execname)
-            if os.path.isfile(execname+'_real'):
-                os.unlink(execname+'_real')
-            if os.path.exists(execname+'.dSYM'):
+            if os.path.isfile(execname + "_real"):
+                os.unlink(execname + "_real")
+            if os.path.exists(execname + ".dSYM"):
                 import shutil
-                shutil.rmtree(execname+'.dSYM')
-            if os.path.exists(execname+'_real.dSYM'):
+
+                shutil.rmtree(execname + ".dSYM")
+            if os.path.exists(execname + "_real.dSYM"):
                 import shutil
-                shutil.rmtree(execname+'_real.dSYM')
+
+                shutil.rmtree(execname + "_real.dSYM")
             # Hopefully short term workaround on cygwin where we've been seeing
             # an issue where after a test is run, some other process has a
             # handle on the executable and we can't create a new executable
@@ -429,26 +479,35 @@ def cleanup(execname, test_ran_and_more_compopts=False):
             # additional compopts (which means the exec name will be reused)
             # wait a second while cleaning up the executable to give the other
             # process time to release its handle.
-            if test_ran_and_more_compopts and 'cygwin' in platform:
+            if test_ran_and_more_compopts and "cygwin" in platform:
                 time.sleep(1)
     except (IOError, OSError) as ex:
         # If the error is "Device or resource busy", call lsof on the file (or
         # handle for windows) to see what is holding the file handle, to help
         # debug the issue.
         if isinstance(ex, OSError) and ex.errno == 16:
-            handle = which('handle')
-            lsof = which('lsof')
+            handle = which("handle")
+            lsof = which("lsof")
             if handle is not None:
-                sys.stdout.write('[Inspecting open file handles with: {0}\n'.format(handle))
+                sys.stdout.write(
+                    "[Inspecting open file handles with: {0}\n".format(handle)
+                )
                 run_process([handle])
             elif lsof is not None:
                 cmd = [lsof, execname]
-                sys.stdout.write('[Inspecting open file handles with: {0}\n'.format(' '.join(cmd)))
+                sys.stdout.write(
+                    "[Inspecting open file handles with: {0}\n".format(
+                        " ".join(cmd)
+                    )
+                )
                 run_process(cmd)
 
         # Do not print the warning for cygwin32 when errno is 16 (Device or resource busy).
-        if not (getattr(ex, 'errno', 0) == 16 and platform == 'cygwin32'):
-            sys.stdout.write('[Warning: could not remove {0}: {1}]\n'.format(execname, ex))
+        if not (getattr(ex, "errno", 0) == 16 and platform == "cygwin32"):
+            sys.stdout.write(
+                "[Warning: could not remove {0}: {1}]\n".format(execname, ex)
+            )
+
 
 def which(program):
     """Returns absolute path to program, if it exists in $PATH. If not found,
@@ -456,6 +515,7 @@ def which(program):
 
     From: http://stackoverflow.com/a/377028
     """
+
     def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 
@@ -464,7 +524,7 @@ def which(program):
         if is_exe(program):
             return program
     else:
-        for path in os.environ.get('PATH', '').split(os.pathsep):
+        for path in os.environ.get("PATH", "").split(os.pathsep):
             path = path.strip('"')
             exe_file = os.path.join(path, program)
             if is_exe(exe_file):
@@ -473,50 +533,65 @@ def which(program):
 
 
 # print (compopts: XX, execopts: XX) for later decoding of failed tests
-def printTestVariation(compoptsnum, compoptslist,
-                       execoptsnum=0, execoptslist=[] ):
+def printTestVariation(
+    compoptsnum, compoptslist, execoptsnum=0, execoptslist=[]
+):
     printCompOpts = True
     printExecOpts = True
-    if compoptsnum==0 or len(compoptslist) <= 1:
+    if compoptsnum == 0 or len(compoptslist) <= 1:
         printCompOpts = False
-    if execoptsnum==0 or len(execoptslist) <= 1:
+    if execoptsnum == 0 or len(execoptslist) <= 1:
         printExecOpts = False
 
     if (not printCompOpts) and (not printExecOpts):
         return
 
-    sys.stdout.write(' (')
+    sys.stdout.write(" (")
     if printCompOpts:
-        sys.stdout.write('compopts: %d'%(compoptsnum))
+        sys.stdout.write("compopts: %d" % (compoptsnum))
     if printExecOpts:
         if printCompOpts:
-            sys.stdout.write(', ')
-        sys.stdout.write('execopts: %d'%(execoptsnum))
-    sys.stdout.write(')')
+            sys.stdout.write(", ")
+        sys.stdout.write("execopts: %d" % (execoptsnum))
+    sys.stdout.write(")")
     return
 
+
 def printStartOfTestMsg(startTime, preexecs=None, prediffs=None):
-    sys.stdout.write('[Starting subtest - %s]\n'%(time.strftime('%a %b %d %H:%M:%S %Z %Y', startTime)))
-    #sys.stdout.write('[compiler: \'%s\']\n'%(compiler))
+    sys.stdout.write(
+        "[Starting subtest - %s]\n"
+        % (time.strftime("%a %b %d %H:%M:%S %Z %Y", startTime))
+    )
+    # sys.stdout.write('[compiler: \'%s\']\n'%(compiler))
     if preexecs:
-        sys.stdout.write('[system-wide preexec(s): \'%s\']\n'%(', '.join(preexecs)))
+        sys.stdout.write(
+            "[system-wide preexec(s): '%s']\n" % (", ".join(preexecs))
+        )
     if prediffs:
-        sys.stdout.write('[system-wide prediff(s): \'%s\']\n'%(', '.join(prediffs)))
+        sys.stdout.write(
+            "[system-wide prediff(s): '%s']\n" % (", ".join(prediffs))
+        )
+
 
 # print '[Elapsed time to compile and execute all versions of ...'
 #   in the format expected by convert_start_test_log_to_junit_xml.py.
 
+
 def printEndOfTestMsg(test_name, elapsedTime):
     sys.stdout.flush()
-    print('[Elapsed time to compile and execute all versions of "{0}" - '
-        '{1:.3f} seconds]'.format(test_name, elapsedTime))
+    print(
+        '[Elapsed time to compile and execute all versions of "{0}" - '
+        "{1:.3f} seconds]".format(test_name, elapsedTime)
+    )
 
 
 def printTestName(name):
-    sys.stdout.write('[test: %s]\n' % name)
+    sys.stdout.write("[test: %s]\n" % name)
+
 
 def printSkipping(name, reason):
-    sys.stdout.write('Skipping test %s: %s\n' % (name, reason))
+    sys.stdout.write("Skipping test %s: %s\n" % (name, reason))
+
 
 # return true if string is an integer
 def IsInteger(str):
@@ -526,47 +601,55 @@ def IsInteger(str):
     except ValueError:
         return False
 
+
 # read integer value from a file
 def ReadIntegerValue(f, localdir):
     to = ReadFileWithComments(f)
     if to:
         for l in to:
-            if l[0] == '#':
+            if l[0] == "#":
                 continue
             if IsInteger(l):
                 return int(l)
             else:
                 break
-    Fatal('Invalid integer value in '+f+' ('+localdir+')')
+    Fatal("Invalid integer value in " + f + " (" + localdir + ")")
+
 
 # report an error message and exit
 def Fatal(message):
-    sys.stdout.write('[Error (sub_test): '+message+']\n')
-    magic_exit_code = reduce(operator.add, map(ord, 'CHAPEL')) % 256
+    sys.stdout.write("[Error (sub_test): " + message + "]\n")
+    magic_exit_code = reduce(operator.add, map(ord, "CHAPEL")) % 256
     sys.exit(magic_exit_code)
+
 
 # Attempts to find an appropriate timer to use. The timer must be in
 # util/test/timers/. Expects to be passed a file containing only the name of
 # the timer script. If the file is improperly formatted the default timer is
 # used, and if the timer is not executable or can't be found 'time -p' is used
 def GetTimer(f):
-    timersdir = os.path.join(utildir, 'test', 'timers')
-    defaultTimer = os.path.join(timersdir, 'defaultTimer')
+    timersdir = os.path.join(utildir, "test", "timers")
+    defaultTimer = os.path.join(timersdir, "defaultTimer")
 
     lines = ReadFileWithComments(f)
     if len(lines) != 1:
-        sys.stdout.write('[Error "%s" must contain exactly one non-comment line '
-            'with the name of the timer located in %s to use. Using default '
-            'timer %s.]\n' %(f, timersdir, defaultTimer))
+        sys.stdout.write(
+            '[Error "%s" must contain exactly one non-comment line '
+            "with the name of the timer located in %s to use. Using default "
+            "timer %s.]\n" % (f, timersdir, defaultTimer)
+        )
         timer = defaultTimer
     else:
         timer = os.path.join(timersdir, lines[0])
 
-    if not os.access(timer,os.R_OK|os.X_OK):
-        sys.stdout.write('[Error cannot execute timer "%s", using "time -p"]\n' %(timer))
-        return 'time -p'
+    if not os.access(timer, os.R_OK | os.X_OK):
+        sys.stdout.write(
+            '[Error cannot execute timer "%s", using "time -p"]\n' % (timer)
+        )
+        return "time -p"
 
     return timer
+
 
 # attempts to find an appropriate .good file. Good files are expected to be of
 # the form basename.<configuration>.<commExecNums>.good. Where configuration
@@ -574,22 +657,22 @@ def GetTimer(f):
 # checked for. E.G the current comm layer. commExecNums are the optional
 # compopt and execopt number to enable different .good files for different
 # compopts/execopts with explicitly specifying name.
-def FindGoodFile(basename, commExecNums=['']):
+def FindGoodFile(basename, commExecNums=[""]):
     global envCompopts
 
-    goodfile = ''
+    goodfile = ""
     for commExecNum in commExecNums:
         # Try the machine specific .good
         if not os.path.isfile(goodfile):
-            goodfile = basename+'.'+machine+commExecNum+'.good'
+            goodfile = basename + "." + machine + commExecNum + ".good"
         # Else if --no-local try the no-local .good file.
         if not os.path.isfile(goodfile):
-            if '--no-local' in envCompopts:
-                goodfile=basename+'.no-local'+commExecNum+'.good'
+            if "--no-local" in envCompopts:
+                goodfile = basename + ".no-local" + commExecNum + ".good"
         # Else if --fast try the fast .good file.
         if not os.path.isfile(goodfile):
-            if '--fast' in envCompopts:
-                goodfile=basename+'.fast'+commExecNum+'.good'
+            if "--fast" in envCompopts:
+                goodfile = basename + ".fast" + commExecNum + ".good"
         # Else try comm-, networkAtomics-, and localeModel-specific .good
         # files.  All 3, any 2, or just 1 of these may be used, but if more
         # then 1 they must be in the above order.
@@ -597,251 +680,306 @@ def FindGoodFile(basename, commExecNums=['']):
         # list all files with basename prefix and parse them out to avoid the combination
         # blowup and large number of stat calls
         if not os.path.isfile(goodfile):
-            for specstr in [ chplcommstr+chplnastr+chpllmstr,
-                             chplcommstr+chplnastr,
-                             chplcommstr+chpllmstr,
-                             chplcommstr+chpltasksstr,
-                             chplnastr+chpllmstr,
-                             chplcommstr,
-                             chpltasksstr,
-                             chplnastr,
-                             chpllmstr ]:
-                goodfile=basename+specstr+commExecNum+'.good'
+            for specstr in [
+                chplcommstr + chplnastr + chpllmstr,
+                chplcommstr + chplnastr,
+                chplcommstr + chpllmstr,
+                chplcommstr + chpltasksstr,
+                chplnastr + chpllmstr,
+                chplcommstr,
+                chpltasksstr,
+                chplnastr,
+                chpllmstr,
+            ]:
+                goodfile = basename + specstr + commExecNum + ".good"
                 if os.path.isfile(goodfile):
                     break
         # Else try the platform-specific .good file.
         if not os.path.isfile(goodfile):
-            goodfile=basename+'.'+platform+commExecNum+'.good'
+            goodfile = basename + "." + platform + commExecNum + ".good"
         # Else use the execopts-specific .good file.
         if not os.path.isfile(goodfile):
-            goodfile=basename+commExecNum+'.good'
+            goodfile = basename + commExecNum + ".good"
 
         # look for a .dyno good file, and prefer it over the regular .good file
-        if '--dyno-resolve-only' in envCompopts:
+        if "--dyno-resolve-only" in envCompopts:
             if os.path.isfile(goodfile):
-                prefix = goodfile.removesuffix('.good')
-                dynogood=prefix+'.dyno.good'
+                prefix = goodfile.removesuffix(".good")
+                dynogood = prefix + ".dyno.good"
                 if os.path.isfile(dynogood):
                     goodfile = dynogood
 
     return goodfile
 
+
 def get_exec_log_name(execname, comp_opts_count=None, exec_opts_count=None):
     """Returns the execution output log name based on number of comp and exec opts."""
-    suffix = '.exec.out.tmp'
+    suffix = ".exec.out.tmp"
     if comp_opts_count is None and exec_opts_count is None:
-        return '{0}{1}'.format(execname, suffix)
+        return "{0}{1}".format(execname, suffix)
     else:
-        return '{0}.{1}-{2}{3}'.format(execname, comp_opts_count, exec_opts_count, suffix)
+        return "{0}.{1}-{2}{3}".format(
+            execname, comp_opts_count, exec_opts_count, suffix
+        )
+
 
 # Use testEnv to process skipif files, it works for executable and
 # non-executable versions
 def runSkipIf(skipifName):
-    (status, stdout, stderr) = run_process([utildir+'/test/testEnv', './'+skipifName],
-                                           stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE)
+    status, stdout, stderr = run_process(
+        [utildir + "/test/testEnv", "./" + skipifName],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     stderr = stderr.strip()
     errmsg = ""
     if stderr:
         errmsg = stderr
     if status:
         if stderr:
-            errmsg += '\n'
-        errmsg += 'exit status %d' % (status)
+            errmsg += "\n"
+        errmsg += "exit status %d" % (status)
     if stderr or status:
         raise RuntimeError(errmsg)
 
     # Print stdout up to the last line and consider only the last line
     lines = stdout.splitlines()
     if len(lines) == 0:
-      return stdout
+        return stdout
     elif len(lines) > 1:
-      print("\n".join(lines[:-1]))
+        print("\n".join(lines[:-1]))
     stdout = lines[-1]
 
     return stdout
 
+
 # Translate some known failures into more easily understood forms
 def translateOutput(output_in):
-    xlates = (('slurmstepd: Munge decode failed: Expired credential',
-               'private issue #4552 -- Expired slurm credential for'),
-              ('output file from job .* does not exist',
-               'private issue #906 -- Missing output file for'),
-              ('qsub: cannot connect to server sdb',
-               'private issue #4542 -- Sporadic: qstat failed to connect to server sdb'),
-              ('qstat: cannot connect to server sdb',
-               'private issue #4542 -- Sporadic: qstat failed to connect to server sdb'),
-              ('Failed to recv data from background qsub',
-               'private issue #4553 -- Failed to recv data from background qsub for'),
-              ('Text file busy',
-               'private issue #474 -- Text file busy for'),
-              ('Socket timed out on send/recv operation',
-               'private issue #579 -- Slurm socket timed out on send/recv'))
+    xlates = (
+        (
+            "slurmstepd: Munge decode failed: Expired credential",
+            "private issue #4552 -- Expired slurm credential for",
+        ),
+        (
+            "output file from job .* does not exist",
+            "private issue #906 -- Missing output file for",
+        ),
+        (
+            "qsub: cannot connect to server sdb",
+            "private issue #4542 -- Sporadic: qstat failed to connect to server sdb",
+        ),
+        (
+            "qstat: cannot connect to server sdb",
+            "private issue #4542 -- Sporadic: qstat failed to connect to server sdb",
+        ),
+        (
+            "Failed to recv data from background qsub",
+            "private issue #4553 -- Failed to recv data from background qsub for",
+        ),
+        ("Text file busy", "private issue #474 -- Text file busy for"),
+        (
+            "Socket timed out on send/recv operation",
+            "private issue #579 -- Slurm socket timed out on send/recv",
+        ),
+    )
 
-    known_error = ''
+    known_error = ""
     was_timeout = False
 
     output = output_in
     if isinstance(output, bytes):
-        output = str(output, encoding='utf-8', errors='surrogateescape')
+        output = str(output, encoding="utf-8", errors="surrogateescape")
 
     for x in xlates:
         if re.search(x[0], output, re.IGNORECASE) != None:
             known_error = x[1]
             break
     else:
-        if (re.search('PBS: job killed: walltime', output, re.IGNORECASE) != None or
-              re.search('slurm.* CANCELLED .* DUE TO TIME LIMIT', output, re.IGNORECASE) != None):
-            known_error = 'Timed out executing program'
+        if (
+            re.search("PBS: job killed: walltime", output, re.IGNORECASE)
+            != None
+            or re.search(
+                "slurm.* CANCELLED .* DUE TO TIME LIMIT", output, re.IGNORECASE
+            )
+            != None
+        ):
+            known_error = "Timed out executing program"
             was_timeout = True
 
     return known_error, was_timeout
 
+
 # Remove innocuous warnings about clock skew from when we `make` the generated code
 def remove_clock_skew_warning(output):
-    output = re.sub(r'g?make.*: Warning: File .* has modification time .* s in the future *\n', '', output)
-    output = re.sub(r'g?make.*: warning:  Clock skew detected\.  Your build may be incomplete\. *\n', '', output)
+    output = re.sub(
+        r"g?make.*: Warning: File .* has modification time .* s in the future *\n",
+        "",
+        output,
+    )
+    output = re.sub(
+        r"g?make.*: warning:  Clock skew detected\.  Your build may be incomplete\. *\n",
+        "",
+        output,
+    )
     return output
+
 
 def filter_compiler_errors(compiler_output):
     """Identify common errors that occur in compilation.
     Return message to emit when error found."""
 
-    error_msg = ''
-    err_strings = [r'could not checkout FLEXlm license']
+    error_msg = ""
+    err_strings = [r"could not checkout FLEXlm license"]
     for s in err_strings:
         if re.search(s, compiler_output, re.IGNORECASE) != None:
-            error_msg = '(private issue #398)'
+            error_msg = "(private issue #398)"
             break
 
     return error_msg
+
 
 def filter_errors(output_in, pre_exec_output, execgoodfile, execlog):
     """Identify common errors that occur in runtime or compiler warnings.
     Return message to emit when error found."""
 
-    extra_msg = ''
-    err_strings = [r'got exn while reading exit code: connection closed',
-                   r'slave got an unknown command on coord socket:',
-                   r'Slave got an xSocket: connection closed on recv',
-                   r'recursive failure in AMUDP_SPMDShutdown',
-                   r'AM_ERR_RESOURCE \(Problem with requested resource\)']
+    extra_msg = ""
+    err_strings = [
+        r"got exn while reading exit code: connection closed",
+        r"slave got an unknown command on coord socket:",
+        r"Slave got an xSocket: connection closed on recv",
+        r"recursive failure in AMUDP_SPMDShutdown",
+        r"AM_ERR_RESOURCE \(Problem with requested resource\)",
+    ]
 
     output = output_in
     if isinstance(output, bytes):
-        output = str(output, encoding='utf-8', errors='surrogateescape')
+        output = str(output, encoding="utf-8", errors="surrogateescape")
 
     for s in err_strings:
         if re.search(s, output, re.IGNORECASE) != None:
-            extra_msg = '(private issue #634) '
+            extra_msg = "(private issue #634) "
             DiffBinaryFiles(execgoodfile, execlog)
             break
 
-    err_strings = [r'Clock skew detected']
+    err_strings = [r"Clock skew detected"]
     for s in err_strings:
         # NOTE: checking pre_exec (compiler) output
         if re.search(s, pre_exec_output, re.IGNORECASE) != None:
-            extra_msg = '(private issue #482) '
+            extra_msg = "(private issue #482) "
             break
 
-    err_strings = [r'could not checkout FLEXlm license']
+    err_strings = [r"could not checkout FLEXlm license"]
     for s in err_strings:
-        if (re.search(s, output, re.IGNORECASE) != None or
-            re.search(s, pre_exec_output, re.IGNORECASE) != None):
-            extra_msg = '(private issue #398)'
+        if (
+            re.search(s, output, re.IGNORECASE) != None
+            or re.search(s, pre_exec_output, re.IGNORECASE) != None
+        ):
+            extra_msg = "(private issue #398)"
             break
 
-    err_strings = [r'=* Memory Leaks =*']
+    err_strings = [r"=* Memory Leaks =*"]
     for s in err_strings:
-        if (re.search(s, output, re.IGNORECASE) != None):
-            extra_msg = '(memory leak) '
+        if re.search(s, output, re.IGNORECASE) != None:
+            extra_msg = "(memory leak) "
             break
 
     # detect cases of 'GASNet timer calibration on %s detected non-linear
     # timer behavior:' messages which we can't do much about
-    err_strings = [r'GASNet timer calibration on']
+    err_strings = [r"GASNet timer calibration on"]
     for s in err_strings:
-        if (re.search(s, output, re.IGNORECASE) != None):
-            extra_msg = '(private issue #480) '
+        if re.search(s, output, re.IGNORECASE) != None:
+            extra_msg = "(private issue #480) "
             break
 
     # detect cases of a known issue on our EX testbed
-    err_strings = [r'Failed to destroy CXI Service']
+    err_strings = [r"Failed to destroy CXI Service"]
     for s in err_strings:
-        if (re.search(s, output, re.IGNORECASE) != None):
-            extra_msg = '(private issue #6295) '
+        if re.search(s, output, re.IGNORECASE) != None:
+            extra_msg = "(private issue #6295) "
             break
 
     return extra_msg
 
+
 def get_chpl_base(compiler):
     """Returns the normalized path to the base installation."""
-    if not os.access(compiler,os.R_OK|os.X_OK):
-        Fatal('Cannot execute compiler \''+compiler+'\'')
+    if not os.access(compiler, os.R_OK | os.X_OK):
+        Fatal("Cannot execute compiler '" + compiler + "'")
 
-    path_to_compiler=os.path.abspath(os.path.dirname(compiler))
+    path_to_compiler = os.path.abspath(os.path.dirname(compiler))
     # Assume chpl binary is 2 directory levels down in the base installation
-    (chpl_base, tmp) = os.path.split(path_to_compiler)
-    (chpl_base, tmp) = os.path.split(chpl_base)
-    chpl_base=os.path.normpath(chpl_base)
+    chpl_base, tmp = os.path.split(path_to_compiler)
+    chpl_base, tmp = os.path.split(chpl_base)
+    chpl_base = os.path.normpath(chpl_base)
     # sys.stdout.write('CHPL_BASE='+chpl_base+'\n')
     return chpl_base
+
 
 def get_chpl_home(chpl_base):
     """Returns the normalized path to the Chapel installation."""
     # If $CHPL_HOME is not set, use the base installation of the compiler
-    chpl_home=os.getenv('CHPL_HOME', chpl_base)
-    chpl_home=os.path.normpath(chpl_home)
+    chpl_home = os.getenv("CHPL_HOME", chpl_base)
+    chpl_home = os.path.normpath(chpl_home)
     # sys.stdout.write('CHPL_HOME='+chpl_home+'\n')
     return chpl_home
 
+
 def get_test_dir(chpl_home):
     """Find the test directory."""
-    testdir=chpl_home+'/test'
-    if os.path.isdir(testdir)==0:
-        testdir=chpl_home+'/examples'
-        if os.path.isdir(testdir)==0:
-            Fatal('Cannot find test directory '+chpl_home+'/test or '+testdir)
+    testdir = chpl_home + "/test"
+    if os.path.isdir(testdir) == 0:
+        testdir = chpl_home + "/examples"
+        if os.path.isdir(testdir) == 0:
+            Fatal(
+                "Cannot find test directory "
+                + chpl_home
+                + "/test or "
+                + testdir
+            )
     # Needed for MacOS mount points
     testdir = os.path.realpath(testdir)
     # sys.stdout.write('testdir='+testdir+'\n')
 
     # If user specified a different test directory (e.g. with --test-root flag on
     # start_test), use it instead.
-    test_root_dir = os.environ.get('CHPL_TEST_ROOT_DIR')
+    test_root_dir = os.environ.get("CHPL_TEST_ROOT_DIR")
     if test_root_dir is not None:
         testdir = test_root_dir
     return testdir
+
 
 def get_local_dir(test_dir):
     """Returns the cwd relative to the test directory."""
 
     # Get the current directory (normalize for MacOS case-sort-of-sensitivity)
-    localdir = os.path.normpath(os.getcwd()).replace(test_dir, '.')
+    localdir = os.path.normpath(os.getcwd()).replace(test_dir, ".")
     # sys.stdout.write('localdir=%s\n'%(localdir))
 
-    if localdir.find('./') == 0:
+    if localdir.find("./") == 0:
         # strip off the leading './'
-        localdir = localdir.lstrip('.')
-        localdir = localdir.lstrip('/')
+        localdir = localdir.lstrip(".")
+        localdir = localdir.lstrip("/")
     # sys.stdout.write('localdir=%s\n'%(localdir))
 
     return localdir
 
+
 def get_util_dir():
     """Find the test util directory -- set this in start_test to use
-        a version of start_test other than the one in CHPL_HOME."""
-    utildir=os.getenv('CHPL_TEST_UTIL_DIR')
+    a version of start_test other than the one in CHPL_HOME."""
+    utildir = os.getenv("CHPL_TEST_UTIL_DIR")
     if utildir is None or not os.path.isdir(utildir):
-        Fatal('Cannot find test util directory {0}'.format(utildir))
+        Fatal("Cannot find test util directory {0}".format(utildir))
 
     # Needed for MacOS mount points
     utildir = os.path.realpath(utildir)
     # sys.stdout.write('utildir='+utildir+'\n')
     return utildir
 
+
 def get_config_dir(util_dir):
-    return os.path.join(util_dir, 'config')
+    return os.path.join(util_dir, "config")
+
 
 def main():
     # Start of sub_test proper
@@ -850,12 +988,12 @@ def main():
     global chplcommstr, chplnastr, chpllmstr, chpltasksstr, perflabel
     global useLauncherTimeout, localdir, sub_test_start_time
 
-    if len(sys.argv)!=2:
-        print('usage: sub_test COMPILER')
+    if len(sys.argv) != 2:
+        print("usage: sub_test COMPILER")
         sys.exit(0)
 
-    compiler=sys.argv[1]
-    is_chpldoc = compiler.endswith('chpldoc')
+    compiler = sys.argv[1]
+    is_chpldoc = compiler.endswith("chpldoc")
     chpl_base = get_chpl_base(compiler)
     chpl_home = get_chpl_home(chpl_base)
     testdir = get_test_dir(chpl_home)
@@ -870,6 +1008,7 @@ def main():
     # because the test venv is built inside of CHPL_HOME.
     # We do this so tests/prediffs can use the system python instead of the venv
     import fixpath
+
     fixpath.update_path_env()
 
     sub_test_start_time = time.time()
@@ -879,80 +1018,84 @@ def main():
     # We open the compileline inside of CHPL_HOME rather than CHPL_TEST_UTIL_DIR on
     # purpose. compileline will not work correctly in some configurations when run
     # outside of its directory tree.
-    compileline = os.path.join(chpl_home, 'util', 'config', 'compileline')
+    compileline = os.path.join(chpl_home, "util", "config", "compileline")
+
     @cache
     def run_compileline(flag, lookingfor):
-        (returncode, result, _) = run_process([compileline, flag],
-                                              stdout=subprocess.PIPE,
-                                              stderr=subprocess.PIPE)
+        returncode, result, _ = run_process(
+            [compileline, flag], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
         result = result.rstrip()
         if returncode != 0:
-            Fatal('Cannot find ' + lookingfor)
+            Fatal("Cannot find " + lookingfor)
         return result
 
     # Use timedexec
     # As much as I hate calling out to another script for the time out stuff,
     #  subprocess doesn't quite cut it for this kind of stuff
-    useTimedExec=True
+    useTimedExec = True
     if useTimedExec:
-        timedexec=utildir+'/test/timedexec'
-        if not os.access(timedexec,os.R_OK|os.X_OK):
-            Fatal('Cannot execute timedexec script \''+timedexec+'\'')
+        timedexec = utildir + "/test/timedexec"
+        if not os.access(timedexec, os.R_OK | os.X_OK):
+            Fatal("Cannot execute timedexec script '" + timedexec + "'")
     # sys.stdout.write('timedexec='+timedexec+'\n')
 
     # HW platform
-    platform = run_process([utildir+'/chplenv/chpl_platform.py', '--target'], stdout=subprocess.PIPE)[1]
+    platform = run_process(
+        [utildir + "/chplenv/chpl_platform.py", "--target"],
+        stdout=subprocess.PIPE,
+    )[1]
     platform = platform.strip()
     # sys.stdout.write('platform='+platform+'\n')
 
     # Machine name we are running on
-    machine=os.uname()[1].split('.', 1)[0]
+    machine = os.uname()[1].split(".", 1)[0]
     # sys.stdout.write('machine='+machine+'\n')
 
     # Get the system-wide preexec(s)
-    systemPreexecs = os.getenv('CHPL_SYSTEM_PREEXEC')
+    systemPreexecs = os.getenv("CHPL_SYSTEM_PREEXEC")
     if systemPreexecs:
-        systemPreexecs = systemPreexecs.strip().split(',')
+        systemPreexecs = systemPreexecs.strip().split(",")
         for spreexec in systemPreexecs:
-            if not os.access(spreexec, os.R_OK|os.X_OK):
-                Fatal('Cannot execute system-wide preexec \''+spreexec+'\'')
+            if not os.access(spreexec, os.R_OK | os.X_OK):
+                Fatal("Cannot execute system-wide preexec '" + spreexec + "'")
 
     # Get the system-wide prediff(s)
-    systemPrediffs = os.getenv('CHPL_SYSTEM_PREDIFF')
+    systemPrediffs = os.getenv("CHPL_SYSTEM_PREDIFF")
     if systemPrediffs:
-        systemPrediffs = systemPrediffs.strip().split(',')
+        systemPrediffs = systemPrediffs.strip().split(",")
         for sprediff in systemPrediffs:
-            if not os.access(sprediff,os.R_OK|os.X_OK):
-                Fatal('Cannot execute system-wide prediff \''+sprediff+'\'')
+            if not os.access(sprediff, os.R_OK | os.X_OK):
+                Fatal("Cannot execute system-wide prediff '" + sprediff + "'")
 
     # Use the launcher walltime option for timeout
-    useLauncherTimeout = os.getenv('CHPL_LAUNCHER_TIMEOUT')
+    useLauncherTimeout = os.getenv("CHPL_LAUNCHER_TIMEOUT")
 
     uniquifyTests = False
-    if os.getenv('CHPL_TEST_UNIQUIFY_EXE') != None:
+    if os.getenv("CHPL_TEST_UNIQUIFY_EXE") != None:
         uniquifyTests = True
 
     # CHPL_COMM
-    chplcomm=os.getenv('CHPL_COMM','none').strip()
-    chplcommstr='.comm-'+chplcomm
+    chplcomm = os.getenv("CHPL_COMM", "none").strip()
+    chplcommstr = ".comm-" + chplcomm
     # sys.stdout.write('chplcomm=%s\n'%(chplcomm))
 
     # CHPL_NETWORK_ATOMICS
-    chplna=os.getenv('CHPL_NETWORK_ATOMICS','none').strip()
-    chplnastr='.na-'+chplna
+    chplna = os.getenv("CHPL_NETWORK_ATOMICS", "none").strip()
+    chplnastr = ".na-" + chplna
     # sys.stdout.write('chplna=%s\n'%(chplna))
 
     # CHPL_LAUNCHER
-    chpllauncher=os.getenv('CHPL_LAUNCHER','none').strip()
+    chpllauncher = os.getenv("CHPL_LAUNCHER", "none").strip()
 
     # CHPL_LOCALE_MODEL
-    chpllm=os.getenv('CHPL_LOCALE_MODEL','flat').strip()
-    chpllmstr='.lm-'+chpllm
+    chpllm = os.getenv("CHPL_LOCALE_MODEL", "flat").strip()
+    chpllmstr = ".lm-" + chpllm
     # sys.stdout.write('lm=%s\n'%(chpllm))
 
     # CHPL_TASKS
-    chpltasks=os.getenv('CHPL_TASKS', 'none').strip()
-    chpltasksstr='.tasks-'+chpltasks
+    chpltasks = os.getenv("CHPL_TASKS", "none").strip()
+    chpltasksstr = ".tasks-" + chpltasks
 
     #
     # Test options for all tests in this directory
@@ -962,157 +1105,182 @@ def main():
     # directory-wide PRETEST
     # must be run first, in case it generates any of the following files
     #
-    if os.access('./PRETEST', os.R_OK|os.X_OK):
-        sys.stdout.write('[Executing ./PRETEST %s]\n'%(compiler))
+    if os.access("./PRETEST", os.R_OK | os.X_OK):
+        sys.stdout.write("[Executing ./PRETEST %s]\n" % (compiler))
         sys.stdout.flush()
-        stdout = run_process(['./PRETEST', compiler],
-                             stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT,
-                             env=os.environ)[1]
+        stdout = run_process(
+            ["./PRETEST", compiler],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=os.environ,
+        )[1]
         sys.stdout.write(stdout)
         sys.stdout.flush()
 
-    if os.getenv('CHPL_TEST_PERF')!=None:
-        perftest=True
-        perflabel=os.getenv('CHPL_TEST_PERF_LABEL')
-        perfdir=os.getenv('CHPL_TEST_PERF_DIR')
-        perfdescription = os.getenv('CHPL_TEST_PERF_DESCRIPTION')
+    if os.getenv("CHPL_TEST_PERF") != None:
+        perftest = True
+        perflabel = os.getenv("CHPL_TEST_PERF_LABEL")
+        perfdir = os.getenv("CHPL_TEST_PERF_DIR")
+        perfdescription = os.getenv("CHPL_TEST_PERF_DESCRIPTION")
         if perfdescription != None:
-            sys.stdout.write('Setting perfdir to %s from %s because of additional perf description\n' %(os.path.join(perfdir, perfdescription), perfdir))
+            sys.stdout.write(
+                "Setting perfdir to %s from %s because of additional perf description\n"
+                % (os.path.join(perfdir, perfdescription), perfdir)
+            )
             perfdir = os.path.join(perfdir, perfdescription)
         else:
-            perfdescription= ''
-        if perflabel==None or perfdir==None:
-            Fatal('$CHPL_TEST_PERF_DIR and $CHPL_TEST_PERF_LABEL must be set for performance testing')
+            perfdescription = ""
+        if perflabel == None or perfdir == None:
+            Fatal(
+                "$CHPL_TEST_PERF_DIR and $CHPL_TEST_PERF_LABEL must be set for performance testing"
+            )
     else:
-        perftest=False
-        perflabel=''
+        perftest = False
+        perflabel = ""
 
-    compoptssuffix = PerfSfx('compopts')  # .compopts or .perfcompopts or ...
+    compoptssuffix = PerfSfx("compopts")  # .compopts or .perfcompopts or ...
 
     # If compiler is chpldoc, use .chpldocopts for options.
-    chpldocsuffix = '.chpldocopts'
+    chpldocsuffix = ".chpldocopts"
 
-    compenvsuffix  = PerfSfx('compenv')   # compenv  or .perfcompenv  or ...
-    execenvsuffix  = PerfSfx('execenv')   # .execenv  or .perfexecenv  or ...
-    execoptssuffix = PerfSfx('execopts')  # .execopts or .perfexecopts or ...
-    timeoutsuffix  = PerfSfx('timeout')   # .timeout  or .perftimeout  or ...
+    compenvsuffix = PerfSfx("compenv")  # compenv  or .perfcompenv  or ...
+    execenvsuffix = PerfSfx("execenv")  # .execenv  or .perfexecenv  or ...
+    execoptssuffix = PerfSfx("execopts")  # .execopts or .perfexecopts or ...
+    timeoutsuffix = PerfSfx("timeout")  # .timeout  or .perftimeout  or ...
     # sys.stdout.write('perftest=%d perflabel=%s\n'%(perftest,perflabel))
 
     # Get global timeout
-    if os.getenv('CHPL_TEST_VGRND_COMP')=='on' or os.getenv('CHPL_TEST_VGRND_EXE')=='on':
-        defaultTimeout=1000
+    if (
+        os.getenv("CHPL_TEST_VGRND_COMP") == "on"
+        or os.getenv("CHPL_TEST_VGRND_EXE") == "on"
+    ):
+        defaultTimeout = 1000
     else:
-        defaultTimeout=300
-    globalTimeout = int(os.getenv('CHPL_TEST_TIMEOUT', defaultTimeout))
+        defaultTimeout = 300
+    globalTimeout = int(os.getenv("CHPL_TEST_TIMEOUT", defaultTimeout))
 
     # get a threshold for which to report long running tests
     if os.getenv("CHPL_TEST_EXEC_TIME_WARN_LIMIT"):
-        execTimeWarnLimit = int(os.getenv('CHPL_TEST_EXEC_TIME_WARN_LIMIT', '0'))
+        execTimeWarnLimit = int(
+            os.getenv("CHPL_TEST_EXEC_TIME_WARN_LIMIT", "0")
+        )
     else:
         execTimeWarnLimit = 0
 
     # get a threshold for which to skip any remaining trials
     if os.getenv("CHPL_TEST_EXEC_TIME_LIMIT_NUM_TRIALS"):
-        execTimeSkipTrials = int(os.getenv('CHPL_TEST_EXEC_TIME_LIMIT_NUM_TRIALS', '0'))
+        execTimeSkipTrials = int(
+            os.getenv("CHPL_TEST_EXEC_TIME_LIMIT_NUM_TRIALS", "0")
+        )
     else:
         execTimeSkipTrials = 0
 
     # directory level timeout
     directoryTimeout = globalTimeout
-    if os.access('./TIMEOUT',os.R_OK):
-        fileTimeout = ReadIntegerValue('./TIMEOUT', localdir)
+    if os.access("./TIMEOUT", os.R_OK):
+        fileTimeout = ReadIntegerValue("./TIMEOUT", localdir)
         if fileTimeout < defaultTimeout or fileTimeout > globalTimeout:
             directoryTimeout = fileTimeout
     # sys.stdout.write('globalTimeout=%d\n'%(globalTimeout))
 
     # Check for global PERFTIMEEXEC option
-    timerFile = PerfDirFile('TIMEEXEC') # e.g. ./PERFTIMEEXEC
+    timerFile = PerfDirFile("TIMEEXEC")  # e.g. ./PERFTIMEEXEC
     if os.access(timerFile, os.R_OK):
         globalTimer = GetTimer(timerFile)
     else:
         globalTimer = None
 
     # Get global timeout for kill
-    if os.access('./KILLTIMEOUT',os.R_OK):
-        globalKillTimeout = ReadIntegerValue('./KILLTIMEOUT', localdir)
+    if os.access("./KILLTIMEOUT", os.R_OK):
+        globalKillTimeout = ReadIntegerValue("./KILLTIMEOUT", localdir)
     else:
-        globalKillTimeout=10
+        globalKillTimeout = 10
     # sys.stdout.write('globalKillTimeout=%d\n'%(globalKillTimeout))
 
-    if os.access('./NOEXEC',os.R_OK):
-        execute=False
+    if os.access("./NOEXEC", os.R_OK):
+        execute = False
     else:
-        execute=True
+        execute = True
     # sys.stdout.write('execute=%d\n'%(execute))
 
-    if os.access('./NOVGRBIN',os.R_OK):
-        vgrbin=False
+    if os.access("./NOVGRBIN", os.R_OK):
+        vgrbin = False
     else:
-        vgrbin=True
+        vgrbin = True
     # sys.stdout.write('vgrbin=%d\n'%(vgrbin))
 
-    if os.access('./COMPSTDIN',os.R_OK):
-        compstdin='./COMPSTDIN'
+    if os.access("./COMPSTDIN", os.R_OK):
+        compstdin = "./COMPSTDIN"
     else:
-        compstdin='/dev/null'
+        compstdin = "/dev/null"
     # sys.stdout.write('compstdin=%s\n'%(compstdin))
 
-    globalLastcompopts=list()
-    if os.access('./LASTCOMPOPTS',os.R_OK):
-        globalLastcompopts+=ReadFileWithComments('./LASTCOMPOPTS')[0].strip().split()
+    globalLastcompopts = list()
+    if os.access("./LASTCOMPOPTS", os.R_OK):
+        globalLastcompopts += (
+            ReadFileWithComments("./LASTCOMPOPTS")[0].strip().split()
+        )
     # sys.stdout.write('globalLastcompopts=%s\n'%(globalLastcompopts))
 
-    globalLastexecopts=list()
-    if os.access('./LASTEXECOPTS',os.R_OK):
-        globalLastexecopts+=ReadFileWithComments('./LASTCOMPOPTS')[0].strip().split()
+    globalLastexecopts = list()
+    if os.access("./LASTEXECOPTS", os.R_OK):
+        globalLastexecopts += (
+            ReadFileWithComments("./LASTCOMPOPTS")[0].strip().split()
+        )
     # sys.stdout.write('globalLastexecopts=%s\n'%(globalLastexecopts))
 
-    if os.access(PerfDirFile('NUMLOCALES'),os.R_OK):
-        globalNumlocales=ReadIntegerValue(PerfDirFile('NUMLOCALES'), localdir)
+    if os.access(PerfDirFile("NUMLOCALES"), os.R_OK):
+        globalNumlocales = ReadIntegerValue(PerfDirFile("NUMLOCALES"), localdir)
         # globalNumlocales.strip(globalNumlocales)
     else:
         # start_test sets this, so we'll assume it's right :)
-        globalNumlocales=int(os.getenv('NUMLOCALES', '0'))
+        globalNumlocales = int(os.getenv("NUMLOCALES", "0"))
     # sys.stdout.write('globalNumlocales=%s\n'%(globalNumlocales))
 
-    maxLocalesAvailable = os.getenv('CHPL_TEST_MAX_LOCALES')
+    maxLocalesAvailable = os.getenv("CHPL_TEST_MAX_LOCALES")
     if maxLocalesAvailable == None:
-        maxLocalesAvailable = os.getenv('CHPL_TEST_NUM_LOCALES_AVAILABLE')
+        maxLocalesAvailable = os.getenv("CHPL_TEST_NUM_LOCALES_AVAILABLE")
     if maxLocalesAvailable is not None:
         maxLocalesAvailable = int(maxLocalesAvailable)
 
-    if os.access('./CATFILES',os.R_OK):
-        globalCatfiles=run_process(['cat', './CATFILES'], stdout=subprocess.PIPE)[1]
+    if os.access("./CATFILES", os.R_OK):
+        globalCatfiles = run_process(
+            ["cat", "./CATFILES"], stdout=subprocess.PIPE
+        )[1]
         globalCatfiles.strip(globalCatfiles)
     else:
-        globalCatfiles=None
+        globalCatfiles = None
     # sys.stdout.write('globalCatfiles=%s\n'%(globalCatfiles))
 
     #
     # valgrind stuff
     #
-    chpl_valgrind_opts=os.getenv('CHPL_VALGRIND_OPTS', '--tool=memcheck')
+    chpl_valgrind_opts = os.getenv("CHPL_VALGRIND_OPTS", "--tool=memcheck")
     # sys.stdout.write('chpl_valgrind_opts=%s\n'%(chpl_valgrind_opts))
 
-    if os.getenv('CHPL_TEST_VGRND_COMP')=='on':
-        valgrindcomp = 'valgrind'
-        valgrindcompopts=chpl_valgrind_opts.split()
-        valgrindcompopts+=['--gen-suppressions=all']
-        valgrindcompopts+=['--suppressions=%s/compiler/etc/valgrind.suppressions'%(chpl_home)]
-        valgrindcompopts+=['-q']
+    if os.getenv("CHPL_TEST_VGRND_COMP") == "on":
+        valgrindcomp = "valgrind"
+        valgrindcompopts = chpl_valgrind_opts.split()
+        valgrindcompopts += ["--gen-suppressions=all"]
+        valgrindcompopts += [
+            "--suppressions=%s/compiler/etc/valgrind.suppressions" % (chpl_home)
+        ]
+        valgrindcompopts += ["-q"]
     else:
         valgrindcomp = None
         valgrindcompopts = None
     # sys.stdout.write('valgrindcomp=%s %s\n'%(valgrindcomp, valgrindcompopts))
 
-    if (os.getenv('CHPL_TEST_VGRND_EXE')=='on' and vgrbin):
-        valgrindbin = 'valgrind'
-        valgrindbinopts = chpl_valgrind_opts.split()+['-q']
-        if (chplcomm!='none'):
-            valgrindbinopts+=['--trace-children=yes']
-            if (chplcomm=='gasnet'):
-                valgrindbinopts+=['--suppressions=%s/third-party/gasnet/gasnet-src/other/valgrind/gasnet.supp'%(chpl_home)]
+    if os.getenv("CHPL_TEST_VGRND_EXE") == "on" and vgrbin:
+        valgrindbin = "valgrind"
+        valgrindbinopts = chpl_valgrind_opts.split() + ["-q"]
+        if chplcomm != "none":
+            valgrindbinopts += ["--trace-children=yes"]
+            if chplcomm == "gasnet":
+                valgrindbinopts += [
+                    "--suppressions=%s/third-party/gasnet/gasnet-src/other/valgrind/gasnet.supp"
+                    % (chpl_home)
+                ]
     else:
         valgrindbin = None
         valgrindbinopts = None
@@ -1122,57 +1290,60 @@ def main():
     # Misc set up
     #
 
-    testfutures=int(os.getenv('CHPL_TEST_FUTURES','0'))
+    testfutures = int(os.getenv("CHPL_TEST_FUTURES", "0"))
     # sys.stdout.write('testfutures=%s\n'%(testfutures))
 
-    testnotests=os.getenv('CHPL_TEST_NOTESTS')
+    testnotests = os.getenv("CHPL_TEST_NOTESTS")
     # sys.stdout.write('testnotests=%s\n'%(testnotests))
 
-    launchcmd=os.getenv('LAUNCHCMD')
+    launchcmd = os.getenv("LAUNCHCMD")
     # sys.stdout.write('launchcmd=%s\n'%(launchcmd))
 
-    if os.getenv('CHPL_TEST_INTERP')=='on':
-        execute=False
-        futureSuffix='.ifuture'
+    if os.getenv("CHPL_TEST_INTERP") == "on":
+        execute = False
+        futureSuffix = ".ifuture"
     else:
-        futureSuffix='.future'
+        futureSuffix = ".future"
     # sys.stdout.write('futureSuffix=%s\n'%(futureSuffix))
 
     printpassesfile = None
-    if os.getenv('CHPL_TEST_COMP_PERF')!=None:
-        compperftest=True
+    if os.getenv("CHPL_TEST_COMP_PERF") != None:
+        compperftest = True
 
         # check for the main compiler performance directory
-        if os.getenv('CHPL_TEST_COMP_PERF_DIR')!=None:
-            compperfdir=os.getenv('CHPL_TEST_COMP_PERF_DIR')
+        if os.getenv("CHPL_TEST_COMP_PERF_DIR") != None:
+            compperfdir = os.getenv("CHPL_TEST_COMP_PERF_DIR")
         else:
-            compperfdir=chpl_home+'/test/compperfdat/'
+            compperfdir = chpl_home + "/test/compperfdat/"
 
         # The env var CHPL_PRINT_PASSES_FILE will cause the
         # compiler to save the pass timings to specified file.
-        if os.getenv('CHPL_PRINT_PASSES_FILE')!=None:
-            printpassesfile=os.getenv('CHPL_PRINT_PASSES_FILE')
+        if os.getenv("CHPL_PRINT_PASSES_FILE") != None:
+            printpassesfile = os.getenv("CHPL_PRINT_PASSES_FILE")
         else:
-            printpassesfile='timing.txt'
-            os.environ['CHPL_PRINT_PASSES_FILE'] = 'timing.txt'
+            printpassesfile = "timing.txt"
+            os.environ["CHPL_PRINT_PASSES_FILE"] = "timing.txt"
         # make sure we also collect memory usage data
-        os.environ['CHPL_PRINT_PASSES_MEMORY'] = '1'
+        os.environ["CHPL_PRINT_PASSES_MEMORY"] = "1"
 
         # check for the perfkeys file
-        if os.getenv('CHPL_TEST_COMP_PERF_KEYS')!=None:
-            keyfile=os.getenv('CHPL_TEST_COMP_PERF_KEYS')
+        if os.getenv("CHPL_TEST_COMP_PERF_KEYS") != None:
+            keyfile = os.getenv("CHPL_TEST_COMP_PERF_KEYS")
         else:
-            keyfile=chpl_home+'/test/performance/compiler/compilerPerformance.perfkeys'
+            keyfile = (
+                chpl_home
+                + "/test/performance/compiler/compilerPerformance.perfkeys"
+            )
 
         # Check for the directory to store the temporary .dat files that will get
         # combined into one.
-        if os.getenv('CHPL_TEST_COMP_PERF_TEMP_DAT_DIR')!=None:
-            tempDatFilesDir = os.getenv('CHPL_TEST_COMP_PERF_TEMP_DAT_DIR')
+        if os.getenv("CHPL_TEST_COMP_PERF_TEMP_DAT_DIR") != None:
+            tempDatFilesDir = os.getenv("CHPL_TEST_COMP_PERF_TEMP_DAT_DIR")
         else:
-            tempDatFilesDir = compperfdir + 'tempCompPerfDatFiles/'
+            tempDatFilesDir = compperfdir + "tempCompPerfDatFiles/"
 
     else:
-        compperftest=False
+        compperftest = False
 
     #
     # Global COMPOPTS/PERFCOMPOPTS:
@@ -1184,26 +1355,28 @@ def main():
     #   compatibility.
     #
 
-    directoryCompopts = list(' ')
-    if (perftest and os.access(PerfDirFile('COMPOPTS'),os.R_OK)): # ./PERFCOMPOPTS
-        directoryCompopts=ReadFileWithComments(PerfDirFile('COMPOPTS'))
-    elif os.access('./COMPOPTS',os.R_OK):
-        directoryCompopts=ReadFileWithComments('./COMPOPTS')
+    directoryCompopts = list(" ")
+    if perftest and os.access(
+        PerfDirFile("COMPOPTS"), os.R_OK
+    ):  # ./PERFCOMPOPTS
+        directoryCompopts = ReadFileWithComments(PerfDirFile("COMPOPTS"))
+    elif os.access("./COMPOPTS", os.R_OK):
+        directoryCompopts = ReadFileWithComments("./COMPOPTS")
 
-    envCompopts = os.getenv('COMPOPTS')
+    envCompopts = os.getenv("COMPOPTS")
     if envCompopts is not None:
         envCompopts = shlex.split(envCompopts)
     else:
         envCompopts = []
 
     # Global CHPLDOCOPTS
-    if os.access('./CHPLDOCOPTS', os.R_OK):
-        dirChpldocOpts = shlex.split(ReadFileWithComments('./CHPLDOCOPTS')[0])
+    if os.access("./CHPLDOCOPTS", os.R_OK):
+        dirChpldocOpts = shlex.split(ReadFileWithComments("./CHPLDOCOPTS")[0])
     else:
         dirChpldocOpts = []
 
     # Env CHPLDOCOPTS
-    envChpldocOpts = os.getenv('CHPLDOCOPTS')
+    envChpldocOpts = os.getenv("CHPLDOCOPTS")
     if envChpldocOpts is not None:
         envChpldocOpts = shlex.split(envChpldocOpts)
     else:
@@ -1215,18 +1388,18 @@ def main():
     #
     # Global PERFNUMTRIALS
     #
-    if os.access(PerfDirFile('NUMTRIALS'), os.R_OK): # ./PERFNUMTRIALS
-        globalNumTrials = ReadIntegerValue(PerfDirFile('NUMTRIALS'), localdir)
+    if os.access(PerfDirFile("NUMTRIALS"), os.R_OK):  # ./PERFNUMTRIALS
+        globalNumTrials = ReadIntegerValue(PerfDirFile("NUMTRIALS"), localdir)
     else:
-        globalNumTrials=int(os.getenv('CHPL_TEST_NUM_TRIALS', '1'))
+        globalNumTrials = int(os.getenv("CHPL_TEST_NUM_TRIALS", "1"))
 
     #
     # Global COMPENV
     #
-    if os.access('./COMPENV',os.R_OK):
-        globalCompenv=ReadFileWithComments('./COMPENV')
+    if os.access("./COMPENV", os.R_OK):
+        globalCompenv = ReadFileWithComments("./COMPENV")
     else:
-        globalCompenv=list()
+        globalCompenv = list()
 
     #
     # Global EXECOPTS/PERFEXECOPTS
@@ -1239,10 +1412,12 @@ def main():
     #   compatibility.
     #
     filename = None
-    if (perftest and os.access(PerfDirFile('EXECOPTS'),os.R_OK)): # ./PERFEXECOPTS
-        filename = PerfDirFile('EXECOPTS')
-    elif os.access('./EXECOPTS',os.R_OK):
-        filename = './EXECOPTS'
+    if perftest and os.access(
+        PerfDirFile("EXECOPTS"), os.R_OK
+    ):  # ./PERFEXECOPTS
+        filename = PerfDirFile("EXECOPTS")
+    elif os.access("./EXECOPTS", os.R_OK):
+        filename = "./EXECOPTS"
     if filename is not None:
         tgeo = ReadFileWithComments(filename)
         if len(tgeo) >= 1:
@@ -1256,26 +1431,26 @@ def main():
             globalExecopts = list()
     else:
         globalExecopts = list()
-    envExecopts = os.getenv('EXECOPTS')
+    envExecopts = os.getenv("EXECOPTS")
     # sys.stdout.write('globalExecopts=%s\n'%(globalExecopts))
 
     #
     # Global PRECOMP, PREDIFF & PREEXEC
     #
-    if os.access('./PRECOMP', os.R_OK|os.X_OK):
-        globalPrecomp='./PRECOMP'
+    if os.access("./PRECOMP", os.R_OK | os.X_OK):
+        globalPrecomp = "./PRECOMP"
     else:
-        globalPrecomp=None
+        globalPrecomp = None
     #
-    if os.access('./PREDIFF',os.R_OK|os.X_OK):
-        globalPrediff='./PREDIFF'
+    if os.access("./PREDIFF", os.R_OK | os.X_OK):
+        globalPrediff = "./PREDIFF"
     else:
-        globalPrediff=None
+        globalPrediff = None
     # sys.stdout.write('globalPrediff=%s\n'%(globalPrediff))
-    if os.access('./PREEXEC',os.R_OK|os.X_OK):
-        globalPreexec='./PREEXEC'
+    if os.access("./PREEXEC", os.R_OK | os.X_OK):
+        globalPreexec = "./PREEXEC"
     else:
-        globalPreexec=None
+        globalPreexec = None
 
     #
     # Start running tests
@@ -1283,14 +1458,14 @@ def main():
     printStartOfTestMsg(time.localtime(), systemPreexecs, systemPrediffs)
 
     # consistently look only at the files in the current directory
-    dirlist=os.listdir(".")
+    dirlist = os.listdir(".")
     dirlist.sort()
 
-    onetestsrc = os.getenv('CHPL_ONETEST')
-    if onetestsrc==None:
-        testsrc=filter(hasTestableExtension, dirlist)
+    onetestsrc = os.getenv("CHPL_ONETEST")
+    if onetestsrc == None:
+        testsrc = filter(hasTestableExtension, dirlist)
     else:
-        testsrc=list()
+        testsrc = list()
         testsrc.append(onetestsrc)
 
     original_compiler = compiler
@@ -1302,22 +1477,29 @@ def main():
 
         # print testname
         printTestName(os.path.join(localdir, testname))
-        if m := re.match(r'^(.*)\.(?:chpl|test\.c|test\.cpp|ml-test\.c|ml-test\.cpp)$', testname):
+        if m := re.match(
+            r"^(.*)\.(?:chpl|test\.c|test\.cpp|ml-test\.c|ml-test\.cpp)$",
+            testname,
+        ):
             test_filename = m.group(1)
         else:
-            sys.stdout.write('[Error: {} does not match the expected format for a test name]\n'.format(testname))
+            sys.stdout.write(
+                "[Error: {} does not match the expected format for a test name]\n".format(
+                    testname
+                )
+            )
             continue
         execname = test_filename
         if uniquifyTests:
-            execname += '.{0}'.format(os.getpid())
+            execname += ".{0}".format(os.getpid())
         # print test_filename
 
         is_c_test = testname.endswith(".test.c")
         is_ml_c_test = testname.endswith(".ml-test.c")
         is_cpp_test = testname.endswith(".test.cpp")
         is_ml_cpp_test = testname.endswith(".ml-test.cpp")
-        is_c_or_cpp_test = (is_c_test or is_cpp_test)
-        is_ml_c_or_cpp_test = (is_ml_c_test or is_ml_cpp_test)
+        is_c_or_cpp_test = is_c_test or is_cpp_test
+        is_ml_c_or_cpp_test = is_ml_c_test or is_ml_cpp_test
         c_or_cpp = None
         if is_c_test or is_ml_c_test:
             c_or_cpp = "c"
@@ -1326,7 +1508,7 @@ def main():
 
         # If the test name ends with .doc.chpl or the compiler was set to chpldoc
         # (i.e. is_chpldoc=True), run this test with chpldoc options.
-        if testname.endswith('.doc.chpl') or is_chpldoc:
+        if testname.endswith(".doc.chpl") or is_chpldoc:
             test_is_chpldoc = True
         else:
             test_is_chpldoc = False
@@ -1344,24 +1526,37 @@ def main():
         # sys.stdout.write("lastexecopts=%s\n"%(lastexecopts))
 
         # Get the list of files starting with 'test_filename.'
-        test_filename_files = fnmatch.filter(dirlist, test_filename+'.*')
-        test_filename_files += fnmatch.filter(dirlist, 'SUPPRESSIF')
+        test_filename_files = fnmatch.filter(dirlist, test_filename + ".*")
+        test_filename_files += fnmatch.filter(dirlist, "SUPPRESSIF")
         # print test_filename_files, dirlist
 
-        if (perftest and (test_filename_files.count(PerfTFile(test_filename,'keys'))==0) and
-            (test_filename_files.count(PerfTFile(test_filename,'execopts'))==0) and
-            (test_filename_files.count(PerfTFile(test_filename,'compopts'))==0)):
-            sys.stdout.write('[Skipping noperf test: %s/%s]\n'%(localdir,test_filename))
-            continue # on to next test
+        if (
+            perftest
+            and (
+                test_filename_files.count(PerfTFile(test_filename, "keys")) == 0
+            )
+            and (
+                test_filename_files.count(PerfTFile(test_filename, "execopts"))
+                == 0
+            )
+            and (
+                test_filename_files.count(PerfTFile(test_filename, "compopts"))
+                == 0
+            )
+        ):
+            sys.stdout.write(
+                "[Skipping noperf test: %s/%s]\n" % (localdir, test_filename)
+            )
+            continue  # on to next test
 
         timeout = directoryTimeout
         killtimeout = globalKillTimeout
         numTrials = globalNumTrials
-        if (perftest):
+        if perftest:
             timer = globalTimer
         else:
             timer = None
-        futuretest=''
+        futuretest = ""
 
         if test_is_chpldoc:
             executebin = False
@@ -1377,25 +1572,25 @@ def main():
         preexec=None
         postexec=None
 
-        if os.getenv('CHPL_NO_STDIN_REDIRECT') == None:
-            redirectin = '/dev/null'
+        if os.getenv("CHPL_NO_STDIN_REDIRECT") == None:
+            redirectin = "/dev/null"
         else:
             redirectin = None
 
         # If there is a .skipif file, put it at front of list.
         skipif_i = -1
         for i, test_filename_file in enumerate(test_filename_files):
-            if test_filename_file.endswith('.skipif'):
+            if test_filename_file.endswith(".skipif"):
                 skipif_i = i
                 break
         if skipif_i > 0:
             test_filename_files.insert(0, test_filename_files.pop(skipif_i))
 
         # Deal with these files
-        do_not_test=False
+        do_not_test = False
         for f in test_filename_files:
             name = os.path.basename(f)
-            (root, suffix) = os.path.splitext(f)
+            root, suffix = os.path.splitext(f)
             # sys.stdout.write("**** %s ****\n"%(f))
 
             # 'f' is of the form test_filename.SOMETHING.suffix,
@@ -1404,52 +1599,83 @@ def main():
                 continue
 
             # Deal with these later
-            if (suffix == '.good' or
-                suffix=='.compopts' or suffix=='.perfcompopts' or
-                suffix=='.chpldocopts' or
-                suffix=='.execenv' or suffix=='.perfexecenv' or
-                suffix=='.compenv' or suffix=='.perfcompenv' or
-                suffix=='.execopts' or suffix=='.perfexecopts'):
-                continue # on to next file
+            if (
+                suffix == ".good"
+                or suffix == ".compopts"
+                or suffix == ".perfcompopts"
+                or suffix == ".chpldocopts"
+                or suffix == ".execenv"
+                or suffix == ".perfexecenv"
+                or suffix == ".compenv"
+                or suffix == ".perfcompenv"
+                or suffix == ".execopts"
+                or suffix == ".perfexecopts"
+            ):
+                continue  # on to next file
 
-            elif (suffix=='.notest' and (os.access(f, os.R_OK) and
-                                         testnotests=='0')):
-                sys.stdout.write('[Skipping notest test: %s/%s]\n'%(localdir,test_filename))
-                do_not_test=True
+            elif suffix == ".notest" and (
+                os.access(f, os.R_OK) and testnotests == "0"
+            ):
+                sys.stdout.write(
+                    "[Skipping notest test: %s/%s]\n"
+                    % (localdir, test_filename)
+                )
+                do_not_test = True
                 break
 
-            elif (suffix=='.skipif' and (os.access(f, os.R_OK) and
-                   (os.getenv('CHPL_TEST_SINGLES')=='0'))):
-                testskipiffile=True
-                sys.stdout.write('[Checking skipif: %s.skipif]\n'%(test_filename))
+            elif suffix == ".skipif" and (
+                os.access(f, os.R_OK)
+                and (os.getenv("CHPL_TEST_SINGLES") == "0")
+            ):
+                testskipiffile = True
+                sys.stdout.write(
+                    "[Checking skipif: %s.skipif]\n" % (test_filename)
+                )
                 sys.stdout.flush()
                 try:
-                    skipme=False
-                    skiptest=runSkipIf(f)
+                    skipme = False
+                    skiptest = runSkipIf(f)
                     if skiptest.strip() != "False":
-                        skipme = skiptest.strip() == "True" or int(skiptest) == 1
+                        skipme = (
+                            skiptest.strip() == "True" or int(skiptest) == 1
+                        )
                     if skipme:
-                        sys.stdout.write('[Skipping test based on .skipif environment settings: %s]\n'
-                            % os.path.join(localdir, test_filename))
-                        do_not_test=True
+                        sys.stdout.write(
+                            "[Skipping test based on .skipif environment settings: %s]\n"
+                            % os.path.join(localdir, test_filename)
+                        )
+                        do_not_test = True
                 except (ValueError, RuntimeError) as e:
-                    sys.stdout.write(str(e)+'\n')
-                    sys.stdout.write('[Error processing .skipif file for %s]\n'
-                        % os.path.join(localdir, test_filename))
-                    printEndOfTestMsg(os.path.join(localdir, test_filename), 0.0)
-                    do_not_test=True
+                    sys.stdout.write(str(e) + "\n")
+                    sys.stdout.write(
+                        "[Error processing .skipif file for %s]\n"
+                        % os.path.join(localdir, test_filename)
+                    )
+                    printEndOfTestMsg(
+                        os.path.join(localdir, test_filename), 0.0
+                    )
+                    do_not_test = True
                 if do_not_test:
                     break
 
-            elif ((suffix=='.suppressif' or name == 'SUPPRESSIF') and (os.access(f, os.R_OK))):
-                logname = "SUPPRESSIF" if name == "SUPPRESSIF" else "%s.suppressif" % (test_filename)
-                sys.stdout.write('[Checking suppressif: %s]\n'%(logname))
+            elif (suffix == ".suppressif" or name == "SUPPRESSIF") and (
+                os.access(f, os.R_OK)
+            ):
+                logname = (
+                    "SUPPRESSIF"
+                    if name == "SUPPRESSIF"
+                    else "%s.suppressif" % (test_filename)
+                )
+                sys.stdout.write("[Checking suppressif: %s]\n" % (logname))
                 sys.stdout.flush()
                 try:
-                    suppressme=False
-                    suppresstest=runSkipIf(f)
+                    suppressme = False
+                    suppresstest = runSkipIf(f)
                     if suppresstest.strip() != "False":
-                        suppressme = suppresstest.strip() == "True" or int(suppresstest) == 1
+                        suppressme = (
+                            suppresstest.strip() == "True"
+                            or int(suppresstest) == 1
+                        )
                     if suppressme:
                         suppressline = ""
                         suppress_file_name = (
@@ -1457,17 +1683,18 @@ def main():
                             if name != "SUPPRESSIF"
                             else f
                         )
-                        with open(suppress_file_name, 'r') as suppressfile:
+                        with open(suppress_file_name, "r") as suppressfile:
                             for line in suppressfile:
                                 line = line.strip()
-                                is_comment = (line.startswith("#") and
-                                                not line.startswith("#!"))
+                                is_comment = line.startswith(
+                                    "#"
+                                ) and not line.startswith("#!")
                                 if is_comment:
-                                    suppressline = line.replace('#','').strip()
+                                    suppressline = line.replace("#", "").strip()
                                     break
-                        futuretest='Suppress (' + suppressline + ') '
+                        futuretest = "Suppress (" + suppressline + ") "
                 except (ValueError, RuntimeError) as e:
-                    sys.stdout.write(str(e)+'\n')
+                    sys.stdout.write(str(e) + "\n")
                     suppress_name = (
                         ".suppressif" if name != "SUPPRESSIF" else "SUPPRESSIF"
                     )
@@ -1475,186 +1702,251 @@ def main():
                         "[Error processing %s file for %s]\n"
                         % (suppress_name, os.path.join(localdir, test_filename))
                     )
-                    printEndOfTestMsg(os.path.join(localdir, test_filename), 0.0)
-                    do_not_test=True
+                    printEndOfTestMsg(
+                        os.path.join(localdir, test_filename), 0.0
+                    )
+                    do_not_test = True
                     break
-            elif (suffix==timeoutsuffix and os.access(f, os.R_OK)):
+            elif suffix == timeoutsuffix and os.access(f, os.R_OK):
                 fileTimeout = ReadIntegerValue(f, localdir)
                 if fileTimeout < defaultTimeout or fileTimeout > globalTimeout:
                     timeout = fileTimeout
-                    sys.stdout.write('[Overriding default timeout with %d]\n'%(timeout))
-            elif (perftest and suffix==PerfSfx('timeexec') and os.access(f, os.R_OK)): #e.g. .perftimeexec
+                    sys.stdout.write(
+                        "[Overriding default timeout with %d]\n" % (timeout)
+                    )
+            elif (
+                perftest
+                and suffix == PerfSfx("timeexec")
+                and os.access(f, os.R_OK)
+            ):  # e.g. .perftimeexec
                 timer = GetTimer(f)
 
-            elif (suffix==PerfSfx('numtrials') and os.access(f, os.R_OK)): #e.g. .perfnumtrials
+            elif suffix == PerfSfx("numtrials") and os.access(
+                f, os.R_OK
+            ):  # e.g. .perfnumtrials
                 numTrials = ReadIntegerValue(f, localdir)
 
-            elif (suffix=='.killtimeout' and os.access(f, os.R_OK)):
-                killtimeout=ReadIntegerValue(f, localdir)
+            elif suffix == ".killtimeout" and os.access(f, os.R_OK):
+                killtimeout = ReadIntegerValue(f, localdir)
 
-            elif (suffix=='.catfiles' and os.access(f, os.R_OK)):
-                execcatfiles=run_process(['cat', f], stdout=subprocess.PIPE)[1].strip()
+            elif suffix == ".catfiles" and os.access(f, os.R_OK):
+                execcatfiles = run_process(["cat", f], stdout=subprocess.PIPE)[
+                    1
+                ].strip()
                 if catfiles:
-                    catfiles+=execcatfiles
+                    catfiles += execcatfiles
                 else:
-                    catfiles=execcatfiles
+                    catfiles = execcatfiles
 
-            elif (suffix=='.lastcompopts' and os.access(f, os.R_OK)):
-                lastcompopts+=ReadFileWithComments(f)[0].strip().split()
+            elif suffix == ".lastcompopts" and os.access(f, os.R_OK):
+                lastcompopts += ReadFileWithComments(f)[0].strip().split()
 
-            elif (suffix=='.lastexecopts' and os.access(f, os.R_OK)):
-                lastexecopts+=ReadFileWithComments(f)[0].strip().split()
+            elif suffix == ".lastexecopts" and os.access(f, os.R_OK):
+                lastexecopts += ReadFileWithComments(f)[0].strip().split()
 
-            elif (suffix==PerfSfx('numlocales') and os.access(f, os.R_OK)):
-                numlocales=ReadIntegerValue(f, localdir)
+            elif suffix == PerfSfx("numlocales") and os.access(f, os.R_OK):
+                numlocales = ReadIntegerValue(f, localdir)
 
-            elif suffix==futureSuffix and os.access(f, os.R_OK):
-                with open('./'+test_filename+futureSuffix, 'r') as futurefile:
-                    futuretest='Future ('+futurefile.readline().strip()+') '
+            elif suffix == futureSuffix and os.access(f, os.R_OK):
+                with open(
+                    "./" + test_filename + futureSuffix, "r"
+                ) as futurefile:
+                    futuretest = (
+                        "Future (" + futurefile.readline().strip() + ") "
+                    )
 
-            elif (suffix=='.noexec' and os.access(f, os.R_OK)):
-                noexecfile=True
-                executebin=False
+            elif suffix == ".noexec" and os.access(f, os.R_OK):
+                noexecfile = True
+                executebin = False
 
-            elif (suffix=='.precomp' and os.access(f, os.R_OK|os.X_OK)):
-                precomp=f
+            elif suffix == ".precomp" and os.access(f, os.R_OK | os.X_OK):
+                precomp = f
 
-            elif (suffix=='.prediff' and os.access(f, os.R_OK|os.X_OK)):
-                prediff=f
+            elif suffix == ".prediff" and os.access(f, os.R_OK | os.X_OK):
+                prediff = f
 
-            elif (suffix=='.preexec' and os.access(f, os.R_OK|os.X_OK)):
-                preexec=f
+            elif suffix == ".preexec" and os.access(f, os.R_OK | os.X_OK):
+                preexec = f
 
             elif (suffix=='.postexec' and os.access(f, os.R_OK|os.X_OK)):
                 postexec=f
 
             elif (suffix=='.stdin' and os.access(f, os.R_OK)):
                 if redirectin == None:
-                    sys.stdout.write('[Skipping test with .stdin input since -nostdinredirect is given: %s/%s]\n'%(localdir,test_filename))
-                    do_not_test=True
+                    sys.stdout.write(
+                        "[Skipping test with .stdin input since -nostdinredirect is given: %s/%s]\n"
+                        % (localdir, test_filename)
+                    )
+                    do_not_test = True
                     break
                 else:
                     redirectin = f
 
-            if suffix==futureSuffix:
-                testfuturesfile=True
+            if suffix == futureSuffix:
+                testfuturesfile = True
 
         del test_filename_files
 
         # Skip to the next test
         if do_not_test:
-            continue # on to next test
+            continue  # on to next test
 
         # 0: test no futures
         if testfutures == 0 and testfuturesfile == True:
-            sys.stdout.write('[Skipping future test: %s/%s]\n'%(localdir,test_filename))
-            continue # on to next test
+            sys.stdout.write(
+                "[Skipping future test: %s/%s]\n" % (localdir, test_filename)
+            )
+            continue  # on to next test
         # 1: test all futures
         elif testfutures == 1:
             pass
         # 2: test only futures
         elif testfutures == 2 and testfuturesfile == False:
-            sys.stdout.write('[Skipping non-future test: %s/%s]\n'%(localdir,test_filename))
-            continue # on to next test
+            sys.stdout.write(
+                "[Skipping non-future test: %s/%s]\n"
+                % (localdir, test_filename)
+            )
+            continue  # on to next test
         # 3: test futures that have a .skipif file
-        elif testfutures == 3 and testfuturesfile == True and testskipiffile == False:
-            sys.stdout.write('[Skipping future test without a skipif: %s/%s]\n'%(localdir,test_filename))
-            continue # on to next test
+        elif (
+            testfutures == 3
+            and testfuturesfile == True
+            and testskipiffile == False
+        ):
+            sys.stdout.write(
+                "[Skipping future test without a skipif: %s/%s]\n"
+                % (localdir, test_filename)
+            )
+            continue  # on to next test
 
         # c tests don't have a way to launch themselves
-        if is_c_or_cpp_test and chpllauncher != 'none':
-            sys.stdout.write('[Skipping %s test: %s/%s]\n'%(c_or_cpp,localdir,test_filename))
+        if is_c_or_cpp_test and chpllauncher != "none":
+            sys.stdout.write(
+                "[Skipping %s test: %s/%s]\n"
+                % (c_or_cpp, localdir, test_filename)
+            )
             continue
 
         # .ml-test.c tests should only run when we are in a multilocale setting
-        if is_ml_c_or_cpp_test and chplcomm == 'none':
-            sys.stdout.write('[Skipping multilocale-only %s test: %s/%s]\n'%(c_or_cpp,localdir,test_filename))
+        if is_ml_c_or_cpp_test and chplcomm == "none":
+            sys.stdout.write(
+                "[Skipping multilocale-only %s test: %s/%s]\n"
+                % (c_or_cpp, localdir, test_filename)
+            )
             continue
 
         # Set numlocales
-        if (numlocales == 0) or (chplcomm=='none') or is_c_or_cpp_test:
+        if (numlocales == 0) or (chplcomm == "none") or is_c_or_cpp_test:
             numlocexecopts = None
         else:
             if maxLocalesAvailable is not None:
                 if numlocales > maxLocalesAvailable:
-                    sys.stdout.write('[Skipping test {0} because it requires '
-                                     '{1} locales but only {2} are available]\n'
-                                     .format(os.path.join(localdir, test_filename),
-                                             numlocales, maxLocalesAvailable))
+                    sys.stdout.write(
+                        "[Skipping test {0} because it requires "
+                        "{1} locales but only {2} are available]\n".format(
+                            os.path.join(localdir, test_filename),
+                            numlocales,
+                            maxLocalesAvailable,
+                        )
+                    )
                     continue
-            if os.getenv('CHPL_TEST_MULTILOCALE_ONLY') and (numlocales <= 1) and not is_ml_c_or_cpp_test:
-                sys.stdout.write('[Skipping test {0} because it does not '
-                                 'use more than one locale]\n'
-                                 .format(os.path.join(localdir, test_filename)))
+            if (
+                os.getenv("CHPL_TEST_MULTILOCALE_ONLY")
+                and (numlocales <= 1)
+                and not is_ml_c_or_cpp_test
+            ):
+                sys.stdout.write(
+                    "[Skipping test {0} because it does not "
+                    "use more than one locale]\n".format(
+                        os.path.join(localdir, test_filename)
+                    )
+                )
                 continue
-            numlocexecopts = ' -nl '+str(numlocales)
+            numlocexecopts = " -nl " + str(numlocales)
 
         # if any performance test has a timeout longer than the default we only
         # want to run it once
-        if (timeout > globalTimeout):
+        if timeout > globalTimeout:
             if numTrials != 1:
-                sys.stdout.write('[Lowering number of trials for {0} to 1]\n'.format(test_filename))
+                sys.stdout.write(
+                    "[Lowering number of trials for {0} to 1]\n".format(
+                        test_filename
+                    )
+                )
                 numTrials = 1
 
         # Get list of test specific compiler options
         # Default to [' ']
-        compoptslist = list(' ')
+        compoptslist = list(" ")
 
         chpldoc_opts_filename = test_filename + chpldocsuffix
         if test_is_chpldoc and os.access(chpldoc_opts_filename, os.R_OK):
             compoptslist = ReadFileWithComments(chpldoc_opts_filename, False)
             if os.stat(chpldoc_opts_filename).st_size == 0:
-                sys.stdout.write('[Warning: ignoring an empty chpldocopts file %s]\n' %
-                                 (test_filename+compoptssuffix))
-        elif os.access(test_filename+compoptssuffix, os.R_OK):
-            compoptslist = ReadFileWithComments(test_filename+compoptssuffix, False)
-            if os.stat(test_filename+compoptssuffix).st_size == 0:
+                sys.stdout.write(
+                    "[Warning: ignoring an empty chpldocopts file %s]\n"
+                    % (test_filename + compoptssuffix)
+                )
+        elif os.access(test_filename + compoptssuffix, os.R_OK):
+            compoptslist = ReadFileWithComments(
+                test_filename + compoptssuffix, False
+            )
+            if os.stat(test_filename + compoptssuffix).st_size == 0:
                 # cf. for execoptslist no warning is issued
-                sys.stdout.write('[Warning: ignoring an empty compopts file %s]\n'%(test_filename+compoptssuffix))
+                sys.stdout.write(
+                    "[Warning: ignoring an empty compopts file %s]\n"
+                    % (test_filename + compoptssuffix)
+                )
 
-        compoptslist = compoptslist or list(' ')
-        directoryCompopts = directoryCompopts or list(' ')
+        compoptslist = compoptslist or list(" ")
+        directoryCompopts = directoryCompopts or list(" ")
 
         # Merge global compopts list with local compopts.
         # Use the "product" of the two if they are both provided.
-        usecompoptslist = [ ]
+        usecompoptslist = []
         # Note -- this could use itertools.product
         for dir_compopts in directoryCompopts:
             for file_compopts in compoptslist:
                 useopt = [dir_compopts, file_compopts]
-                usearg = ' '.join(useopt)
+                usearg = " ".join(useopt)
                 # But change all-spaces into single space.
-                if usearg.strip() == '':
-                    usearg = ' '
+                if usearg.strip() == "":
+                    usearg = " "
                 usecompoptslist += [usearg]
         compoptslist = usecompoptslist
 
-        if os.access(test_filename+compenvsuffix, os.R_OK):
-            compenv = ReadFileWithComments(test_filename+compenvsuffix)
+        if os.access(test_filename + compenvsuffix, os.R_OK):
+            compenv = ReadFileWithComments(test_filename + compenvsuffix)
         else:
             compenv = list()
 
         testcompenv = {}
-        for var, val in [env.split('=', 1) for env in globalCompenv]:
+        for var, val in [env.split("=", 1) for env in globalCompenv]:
             testcompenv[var.strip()] = val.strip()
-        for var, val in [env.split('=', 1) for env in compenv]:
+        for var, val in [env.split("=", 1) for env in compenv]:
             testcompenv[var.strip()] = val.strip()
 
         # Get list of test specific exec options
-        if os.access(test_filename+execoptssuffix, os.R_OK):
-            execoptsfile=True
-            execoptslist = ReadFileWithComments(test_filename+execoptssuffix, False)
+        if os.access(test_filename + execoptssuffix, os.R_OK):
+            execoptsfile = True
+            execoptslist = ReadFileWithComments(
+                test_filename + execoptssuffix, False
+            )
         else:
             execoptslist = list()
         # Handle empty execopts list
         if len(execoptslist) == 0:
             # cf. for compoptslist, a warning is issued in this case
-            execoptslist.append(' ')
+            execoptslist.append(" ")
 
-        if (os.getenv('CHPL_TEST_INTERP')=='on' and
-            (noexecfile or testfuturesfile or execoptsfile)):
-            sys.stdout.write('[Skipping interpretation of: %s/%s]\n'%(localdir,test_filename))
-            continue # on to next test
+        if os.getenv("CHPL_TEST_INTERP") == "on" and (
+            noexecfile or testfuturesfile or execoptsfile
+        ):
+            sys.stdout.write(
+                "[Skipping interpretation of: %s/%s]\n"
+                % (localdir, test_filename)
+            )
+            continue  # on to next test
 
         clist = list()
         curFileTestStart = time.time()
@@ -1670,38 +1962,49 @@ def main():
             # use the remaining portion as a .good file for executing tests
             #  clist will be *added* to execopts if it is empty, or just used
             #  as the default .good file if not empty
-            clist = compopts.split('#')
+            clist = compopts.split("#")
             if len(clist) >= 2:
                 compopts = clist.pop(0)
-                cstr = ' #' + '#'.join(clist)
+                cstr = " #" + "#".join(clist)
                 del clist[:]
                 clist.append(cstr)
             else:
                 del clist[:]
 
-            if compopts == ' ':
-                complog=execname+'.comp.out.tmp'
+            if compopts == " ":
+                complog = execname + ".comp.out.tmp"
             else:
                 compoptsnum += 1
-                complog = execname+'.'+str(compoptsnum)+'.comp.out.tmp'
+                complog = execname + "." + str(compoptsnum) + ".comp.out.tmp"
 
             #
             # Run the precompile script
             #
             if globalPrecomp:
-                sys.stdout.write('[Executing ./PRECOMP %s %s %s]\n'%(execname, complog, compiler))
+                sys.stdout.write(
+                    "[Executing ./PRECOMP %s %s %s]\n"
+                    % (execname, complog, compiler)
+                )
                 sys.stdout.flush()
-                stdout = run_process(['./PRECOMP', execname, complog, compiler],
-                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                stdout = run_process(
+                    ["./PRECOMP", execname, complog, compiler],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )[1]
                 sys.stdout.write(stdout)
                 sys.stdout.flush()
 
             if precomp:
-                sys.stdout.write('[Executing precomp %s.precomp]\n'%(test_filename))
+                sys.stdout.write(
+                    "[Executing precomp %s.precomp]\n" % (test_filename)
+                )
                 sys.stdout.flush()
-                test_precomp = './{0}.precomp'.format(test_filename)
-                stdout = run_process([test_precomp, execname, complog, compiler],
-                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                test_precomp = "./{0}.precomp".format(test_filename)
+                stdout = run_process(
+                    [test_precomp, execname, complog, compiler],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )[1]
                 sys.stdout.write(stdout)
                 sys.stdout.flush()
 
@@ -1712,8 +2015,8 @@ def main():
 
             # make sure to add this early so that actual compopts file can
             # override
-            if os.getenv('CHPL_TEST_GPU'):
-                args += ['--no-checks']
+            if os.getenv("CHPL_TEST_GPU"):
+                args += ["--no-checks"]
 
             if test_is_chpldoc:
                 args += globalChpldocOpts + shlex.split(compopts)
@@ -1724,41 +2027,55 @@ def main():
             if is_c_or_cpp_test or is_ml_c_or_cpp_test:
                 # we need to drop envCompopts for C tests as those are options
                 # for `chpl` so don't include them here
-                args = ['-o', test_filename]+shlex.split(compopts)+[testname]
+                args = (
+                    ["-o", test_filename] + shlex.split(compopts) + [testname]
+                )
                 cmd = None
                 if is_c_test:
-                    cmd = run_compileline('--compile', 'c compiler')
+                    cmd = run_compileline("--compile", "c compiler")
                 elif is_ml_c_test:
-                    host_c_compiler = run_compileline('--host-c-compiler', 'host c compiler')
-                    runtime_includes_and_defines = run_compileline('--includes-and-defines', 'runtime includes and defines')
+                    host_c_compiler = run_compileline(
+                        "--host-c-compiler", "host c compiler"
+                    )
+                    runtime_includes_and_defines = run_compileline(
+                        "--includes-and-defines", "runtime includes and defines"
+                    )
                     cmd_pieces = [host_c_compiler, runtime_includes_and_defines]
-                    cmd = ' '.join(cmd_pieces)
+                    cmd = " ".join(cmd_pieces)
                 elif is_cpp_test:
-                    cmd = run_compileline('--compile-c++', 'c++ compiler')
+                    cmd = run_compileline("--compile-c++", "c++ compiler")
                 elif is_ml_cpp_test:
-                    host_cpp_compiler = run_compileline('--host-cxx-compiler', 'host c++ compiler')
-                    runtime_includes_and_defines = run_compileline('--includes-and-defines', 'runtime includes and defines')
-                    cmd_pieces = [host_cpp_compiler, runtime_includes_and_defines]
-                    cmd = ' '.join(cmd_pieces)
+                    host_cpp_compiler = run_compileline(
+                        "--host-cxx-compiler", "host c++ compiler"
+                    )
+                    runtime_includes_and_defines = run_compileline(
+                        "--includes-and-defines", "runtime includes and defines"
+                    )
+                    cmd_pieces = [
+                        host_cpp_compiler,
+                        runtime_includes_and_defines,
+                    ]
+                    cmd = " ".join(cmd_pieces)
             else:
-                if test_is_chpldoc and not compiler.endswith('chpldoc'):
+                if test_is_chpldoc and not compiler.endswith("chpldoc"):
                     # For tests with .doc.chpl suffix, use chpldoc compiler. Update
                     # the compopts accordingly. Add 'doc' prefix to existing compiler.
-                    compiler += 'doc'
+                    compiler += "doc"
                     cmd = compiler
 
                     if which(cmd) is None:
                         sys.stdout.write(
-                            '[Warning: Could not find chpldoc, skipping test '
-                            '{0}/{1}]\n'.format(localdir, test_filename))
+                            "[Warning: Could not find chpldoc, skipping test "
+                            "{0}/{1}]\n".format(localdir, test_filename)
+                        )
                         break
 
                 if valgrindcomp:
                     cmd = valgrindcomp
-                    args = valgrindcompopts+[compiler]+args
+                    args = valgrindcompopts + [compiler] + args
                 # TODO: temporary way to plugin chpldoc next for testing
-                elif 'CHPL_CHPLDOC_NEXT' in os.environ:
-                    cmd = os.environ['CHPL_CHPLDOC_NEXT']
+                elif "CHPL_CHPLDOC_NEXT" in os.environ:
+                    cmd = os.environ["CHPL_CHPLDOC_NEXT"]
                 else:
                     cmd = compiler
 
@@ -1780,47 +2097,63 @@ def main():
             # testing. Hopefully this is just a temporary work around and I'll
             # remember to add the cleaner solution soon.
             #
-            comptimeout = 4*timeout
-            cmd=ShellEscapeCommand(cmd)
-            sys.stdout.write('[Executing compiler %s'%(cmd))
+            comptimeout = 4 * timeout
+            cmd = ShellEscapeCommand(cmd)
+            sys.stdout.write("[Executing compiler %s" % (cmd))
             if args:
-                sys.stdout.write(' %s'%(' '.join(args)))
-            sys.stdout.write(' < %s]\n'%(compstdin))
+                sys.stdout.write(" %s" % (" ".join(args)))
+            sys.stdout.write(" < %s]\n" % (compstdin))
             sys.stdout.flush()
             if useTimedExec:
-                wholecmd = cmd+' '+' '.join(map(ShellEscape, args))
-                (status, output, _) = run_process([timedexec, str(comptimeout), wholecmd],
-                                                  env=dict(list(os.environ.items()) + list(testcompenv.items())),
-                                                  stdin=open(compstdin, 'r'),
-                                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                wholecmd = cmd + " " + " ".join(map(ShellEscape, args))
+                status, output, _ = run_process(
+                    [timedexec, str(comptimeout), wholecmd],
+                    env=dict(
+                        list(os.environ.items()) + list(testcompenv.items())
+                    ),
+                    stdin=open(compstdin, "r"),
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
 
                 if status == 222:
-                    sys.stdout.write('%s[Error: Timed out compilation for %s/%s'%
-                                     (futuretest, localdir, test_filename))
+                    sys.stdout.write(
+                        "%s[Error: Timed out compilation for %s/%s"
+                        % (futuretest, localdir, test_filename)
+                    )
                     printTestVariation(compoptsnum, compoptslist)
-                    sys.stdout.write(']\n')
-                    sys.stdout.write('[Compilation output was as follows:]\n')
+                    sys.stdout.write("]\n")
+                    sys.stdout.write("[Compilation output was as follows:]\n")
                     sys.stdout.write(trim_output(output))
                     cleanup(execname)
                     cleanup(printpassesfile)
-                    continue # on to next compopts
+                    continue  # on to next compopts
 
             else:
-                p = subprocess.Popen([cmd]+args,
-                                     env=dict(list(os.environ.items()) + list(testcompenv.items())),
-                                     stdin=open(compstdin, 'r'),
-                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                p = subprocess.Popen(
+                    [cmd] + args,
+                    env=dict(
+                        list(os.environ.items()) + list(testcompenv.items())
+                    ),
+                    stdin=open(compstdin, "r"),
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
                 try:
-                    output = str(SuckOutputWithTimeout(p.stdout, comptimeout), 'utf-8')
+                    output = str(
+                        SuckOutputWithTimeout(p.stdout, comptimeout), "utf-8"
+                    )
                 except ReadTimeoutException:
-                    sys.stdout.write('%s[Error: Timed out compilation for %s/%s'%
-                                     (futuretest, localdir, test_filename))
+                    sys.stdout.write(
+                        "%s[Error: Timed out compilation for %s/%s"
+                        % (futuretest, localdir, test_filename)
+                    )
                     printTestVariation(compoptsnum, compoptslist)
-                    sys.stdout.write(']\n')
+                    sys.stdout.write("]\n")
                     KillProc(p, killtimeout)
                     cleanup(execname)
                     cleanup(printpassesfile)
-                    continue # on to next compopts
+                    continue  # on to next compopts
 
                 p.poll()
                 status = p.returncode
@@ -1828,10 +2161,12 @@ def main():
             elapsedCompTime = time.time() - compStart
             test_name = os.path.join(localdir, test_filename)
             if compoptsnum != 0:
-                test_name += ' (compopts: {0})'.format(compoptsnum)
+                test_name += " (compopts: {0})".format(compoptsnum)
 
-            print('[Elapsed compilation time for "{0}" - {1:.3f} '
-                'seconds]'.format(test_name, elapsedCompTime))
+            print(
+                '[Elapsed compilation time for "{0}" - {1:.3f} '
+                "seconds]".format(test_name, elapsedCompTime)
+            )
 
             output = remove_clock_skew_warning(output)
 
@@ -1844,51 +2179,87 @@ def main():
                         # that some C compilers emit when compiling multiple files
                         output = output.replace(arg + ":\n", "")
 
-            if (status!=0 or not executebin):
+            if status != 0 or not executebin:
                 # Save original output
                 origoutput = output
                 dealWithBinary = False
 
                 # Compare compiler output with expected program output
                 if catfiles:
-                    sys.stdout.write('[Concatenating extra files: %s]\n'%
-                                     (test_filename+'.catfiles'))
+                    sys.stdout.write(
+                        "[Concatenating extra files: %s]\n"
+                        % (test_filename + ".catfiles")
+                    )
                     sys.stdout.flush()
                     WaitForFiles(catfiles.split())
-                    catoutput = run_process(['cat']+catfiles.split(),
-                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                    catoutput = run_process(
+                        ["cat"] + catfiles.split(),
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )[1]
                     output += catoutput
 
                 # Sadly these scripts require an actual file
-                with open(complog, 'w') as complogfile:
-                    complogfile.write('%s'%(output))
+                with open(complog, "w") as complogfile:
+                    complogfile.write("%s" % (output))
 
                 if systemPrediffs:
                     for sprediff in systemPrediffs:
-                        sys.stdout.write('[Executing system-wide prediff %s]\n'%(sprediff))
+                        sys.stdout.write(
+                            "[Executing system-wide prediff %s]\n" % (sprediff)
+                        )
                         sys.stdout.flush()
-                        stdout = run_process([sprediff, execname, complog, compiler,
-                                              ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
-                                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                        stdout = run_process(
+                            [
+                                sprediff,
+                                execname,
+                                complog,
+                                compiler,
+                                " ".join(envCompopts) + " " + compopts,
+                                " ".join(args),
+                            ],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                        )[1]
                         sys.stdout.write(stdout)
                         sys.stdout.flush()
 
                 if globalPrediff:
-                    sys.stdout.write('[Executing ./PREDIFF]\n')
+                    sys.stdout.write("[Executing ./PREDIFF]\n")
                     sys.stdout.flush()
-                    stdout = run_process(['./PREDIFF', execname, complog, compiler,
-                                         ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
-                                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                    stdout = run_process(
+                        [
+                            "./PREDIFF",
+                            execname,
+                            complog,
+                            compiler,
+                            " ".join(envCompopts) + " " + compopts,
+                            " ".join(args),
+                        ],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )[1]
                     sys.stdout.write(stdout)
                     sys.stdout.flush()
 
                 if prediff:
-                    sys.stdout.write('[Executing prediff %s.prediff]\n'%(test_filename))
+                    sys.stdout.write(
+                        "[Executing prediff %s.prediff]\n" % (test_filename)
+                    )
                     sys.stdout.flush()
-                    test_prediff = './{0}.prediff'.format(test_filename)
-                    stdout = run_process([test_prediff, execname, complog, compiler,
-                                         ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
-                                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                    test_prediff = "./{0}.prediff".format(test_filename)
+                    stdout = run_process(
+                        [
+                            test_prediff,
+                            execname,
+                            complog,
+                            compiler,
+                            " ".join(envCompopts) + " " + compopts,
+                            " ".join(args),
+                        ],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )[1]
                     sys.stdout.write(stdout)
                     sys.stdout.flush()
 
@@ -1898,48 +2269,56 @@ def main():
                 # testname.<configuration>.<compoptsnum>.good.
                 basename = test_filename
                 if len(clist) != 0:
-                    explicitcompgoodfile = clist[0].split('#')[1].strip()
-                    basename = explicitcompgoodfile.replace('.good', '')
+                    explicitcompgoodfile = clist[0].split("#")[1].strip()
+                    basename = explicitcompgoodfile.replace(".good", "")
 
-                compOptNum = ['']
+                compOptNum = [""]
                 if len(compoptslist) > 1:
-                    compOptNum.insert(0,'.'+str(compoptsnum))
+                    compOptNum.insert(0, "." + str(compoptsnum))
 
                 goodfile = FindGoodFile(basename, compOptNum)
                 # sys.stdout.write('default goodfile=%s\n'%(goodfile))
                 error_msg = filter_compiler_errors(origoutput)
-                if error_msg != '':
-                    sys.stdout.write(f'{futuretest}[Error {error_msg} for {test_name}]\n')
-                    sys.stdout.write('[Compiler output was as follows:]\n')
+                if error_msg != "":
+                    sys.stdout.write(
+                        f"{futuretest}[Error {error_msg} for {test_name}]\n"
+                    )
+                    sys.stdout.write("[Compiler output was as follows:]\n")
                     sys.stdout.write(origoutput)
                     cleanup(execname)
                     cleanup(printpassesfile)
                     continue
 
-                if not os.path.isfile(goodfile) or not os.access(goodfile, os.R_OK):
+                if not os.path.isfile(goodfile) or not os.access(
+                    goodfile, os.R_OK
+                ):
                     if perftest or executebin:
-                        sys.stdout.write(f'{futuretest}[Error compilation failed for {test_name}]\n')
+                        sys.stdout.write(
+                            f"{futuretest}[Error compilation failed for {test_name}]\n"
+                        )
                     else:
-                        sys.stdout.write(f'{futuretest}[Error cannot locate compiler output comparison file {localdir}/{goodfile}]\n')
-                    sys.stdout.write('[Compiler output was as follows:]\n')
+                        sys.stdout.write(
+                            f"{futuretest}[Error cannot locate compiler output comparison file {localdir}/{goodfile}]\n"
+                        )
+                    sys.stdout.write("[Compiler output was as follows:]\n")
                     sys.stdout.write(origoutput)
                     cleanup(execname)
                     cleanup(printpassesfile)
-                    continue # on to next compopts
+                    continue  # on to next compopts
 
-                if (dealWithBinary):
+                if dealWithBinary:
                     result = DiffBinaryFiles(goodfile, complog)
                 else:
                     result = DiffFiles(goodfile, complog)
                 msg = f"matching compiler output for {localdir}/{test_filename}"
-                if result==0:
+                if result == 0:
                     os.unlink(complog)
                     msg = f"[Success {msg}"
                 else:
                     msg = f"[Error {msg}"
-                sys.stdout.write(f'{futuretest}{msg}')
+                sys.stdout.write(f"{futuretest}{msg}")
                 printTestVariation(compoptsnum, compoptslist)
-                sys.stdout.write(']\n')
+                sys.stdout.write("]\n")
 
                 # If there was a prediff it may have hidden the compilation
                 # failure, so print out the full log. Note that we don't check
@@ -1947,22 +2326,26 @@ def main():
                 # anyways, and it could create noise for configs that use them.
                 if result != 0:
                     if prediff or globalPrediff:
-                        sys.stdout.write('[Compiler output before prediff was as follows:]\n')
+                        sys.stdout.write(
+                            "[Compiler output before prediff was as follows:]\n"
+                        )
                         sys.stdout.write(origoutput)
 
-                if (result != 0 and futuretest != ''):
-                    badfile=test_filename+'.bad'
+                if result != 0 and futuretest != "":
+                    badfile = test_filename + ".bad"
                     if os.access(badfile, os.R_OK):
                         badresult = DiffBadFiles(badfile, complog)
-                        if badresult==0:
+                        if badresult == 0:
                             os.unlink(complog)
-                            sys.stdout.write('[Clean match against .bad file ')
+                            sys.stdout.write("[Clean match against .bad file ")
                         else:
                             # bad file doesn't match, which is bad
-                            sys.stdout.write('[Error matching .bad file ')
-                        sys.stdout.write('for %s/%s'%(localdir, test_filename))
+                            sys.stdout.write("[Error matching .bad file ")
+                        sys.stdout.write(
+                            "for %s/%s" % (localdir, test_filename)
+                        )
                         printTestVariation(compoptsnum, compoptslist)
-                        sys.stdout.write(']\n')
+                        sys.stdout.write("]\n")
 
                 cleanup(execname)
                 cleanup(printpassesfile)
@@ -1973,9 +2356,9 @@ def main():
                 with create_exec_limiter():
                     pass
 
-                continue # on to next compopts
+                continue  # on to next compopts
             else:
-                compoutput = output # save for diff
+                compoutput = output  # save for diff
 
                 exec_log_names = []
 
@@ -1986,31 +2369,41 @@ def main():
                 # One execution output file for the current compiler opt.
                 elif len(compoptslist) > 1 and len(execoptslist) == 1:
                     exec_opts_num_tmp = 1
-                    if execoptslist[0] == ' ':
+                    if execoptslist[0] == " ":
                         exec_opts_num_tmp = 0
-                    exec_log_names.append(get_exec_log_name(execname, compoptsnum, exec_opts_num_tmp))
+                    exec_log_names.append(
+                        get_exec_log_name(
+                            execname, compoptsnum, exec_opts_num_tmp
+                        )
+                    )
 
                 # One execution output file for each of the execution opts.
                 elif len(compoptslist) == 1 and len(execoptslist) > 1:
                     for i in range(1, len(execoptslist) + 1):
-                        exec_log_names.append(get_exec_log_name(execname, compoptsnum, i))
+                        exec_log_names.append(
+                            get_exec_log_name(execname, compoptsnum, i)
+                        )
 
                 # This enumerates the cross product of all compiler and execution
                 # opts. It's not clear whether this is actually supported elsewhere
                 # (like start_test), but it's here.
                 else:
                     for i in range(1, len(execoptslist) + 1):
-                        exec_log_names.append(get_exec_log_name(execname, compoptsnum, i))
+                        exec_log_names.append(
+                            get_exec_log_name(execname, compoptsnum, i)
+                        )
 
                 # Write the log(s), so it/they can be modified by preexec(s).
                 for exec_log_name in exec_log_names:
-                    with open(exec_log_name, 'w') as execlogfile:
+                    with open(exec_log_name, "w") as execlogfile:
                         execlogfile.write(compoutput)
 
             #
             # Compile successful
             #
-            sys.stdout.write('[Success compiling %s/%s]\n'%(localdir, test_filename))
+            sys.stdout.write(
+                "[Success compiling %s/%s]\n" % (localdir, test_filename)
+            )
 
             # Note that compiler performance only times successful compilations.
             # Tests that are designed to fail before compilation is complete will
@@ -2018,16 +2411,26 @@ def main():
             if compperftest and not is_c_or_cpp_test:
                 # make the compiler performance directories if they don't exist
                 timePasses = True
-                if not os.path.isdir(compperfdir) and not os.path.isfile(compperfdir):
+                if not os.path.isdir(compperfdir) and not os.path.isfile(
+                    compperfdir
+                ):
                     py3_compat.makedirs(compperfdir, exist_ok=True)
-                if not os.access(compperfdir, os.R_OK|os.X_OK):
-                    sys.stdout.write('[Error creating compiler performance test directory %s]\n'%(compperfdir))
+                if not os.access(compperfdir, os.R_OK | os.X_OK):
+                    sys.stdout.write(
+                        "[Error creating compiler performance test directory %s]\n"
+                        % (compperfdir)
+                    )
                     timePasses = False
 
-                if not os.path.isdir(tempDatFilesDir) and not os.path.isfile(tempDatFilesDir):
+                if not os.path.isdir(tempDatFilesDir) and not os.path.isfile(
+                    tempDatFilesDir
+                ):
                     py3_compat.makedirs(tempDatFilesDir, exist_ok=True)
-                if not os.access(compperfdir, os.R_OK|os.X_OK):
-                    sys.stdout.write('[Error creating compiler performance temp dat file test directory %s]\n'%(tempDatFilesDir))
+                if not os.access(compperfdir, os.R_OK | os.X_OK):
+                    sys.stdout.write(
+                        "[Error creating compiler performance temp dat file test directory %s]\n"
+                        % (tempDatFilesDir)
+                    )
                     timePasses = False
 
                 # so long as we have to the directories
@@ -2036,28 +2439,67 @@ def main():
                     # option. 0 is the default compoptsnum if there are no options
                     # listed so we don't need to clutter the names with that
                     compoptsstring = str(compoptsnum)
-                    if compoptsstring == '0':
-                        compoptsstring = ''
+                    if compoptsstring == "0":
+                        compoptsstring = ""
 
                     # make the datFileName the full path with / replaced with ~~ so
                     # we can keep the full path for later but not create a bunch of
                     # new directories.
-                    datFileName = localdir.replace('/', '~~') + '~~' + test_filename + compoptsstring
+                    datFileName = (
+                        localdir.replace("/", "~~")
+                        + "~~"
+                        + test_filename
+                        + compoptsstring
+                    )
 
                     # computePerfStats for the current test
-                    sys.stdout.write('[Executing computePerfStats %s %s %s %s %s]\n'%(datFileName, tempDatFilesDir, keyfile, printpassesfile, 'False'))
+                    sys.stdout.write(
+                        "[Executing computePerfStats %s %s %s %s %s]\n"
+                        % (
+                            datFileName,
+                            tempDatFilesDir,
+                            keyfile,
+                            printpassesfile,
+                            "False",
+                        )
+                    )
                     sys.stdout.flush()
-                    (status, compkeysOutput, _) = run_process([utildir+'/test/computePerfStats', datFileName, tempDatFilesDir, keyfile, printpassesfile, 'False'], stdout=subprocess.PIPE)
-                    datFiles = [tempDatFilesDir+'/'+datFileName+'.dat',  tempDatFilesDir+'/'+datFileName+'.error']
+                    status, compkeysOutput, _ = run_process(
+                        [
+                            utildir + "/test/computePerfStats",
+                            datFileName,
+                            tempDatFilesDir,
+                            keyfile,
+                            printpassesfile,
+                            "False",
+                        ],
+                        stdout=subprocess.PIPE,
+                    )
+                    datFiles = [
+                        tempDatFilesDir + "/" + datFileName + ".dat",
+                        tempDatFilesDir + "/" + datFileName + ".error",
+                    ]
 
                     if status == 0:
-                        sys.stdout.write('[Success finding compiler performance keys for %s/%s]\n'% (localdir, test_filename))
+                        sys.stdout.write(
+                            "[Success finding compiler performance keys for %s/%s]\n"
+                            % (localdir, test_filename)
+                        )
                     else:
-                        sys.stdout.write('[Error finding compiler performance keys for %s/%s.]\n'% (localdir, test_filename))
+                        sys.stdout.write(
+                            "[Error finding compiler performance keys for %s/%s.]\n"
+                            % (localdir, test_filename)
+                        )
                         printTestVariation(compoptsnum, compoptslist)
-                        sys.stdout.write('computePerfStats output was:\n%s\n'%(compkeysOutput))
+                        sys.stdout.write(
+                            "computePerfStats output was:\n%s\n"
+                            % (compkeysOutput)
+                        )
                         sys.stdout.flush()
-                        sys.stdout.write('Deleting .dat files for %s/%s because of failure to find all keys\n'%(localdir, test_filename))
+                        sys.stdout.write(
+                            "Deleting .dat files for %s/%s because of failure to find all keys\n"
+                            % (localdir, test_filename)
+                        )
                         for datFile in datFiles:
                             if os.path.isfile(datFile):
                                 os.unlink(datFile)
@@ -2065,16 +2507,18 @@ def main():
                 # delete the timing file
                 cleanup(printpassesfile)
 
-            if os.getenv('CHPL_COMPONLY'):
-                sys.stdout.write('[Note: Not executing or comparing the output due to -noexec flags]\n')
+            if os.getenv("CHPL_COMPONLY"):
+                sys.stdout.write(
+                    "[Note: Not executing or comparing the output due to -noexec flags]\n"
+                )
                 cleanup(execname)
-                continue # on to next compopts
+                continue  # on to next compopts
             explicitcompgoodfile = None
             # Execute the test for all requested execopts
             execoptsnum = 0
-            if len(clist)!=0:
-                if len(clist[0].split('#')) > 1:
-                    explicitcompgoodfile = clist[0].split('#')[1].strip()
+            if len(clist) != 0:
+                if len(clist[0].split("#")) > 1:
+                    explicitcompgoodfile = clist[0].split("#")[1].strip()
             redirectin_set_in_loop = False
             for texecopts in execoptslist:
                 sys.stdout.flush()
@@ -2084,16 +2528,18 @@ def main():
                 if redirectin_set_in_loop:
                     redirectin = redirectin_original_value
                     redirectin_set_in_loop = False
-                if (len(compoptslist)==1) and (len(execoptslist)==1):
+                if (len(compoptslist) == 1) and (len(execoptslist) == 1):
                     onlyone = True
                     execlog = get_exec_log_name(execname)
                 else:
                     onlyone = False
-                    if texecopts != ' ':
+                    if texecopts != " ":
                         execoptsnum += 1
-                    execlog = get_exec_log_name(execname, compoptsnum, execoptsnum)
+                    execlog = get_exec_log_name(
+                        execname, compoptsnum, execoptsnum
+                    )
 
-                tlist = texecopts.split('#')
+                tlist = texecopts.split("#")
                 execopts = tlist[0].strip()
 
                 if numlocexecopts != None:
@@ -2107,109 +2553,140 @@ def main():
 
                 if systemPreexecs:
                     for spreexec in systemPreexecs:
-                        sys.stdout.write('[Executing system-wide preexec %s]\n'%(spreexec))
+                        sys.stdout.write(
+                            "[Executing system-wide preexec %s]\n" % (spreexec)
+                        )
                         sys.stdout.flush()
-                        stdout = run_process([spreexec, execname, execlog, compiler],
-                                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                        stdout = run_process(
+                            [spreexec, execname, execlog, compiler],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                        )[1]
                         sys.stdout.write(stdout)
                         sys.stdout.flush()
 
                 if globalPreexec:
-                    sys.stdout.write('[Executing ./PREEXEC]\n')
+                    sys.stdout.write("[Executing ./PREEXEC]\n")
                     sys.stdout.flush()
-                    stdout = run_process(['./PREEXEC', execname, execlog, compiler],
-                                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                    stdout = run_process(
+                        ["./PREEXEC", execname, execlog, compiler],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )[1]
                     sys.stdout.write(stdout)
                     sys.stdout.flush()
 
                 if preexec:
-                    sys.stdout.write('[Executing preexec %s.preexec]\n'%(test_filename))
+                    sys.stdout.write(
+                        "[Executing preexec %s.preexec]\n" % (test_filename)
+                    )
                     sys.stdout.flush()
-                    test_preexec = './{0}.preexec'.format(test_filename)
-                    stdout = run_process([test_preexec, execname, execlog, compiler],
-                                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                    test_preexec = "./{0}.preexec".format(test_filename)
+                    stdout = run_process(
+                        [test_preexec, execname, execlog, compiler],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    )[1]
                     sys.stdout.write(stdout)
                     sys.stdout.flush()
 
                 #
                 # Global EXECENV
                 #
-                if os.access('./EXECENV',os.R_OK):
-                    args = [execname, execlog, compiler] + envCompopts + \
-                            shlex.split(compopts) + globalExecopts + \
-                            shlex.split(execopts)
-                    globalExecenv=ReadFileWithComments('./EXECENV',
-                                                       args=args)
+                if os.access("./EXECENV", os.R_OK):
+                    args = (
+                        [execname, execlog, compiler]
+                        + envCompopts
+                        + shlex.split(compopts)
+                        + globalExecopts
+                        + shlex.split(execopts)
+                    )
+                    globalExecenv = ReadFileWithComments("./EXECENV", args=args)
                 else:
-                    globalExecenv=list()
+                    globalExecenv = list()
 
                 testenv = {}
                 for env in globalExecenv:
-                    if env.startswith('unset '):
-                        var = env.split(' ', 1)[1]
+                    if env.startswith("unset "):
+                        var = env.split(" ", 1)[1]
                         testenv[var.strip()] = None
                     else:
-                        var, val = env.split('=', 1)
+                        var, val = env.split("=", 1)
                         testenv[var.strip()] = val.strip()
 
                 # The test environment is that of this process,
                 # augmented as specified
-                if os.access(test_filename+execenvsuffix, os.R_OK):
-                    args = [execname, execlog, compiler] + envCompopts + \
-                            shlex.split(compopts) + globalExecopts + \
-                            shlex.split(execopts)
-                    execenv = ReadFileWithComments(test_filename+execenvsuffix,
-                                                    args=args)
+                if os.access(test_filename + execenvsuffix, os.R_OK):
+                    args = (
+                        [execname, execlog, compiler]
+                        + envCompopts
+                        + shlex.split(compopts)
+                        + globalExecopts
+                        + shlex.split(execopts)
+                    )
+                    execenv = ReadFileWithComments(
+                        test_filename + execenvsuffix, args=args
+                    )
                 else:
                     execenv = list()
                 for env in execenv:
-                    if env.startswith('unset '):
-                        var = env.split(' ', 1)[1]
+                    if env.startswith("unset "):
+                        var = env.split(" ", 1)[1]
                         testenv[var.strip()] = None
                     else:
-                        var, val = env.split('=', 1)
+                        var, val = env.split("=", 1)
                         testenv[var.strip()] = val.strip()
 
-                pre_exec_output = ''
+                pre_exec_output = ""
                 if os.path.exists(execlog):
-                    with open(execlog, 'r') as exec_log_file:
+                    with open(execlog, "r") as exec_log_file:
                         pre_exec_output = exec_log_file.read()
 
-                if not os.access(execname, os.R_OK|os.X_OK):
-                    sys.stdout.write('%s[Error could not locate executable %s for %s/%s'%
-                                     (futuretest, execname, localdir, test_filename))
-                    printTestVariation(compoptsnum, compoptslist,
-                                       execoptsnum, execoptslist)
-                    sys.stdout.write(']\n')
-                    break; # on to next compopts
+                if not os.access(execname, os.R_OK | os.X_OK):
+                    sys.stdout.write(
+                        "%s[Error could not locate executable %s for %s/%s"
+                        % (futuretest, execname, localdir, test_filename)
+                    )
+                    printTestVariation(
+                        compoptsnum, compoptslist, execoptsnum, execoptslist
+                    )
+                    sys.stdout.write("]\n")
+                    break
+                    # on to next compopts
 
                 # When doing whole program execution, we want to time the _real
                 # binary for launchers that use a queue so we don't include the
                 # time to get the reservation. These are the launchers known to
                 # support timing the _real using CHPL_LAUNCHER_REAL_WRAPPER.
-                timereal = (chpllauncher in ['pbs-aprun', 'aprun', 'slurm-srun'] or
-                            'slurm-gasnetrun' in chpllauncher)
+                timereal = (
+                    chpllauncher in ["pbs-aprun", "aprun", "slurm-srun"]
+                    or "slurm-gasnetrun" in chpllauncher
+                )
 
-                args=list()
+                args = list()
                 if timer and timereal:
-                    cmd='./'+execname
-                    testenv['CHPL_LAUNCHER_REAL_WRAPPER'] = timer
+                    cmd = "./" + execname
+                    testenv["CHPL_LAUNCHER_REAL_WRAPPER"] = timer
                 elif timer:
-                    cmd=timer
-                    args+=['./'+execname]
+                    cmd = timer
+                    args += ["./" + execname]
                 elif valgrindbin:
-                    cmd=valgrindbin
-                    args+=valgrindbinopts+['./'+execname]
+                    cmd = valgrindbin
+                    args += valgrindbinopts + ["./" + execname]
                 else:
-                    cmd='./'+execname
+                    cmd = "./" + execname
 
                 # if we're using a launchcmd, build up the command to call
                 # launchcmd, and have it run the cmd and args built above
                 if launchcmd:
                     # have chpl_launchcmd time execution and place results in a
                     # file since sub_test time will include time to get reservation
-                    launchcmd_exec_time_file = execname + '_launchcmd_exec_time.txt'
-                    os.environ['CHPL_LAUNCHCMD_EXEC_TIME_FILE'] = launchcmd_exec_time_file
+                    launchcmd_exec_time_file = (
+                        execname + "_launchcmd_exec_time.txt"
+                    )
+                    os.environ["CHPL_LAUNCHCMD_EXEC_TIME_FILE"] = (
+                        launchcmd_exec_time_file
+                    )
 
                     # save old cmd and args and add them after launchcmd args.
                     oldcmd = cmd
@@ -2220,11 +2697,11 @@ def main():
                     args += [oldcmd]
                     args += oldargs
 
-                args+=globalExecopts
-                args+=shlex.split(execopts)
+                args += globalExecopts
+                args += shlex.split(execopts)
                 # envExecopts are meant for chpl programs, dont add them to C tests
                 if not is_c_or_cpp_test and envExecopts != None:
-                    args+=shlex.split(envExecopts)
+                    args += shlex.split(envExecopts)
                 # lastexecopts really must be last, so add any launcher timeout now
                 if useLauncherTimeout:
                     args += LauncherTimeoutArgs(timeout)
@@ -2232,27 +2709,37 @@ def main():
                     args += lastexecopts
                 # sys.stdout.write("args=%s\n"%(args))
 
-                if len(args) >= 2 and '<' in args:
-                    redirIdx = args.index('<')
+                if len(args) >= 2 and "<" in args:
+                    redirIdx = args.index("<")
                     execOptRedirect = args[redirIdx + 1]
-                    args.pop(redirIdx+1)
+                    args.pop(redirIdx + 1)
                     args.pop(redirIdx)
                     if redirectin == None:
                         # It is a little unfortunate that we compile the test only to skip it here.
                         # In order to prevent this, the logic for combining all the places execpopts
                         # come from and checking for '<' would have to be factored out or duplicated
-                        print('[Skipping test with stdin redirection ("<") in execopts since '
-                            '-nostdinredirect is given {0}/{1}]'.format(localdir, test_filename))
+                        print(
+                            '[Skipping test with stdin redirection ("<") in execopts since '
+                            "-nostdinredirect is given {0}/{1}]".format(
+                                localdir, test_filename
+                            )
+                        )
                         break
                     elif redirectin == "/dev/null":
                         if os.access(execOptRedirect, os.R_OK):
                             redirectin = execOptRedirect
                             redirectin_set_in_loop = True
                         else:
-                            sys.stdout.write('[Error: redirection file %s does not exist]\n'%(execOptRedirect))
+                            sys.stdout.write(
+                                "[Error: redirection file %s does not exist]\n"
+                                % (execOptRedirect)
+                            )
                             break
                     else:
-                        sys.stdout.write('[Error: a redirection file already exists: %s]\n'%(redirectin))
+                        sys.stdout.write(
+                            "[Error: a redirection file already exists: %s]\n"
+                            % (redirectin)
+                        )
                         break
 
                 #
@@ -2266,11 +2753,13 @@ def main():
 
                     with create_exec_limiter():
                         exectimeout = False  # 'exectimeout' is specific to one trial of one execopt setting
-                        launcher_error = '' # used to suppress output/timeout errors whose root cause is a launcher error
-                        sys.stdout.write('[Executing program %s %s'%(cmd, ' '.join(args)))
+                        launcher_error = ""  # used to suppress output/timeout errors whose root cause is a launcher error
+                        sys.stdout.write(
+                            "[Executing program %s %s" % (cmd, " ".join(args))
+                        )
                         if redirectin:
-                            sys.stdout.write(' < %s'%(redirectin))
-                        sys.stdout.write(']\n')
+                            sys.stdout.write(" < %s" % (redirectin))
+                        sys.stdout.write("]\n")
                         sys.stdout.flush()
 
                         execStart = time.time()
@@ -2278,76 +2767,130 @@ def main():
                             if redirectin == None:
                                 my_stdin = None
                             else:
-                                my_stdin=open(redirectin, 'r')
+                                my_stdin = open(redirectin, "r")
                             test_command = [cmd] + args
-                            (exec_status, stdout, stderr) = run_process(test_command,
-                                            env=get_process_env(testenv),
-                                            stdin=my_stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                            exec_status, stdout, stderr = run_process(
+                                test_command,
+                                env=get_process_env(testenv),
+                                stdin=my_stdin,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                            )
                             output = stdout + stderr
 
                             # Check for well-known failure modes
-                            launcher_error, thistimeout = translateOutput(output)
+                            launcher_error, thistimeout = translateOutput(
+                                output
+                            )
                             exectimeout = exectimeout or thistimeout
 
                             if launcher_error:
-                                sys.stdout.write('%s[Error: %s %s/%s'%
-                                                (futuretest, launcher_error, localdir, test_filename))
-                                printTestVariation(compoptsnum, compoptslist,
-                                                   execoptsnum, execoptslist)
-                                sys.stdout.write(']\n')
-                                sys.stdout.write('[Execution output was as follows:]\n')
+                                sys.stdout.write(
+                                    "%s[Error: %s %s/%s"
+                                    % (
+                                        futuretest,
+                                        launcher_error,
+                                        localdir,
+                                        test_filename,
+                                    )
+                                )
+                                printTestVariation(
+                                    compoptsnum,
+                                    compoptslist,
+                                    execoptsnum,
+                                    execoptslist,
+                                )
+                                sys.stdout.write("]\n")
+                                sys.stdout.write(
+                                    "[Execution output was as follows:]\n"
+                                )
                                 sys.stdout.write(trim_output(output))
 
                         elif useTimedExec:
-                            wholecmd = cmd+' '+' '.join(map(ShellEscape, args))
+                            wholecmd = (
+                                cmd + " " + " ".join(map(ShellEscape, args))
+                            )
 
                             if redirectin == None:
                                 my_stdin = sys.stdin
                             else:
-                                my_stdin = open(redirectin, 'r')
+                                my_stdin = open(redirectin, "r")
 
-                            (exec_status, stdout, stderr) = run_process([timedexec, str(timeout), wholecmd],
-                                             env=get_process_env(testenv),
-                                             stdin=my_stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                            exec_status, stdout, stderr = run_process(
+                                [timedexec, str(timeout), wholecmd],
+                                env=get_process_env(testenv),
+                                stdin=my_stdin,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                            )
                             output = stdout + stderr
 
                             if exec_status == 222:
                                 exectimeout = True
-                                sys.stdout.write('%s[Error: Timed out executing program %s/%s'%
-                                                (futuretest, localdir, test_filename))
-                                printTestVariation(compoptsnum, compoptslist,
-                                                   execoptsnum, execoptslist)
-                                sys.stdout.write(']\n')
-                                sys.stdout.write('[Execution output was as follows:]\n')
+                                sys.stdout.write(
+                                    "%s[Error: Timed out executing program %s/%s"
+                                    % (futuretest, localdir, test_filename)
+                                )
+                                printTestVariation(
+                                    compoptsnum,
+                                    compoptslist,
+                                    execoptsnum,
+                                    execoptslist,
+                                )
+                                sys.stdout.write("]\n")
+                                sys.stdout.write(
+                                    "[Execution output was as follows:]\n"
+                                )
                                 sys.stdout.write(trim_output(output))
                             else:
                                 # for perf runs print out the 5 processes with the
                                 # highest cpu usage. This should help identify if other
                                 # processes might have interfered with a test.
                                 if perftest:
-                                    print('[Reporting processes with top 5 highest cpu usages]')
+                                    print(
+                                        "[Reporting processes with top 5 highest cpu usages]"
+                                    )
                                     sys.stdout.flush()
-                                    psCom = 'ps ax -o user,pid,pcpu,command '
-                                    subprocess.call(psCom + '| head -n 1', shell=True)
-                                    subprocess.call(psCom + '| tail -n +2 | sort -r -k 3 | head -n 5', shell=True)
+                                    psCom = "ps ax -o user,pid,pcpu,command "
+                                    subprocess.call(
+                                        psCom + "| head -n 1", shell=True
+                                    )
+                                    subprocess.call(
+                                        psCom
+                                        + "| tail -n +2 | sort -r -k 3 | head -n 5",
+                                        shell=True,
+                                    )
 
                         else:
                             if redirectin == None:
                                 my_stdin = None
                             else:
-                                my_stdin=open(redirectin, 'r')
-                            p = subprocess.Popen([cmd]+args,
-                                                 env=get_process_env(testenv),
-                                                 stdin=my_stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                                my_stdin = open(redirectin, "r")
+                            p = subprocess.Popen(
+                                [cmd] + args,
+                                env=get_process_env(testenv),
+                                stdin=my_stdin,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                            )
                             try:
-                                stdoutOutput = str(SuckOutputWithTimeout(p.stdout, timeout), "utf-8")
+                                stdoutOutput = str(
+                                    SuckOutputWithTimeout(p.stdout, timeout),
+                                    "utf-8",
+                                )
                             except ReadTimeoutException:
                                 exectimeout = True
-                                sys.stdout.write('%s[Error: Timed out executing program %s/%s'%
-                                                (futuretest, localdir, test_filename))
-                                printTestVariation(compoptsnum, compoptslist,
-                                                   execoptsnum, execoptslist)
-                                sys.stdout.write(']\n')
+                                sys.stdout.write(
+                                    "%s[Error: Timed out executing program %s/%s"
+                                    % (futuretest, localdir, test_filename)
+                                )
+                                printTestVariation(
+                                    compoptsnum,
+                                    compoptslist,
+                                    execoptsnum,
+                                    execoptslist,
+                                )
+                                sys.stdout.write("]\n")
                                 KillProc(p, killtimeout)
 
                             stderrOutput = str(p.stderr.read(), "utf-8")
@@ -2359,51 +2902,78 @@ def main():
 
                     elapsedExecTime = time.time() - execStart
                     test_name = os.path.join(localdir, test_filename)
-                    compExecStr = ''
+                    compExecStr = ""
                     if compoptsnum != 0:
-                        compExecStr += 'compopts: {0} '.format(compoptsnum)
+                        compExecStr += "compopts: {0} ".format(compoptsnum)
                     if execoptsnum != 0:
-                        compExecStr += 'execopts: {0}'.format(execoptsnum)
+                        compExecStr += "execopts: {0}".format(execoptsnum)
                     if compExecStr:
-                        test_name += ' ({0})'.format(compExecStr.strip())
+                        test_name += " ({0})".format(compExecStr.strip())
 
                     if launchcmd and os.path.exists(launchcmd_exec_time_file):
-                        with open(launchcmd_exec_time_file, 'r') as fp:
+                        with open(launchcmd_exec_time_file, "r") as fp:
                             try:
                                 launchcmd_exec_time = float(fp.read())
-                                print('[launchcmd reports elapsed execution time '
-                                    'for "{0}" - {1:.3f} seconds]'
-                                    .format(test_name, launchcmd_exec_time))
+                                print(
+                                    "[launchcmd reports elapsed execution time "
+                                    'for "{0}" - {1:.3f} seconds]'.format(
+                                        test_name, launchcmd_exec_time
+                                    )
+                                )
                             except ValueError:
-                                print('Could not parse launchcmd time file '
-                                    '{0}'.format(launchcmd_exec_time_file))
+                                print(
+                                    "Could not parse launchcmd time file "
+                                    "{0}".format(launchcmd_exec_time_file)
+                                )
                         os.unlink(launchcmd_exec_time_file)
 
-                    print('[Elapsed execution time for "{0}" - {1:.3f} '
-                        'seconds]'.format(test_name, elapsedExecTime))
+                    print(
+                        '[Elapsed execution time for "{0}" - {1:.3f} '
+                        "seconds]".format(test_name, elapsedExecTime)
+                    )
 
-                    if execTimeWarnLimit and elapsedExecTime > execTimeWarnLimit:
-                        sys.stdout.write('[Warning: %s/%s took over %.0f seconds to '
-                            'execute]\n' %(localdir, test_filename, execTimeWarnLimit))
+                    if (
+                        execTimeWarnLimit
+                        and elapsedExecTime > execTimeWarnLimit
+                    ):
+                        sys.stdout.write(
+                            "[Warning: %s/%s took over %.0f seconds to "
+                            "execute]\n"
+                            % (localdir, test_filename, execTimeWarnLimit)
+                        )
 
-                    if execTimeSkipTrials and elapsedExecTime > execTimeSkipTrials:
+                    if (
+                        execTimeSkipTrials
+                        and elapsedExecTime > execTimeSkipTrials
+                    ):
                         skip_remaining_trials = True
 
                     if catfiles:
-                        sys.stdout.write('[Concatenating extra files: %s]\n'%
-                                        (test_filename+'.catfiles'))
+                        sys.stdout.write(
+                            "[Concatenating extra files: %s]\n"
+                            % (test_filename + ".catfiles")
+                        )
                         sys.stdout.flush()
                         WaitForFiles(catfiles.split())
-                        cat_output = run_process(['cat']+catfiles.split(),
-                                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                        cat_output = run_process(
+                            ["cat"] + catfiles.split(),
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                        )[1]
                         output += cat_output
 
                     # It's got surrogates, so encode it as bytes and write it as binary
                     mode = "w"
                     output_to_write, pre_exec_to_write = output, pre_exec_output
-                    if re.search(r'[\uD800-\uDFFF]', output) or re.search(r'[\uD800-\uDFFF]', pre_exec_output):
-                        output_to_write = output.encode(errors="surrogateescape")
-                        pre_exec_to_write = pre_exec_output.encode(errors="surrogateescape")
+                    if re.search(r"[\uD800-\uDFFF]", output) or re.search(
+                        r"[\uD800-\uDFFF]", pre_exec_output
+                    ):
+                        output_to_write = output.encode(
+                            errors="surrogateescape"
+                        )
+                        pre_exec_to_write = pre_exec_output.encode(
+                            errors="surrogateescape"
+                        )
                         mode = "wb"
 
                     # Sadly the scripts used below require an actual file
@@ -2423,138 +2993,256 @@ def main():
                     if not exectimeout and not launcher_error:
                         if systemPrediffs:
                             for sprediff in systemPrediffs:
-                                sys.stdout.write('[Executing system-wide prediff %s]\n'%(sprediff))
+                                sys.stdout.write(
+                                    "[Executing system-wide prediff %s]\n"
+                                    % (sprediff)
+                                )
                                 sys.stdout.flush()
-                                stdout = run_process([sprediff, execname, execlog, compiler,
-                                                      ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
-                                                     env=get_process_env(testenv),
-                                                     stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                                stdout = run_process(
+                                    [
+                                        sprediff,
+                                        execname,
+                                        execlog,
+                                        compiler,
+                                        " ".join(envCompopts) + " " + compopts,
+                                        " ".join(args),
+                                    ],
+                                    env=get_process_env(testenv),
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT,
+                                )[1]
                                 sys.stdout.write(stdout)
 
                         if globalPrediff:
-                            sys.stdout.write('[Executing ./PREDIFF]\n')
+                            sys.stdout.write("[Executing ./PREDIFF]\n")
                             sys.stdout.flush()
-                            stdout = run_process(['./PREDIFF', execname, execlog, compiler,
-                                                 ' '.join(envCompopts)+ ' '+compopts, ' '.join(args)],
-                                                 env=get_process_env(testenv),
-                                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                            stdout = run_process(
+                                [
+                                    "./PREDIFF",
+                                    execname,
+                                    execlog,
+                                    compiler,
+                                    " ".join(envCompopts) + " " + compopts,
+                                    " ".join(args),
+                                ],
+                                env=get_process_env(testenv),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                            )[1]
                             sys.stdout.write(stdout)
 
                         if prediff:
-                            sys.stdout.write('[Executing prediff ./%s]\n'%(prediff))
+                            sys.stdout.write(
+                                "[Executing prediff ./%s]\n" % (prediff)
+                            )
                             sys.stdout.flush()
-                            stdout = run_process(['./'+prediff, execname, execlog, compiler,
-                                                 ' '.join(envCompopts)+' '+compopts, ' '.join(args)],
-                                                 env=get_process_env(testenv),
-                                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                            stdout = run_process(
+                                [
+                                    "./" + prediff,
+                                    execname,
+                                    execlog,
+                                    compiler,
+                                    " ".join(envCompopts) + " " + compopts,
+                                    " ".join(args),
+                                ],
+                                env=get_process_env(testenv),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT,
+                            )[1]
                             sys.stdout.write(stdout)
 
                         if not perftest:
                             # find the good file
 
                             basename = test_filename
-                            commExecNum = ['']
+                            commExecNum = [""]
 
                             # if there were multiple compopts/execopts find the
                             # .good file that corresponds to that run
                             if not onlyone:
-                                commExecNum.insert(0,'.'+str(compoptsnum)+'-'+str(execoptsnum))
+                                commExecNum.insert(
+                                    0,
+                                    "."
+                                    + str(compoptsnum)
+                                    + "-"
+                                    + str(execoptsnum),
+                                )
 
                             # if the .good file was explicitly specified, look for
                             # that version instead of the multiple
                             # compopts/execopts or just the base .good file
                             if explicitexecgoodfile != None:
-                                basename  = explicitexecgoodfile.replace('.good', '')
-                                commExecNum = ['']
+                                basename = explicitexecgoodfile.replace(
+                                    ".good", ""
+                                )
+                                commExecNum = [""]
 
                             execgoodfile = FindGoodFile(basename, commExecNum)
 
-                            if not os.path.isfile(execgoodfile) or not os.access(execgoodfile, os.R_OK):
-                                sys.stdout.write('[Error cannot locate program output comparison file %s/%s]\n'%(localdir, execgoodfile))
-                                sys.stdout.write('[Execution output was as follows:]\n')
-                                exec_output = run_process(['cat', execlog], stdout=subprocess.PIPE)[1]
+                            if not os.path.isfile(
+                                execgoodfile
+                            ) or not os.access(execgoodfile, os.R_OK):
+                                sys.stdout.write(
+                                    "[Error cannot locate program output comparison file %s/%s]\n"
+                                    % (localdir, execgoodfile)
+                                )
+                                sys.stdout.write(
+                                    "[Execution output was as follows:]\n"
+                                )
+                                exec_output = run_process(
+                                    ["cat", execlog], stdout=subprocess.PIPE
+                                )[1]
                                 sys.stdout.write(trim_output(exec_output))
 
-                                continue # on to next execopts
+                                continue  # on to next execopts
 
                             result = DiffFiles(execgoodfile, execlog)
-                            if result==0:
+                            if result == 0:
                                 os.unlink(execlog)
-                                sys.stdout.write('%s[Success '%(futuretest))
+                                sys.stdout.write("%s[Success " % (futuretest))
                             else:
-                                extra_msg = filter_errors(output, pre_exec_output, execgoodfile, execlog)
-                                sys.stdout.write('%s[Error %s'%(futuretest, extra_msg))
+                                extra_msg = filter_errors(
+                                    output,
+                                    pre_exec_output,
+                                    execgoodfile,
+                                    execlog,
+                                )
+                                sys.stdout.write(
+                                    "%s[Error %s" % (futuretest, extra_msg)
+                                )
 
-                            sys.stdout.write('matching program output for %s/%s'%
-                                            (localdir, test_filename))
-                            if result!=0:
-                                printTestVariation(compoptsnum, compoptslist,
-                                                   execoptsnum, execoptslist)
-                            sys.stdout.write(']\n')
+                            sys.stdout.write(
+                                "matching program output for %s/%s"
+                                % (localdir, test_filename)
+                            )
+                            if result != 0:
+                                printTestVariation(
+                                    compoptsnum,
+                                    compoptslist,
+                                    execoptsnum,
+                                    execoptslist,
+                                )
+                            sys.stdout.write("]\n")
 
-                            if (result != 0 and futuretest != ''):
-                                badfile=test_filename+'.bad'
+                            if result != 0 and futuretest != "":
+                                badfile = test_filename + ".bad"
                                 if os.access(badfile, os.R_OK):
                                     badresult = DiffFiles(badfile, execlog)
-                                    if badresult==0:
+                                    if badresult == 0:
                                         os.unlink(execlog)
-                                        sys.stdout.write('[Clean match against .bad file ')
+                                        sys.stdout.write(
+                                            "[Clean match against .bad file "
+                                        )
                                     else:
                                         # bad file doesn't match, which is bad
-                                        sys.stdout.write('[Error matching .bad file ')
-                                    sys.stdout.write('for %s/%s'%(localdir, test_filename))
-                                    printTestVariation(compoptsnum, compoptslist)
-                                    sys.stdout.write(']\n')
+                                        sys.stdout.write(
+                                            "[Error matching .bad file "
+                                        )
+                                    sys.stdout.write(
+                                        "for %s/%s" % (localdir, test_filename)
+                                    )
+                                    printTestVariation(
+                                        compoptsnum, compoptslist
+                                    )
+                                    sys.stdout.write("]\n")
 
                     if perftest:
-                        if not os.path.isdir(perfdir) and not os.path.isfile(perfdir):
+                        if not os.path.isdir(perfdir) and not os.path.isfile(
+                            perfdir
+                        ):
                             py3_compat.makedirs(perfdir, exist_ok=True)
-                        if not os.access(perfdir, os.R_OK|os.X_OK):
-                            sys.stdout.write('[Error creating performance test directory %s]\n'%(perfdir))
-                            break # on to next compopts
+                        if not os.access(perfdir, os.R_OK | os.X_OK):
+                            sys.stdout.write(
+                                "[Error creating performance test directory %s]\n"
+                                % (perfdir)
+                            )
+                            break  # on to next compopts
 
-                        if explicitexecgoodfile==None:
+                        if explicitexecgoodfile == None:
                             perfexecname = test_filename
-                            keyfile = PerfTFile(test_filename,'keys') #e.g. .perfkeys
+                            keyfile = PerfTFile(
+                                test_filename, "keys"
+                            )  # e.g. .perfkeys
                         else:
-                            perfexecname = re.sub(r'\{0}$'.format(PerfSfx('keys')), '', explicitexecgoodfile)
-                            if (os.path.isfile(explicitexecgoodfile) and
-                                test_filename != explicitexecgoodfile):
+                            perfexecname = re.sub(
+                                r"\{0}$".format(PerfSfx("keys")),
+                                "",
+                                explicitexecgoodfile,
+                            )
+                            if (
+                                os.path.isfile(explicitexecgoodfile)
+                                and test_filename != explicitexecgoodfile
+                            ):
                                 keyfile = explicitexecgoodfile
                             else:
-                                keyfile = PerfTFile(test_filename,'keys')
+                                keyfile = PerfTFile(test_filename, "keys")
 
-                        perfdate = os.getenv('CHPL_TEST_PERF_DATE')
+                        perfdate = os.getenv("CHPL_TEST_PERF_DATE")
                         if perfdate == None:
-                            perfdate = datetime.date.today().strftime("%m/%d/%y")
+                            perfdate = datetime.date.today().strftime(
+                                "%m/%d/%y"
+                            )
 
                         # if the program exited with a non-zero exit code, don't attempt to collect performance keys
                         status = 0
                         if exec_status == 0:
-                            sys.stdout.write('[Executing %s/test/computePerfStats %s %s %s %s %s %s]\n'%(utildir, perfexecname, perfdir, keyfile, execlog, str(exectimeout), perfdate))
+                            sys.stdout.write(
+                                "[Executing %s/test/computePerfStats %s %s %s %s %s %s]\n"
+                                % (
+                                    utildir,
+                                    perfexecname,
+                                    perfdir,
+                                    keyfile,
+                                    execlog,
+                                    str(exectimeout),
+                                    perfdate,
+                                )
+                            )
                             sys.stdout.flush()
-                            (status, stdout, _) = run_process([utildir+'/test/computePerfStats',
-                                                perfexecname, perfdir, keyfile, execlog, str(exectimeout), perfdate],
-                                                stdout=subprocess.PIPE)
-                            sys.stdout.write('%s'%(stdout))
+                            status, stdout, _ = run_process(
+                                [
+                                    utildir + "/test/computePerfStats",
+                                    perfexecname,
+                                    perfdir,
+                                    keyfile,
+                                    execlog,
+                                    str(exectimeout),
+                                    perfdate,
+                                ],
+                                stdout=subprocess.PIPE,
+                            )
+                            sys.stdout.write("%s" % (stdout))
                             sys.stdout.flush()
 
                             if not exectimeout and not launcher_error:
                                 if status == 0:
                                     os.unlink(execlog)
-                                    sys.stdout.write('%s[Success '%(futuretest))
+                                    sys.stdout.write(
+                                        "%s[Success " % (futuretest)
+                                    )
                                 else:
-                                    sys.stdout.write('%s[Error '%(futuretest))
-                                sys.stdout.write('matching performance keys for %s/%s'%
-                                                (localdir, test_filename))
-                                if status!=0:
-                                    printTestVariation(compoptsnum, compoptslist,
-                                                    execoptsnum, execoptslist)
-                                sys.stdout.write(']\n')
+                                    sys.stdout.write("%s[Error " % (futuretest))
+                                sys.stdout.write(
+                                    "matching performance keys for %s/%s"
+                                    % (localdir, test_filename)
+                                )
+                                if status != 0:
+                                    printTestVariation(
+                                        compoptsnum,
+                                        compoptslist,
+                                        execoptsnum,
+                                        execoptslist,
+                                    )
+                                sys.stdout.write("]\n")
                         # only notify for a failed execution if launching the test was successful
-                        elif (not launcher_error):
-                            sys.stdout.write('%s[Error execution failed for %s]\n'%(futuretest,test_name))
-                            sys.stdout.write('[Execution output was as follows:]\n')
+                        elif not launcher_error:
+                            sys.stdout.write(
+                                "%s[Error execution failed for %s]\n"
+                                % (futuretest, test_name)
+                            )
+                            sys.stdout.write(
+                                "[Execution output was as follows:]\n"
+                            )
                             sys.stdout.write(trim_output(output))
 
                         if exectimeout or status != 0 or exec_status != 0:
@@ -2571,5 +3259,6 @@ def main():
 
     sys.exit(0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -1563,14 +1563,14 @@ def main():
         else:
             executebin = execute
 
-        testfuturesfile=False
-        testskipiffile=False
-        noexecfile=False
-        execoptsfile=False
-        precomp=None
-        prediff=None
-        preexec=None
-        postexec=None
+        testfuturesfile = False
+        testskipiffile = False
+        noexecfile = False
+        execoptsfile = False
+        precomp = None
+        prediff = None
+        preexec = None
+        postexec = None
 
         if os.getenv("CHPL_NO_STDIN_REDIRECT") == None:
             redirectin = "/dev/null"
@@ -1768,10 +1768,10 @@ def main():
             elif suffix == ".preexec" and os.access(f, os.R_OK | os.X_OK):
                 preexec = f
 
-            elif (suffix=='.postexec' and os.access(f, os.R_OK|os.X_OK)):
-                postexec=f
+            elif suffix == ".postexec" and os.access(f, os.R_OK | os.X_OK):
+                postexec = f
 
-            elif (suffix=='.stdin' and os.access(f, os.R_OK)):
+            elif suffix == ".stdin" and os.access(f, os.R_OK):
                 if redirectin == None:
                     sys.stdout.write(
                         "[Skipping test with .stdin input since -nostdinredirect is given: %s/%s]\n"
@@ -2982,11 +2982,17 @@ def main():
                         execlogfile.write(output_to_write)
 
                     if postexec:
-                        sys.stdout.write('[Executing postexec %s.postexec]\n'%(test_filename))
+                        sys.stdout.write(
+                            "[Executing postexec %s.postexec]\n"
+                            % (test_filename)
+                        )
                         sys.stdout.flush()
-                        test_postexec = './{0}.postexec'.format(test_filename)
-                        stdout = run_process([test_postexec, execname, execlog, compiler],
-                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)[1]
+                        test_postexec = "./{0}.postexec".format(test_filename)
+                        stdout = run_process(
+                            [test_postexec, execname, execlog, compiler],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                        )[1]
                         sys.stdout.write(stdout)
                         sys.stdout.flush()
 


### PR DESCRIPTION
Fixes the python CI format check.

* Makes sure files in `third-party/chpl-venv` get checked, since those counterintuitively are not third-party code
* Makes sure only `test` files at the root get checked, since the check historically worked on `tools/chpl-language-server/test` but after being expanded no longer did. This also means important test files like `sub_test.py` and `start_test.py` get formatted

- [x] paratest

[Reviewed by @arifthpe]