### PR TITLE
dlopen: Move user module initialization into a procedure

### DIFF
--- a/compiler/optimizations/noAliasSets.cpp
+++ b/compiler/optimizations/noAliasSets.cpp
@@ -503,7 +503,7 @@ void addNoAliasSetsInFn(FnSymbol* fn) {
 
   if (fReportAliases) {
     if (fn->getModule()->modTag == MOD_USER) {
-      // Don't produce output for compiler-generated functions
+      // Don't produce output for specific functions in most cases.
       if (developer ||
           (!fn->hasFlag(FLAG_MODULE_INIT) &&
            !fn->hasFlag(FLAG_GEN_MAIN_FUNC))) {

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -795,12 +795,6 @@ static FnSymbol* buildInitProgramCommandLineModulesFn() {
   auto mainModule = ModuleSymbol::mainModule();
   auto fnName = astr("chpl_initProgramCommandLineModules");
 
-  for_alist(e, mainModule->block->body) {
-    auto def = toDefExpr(e);
-    auto fn = def ? toFnSymbol(def->sym) : nullptr;
-    if (fn && fn->name == fnName) return fn;
-  }
-
   auto ret = new FnSymbol(fnName);
   ret->addFlag(FLAG_EXPORT);
   ret->addFlag(FLAG_LOCAL_ARGS);

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -802,7 +802,8 @@ static FnSymbol* buildInitProgramCommandLineModulesFn() {
   ret->cname = fnName;
   ret->addFlag(FLAG_COMPILER_GENERATED);
 
-  mainModule->block->insertAtTail(new DefExpr(ret));
+  // Insert into an internal module to restrict user visibility.
+  theProgram->block->insertAtTail(new DefExpr(ret));
 
   ret->insertAtTail(new CallExpr(mainModule->initFn));
 

--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -791,6 +791,39 @@ static FnSymbol* chplGenMainExists() {
   return matchFn;
 }
 
+static FnSymbol* buildInitProgramCommandLineModulesFn() {
+  auto mainModule = ModuleSymbol::mainModule();
+  auto fnName = astr("chpl_initProgramCommandLineModules");
+
+  for_alist(e, mainModule->block->body) {
+    auto def = toDefExpr(e);
+    auto fn = def ? toFnSymbol(def->sym) : nullptr;
+    if (fn && fn->name == fnName) return fn;
+  }
+
+  auto ret = new FnSymbol(fnName);
+  ret->addFlag(FLAG_EXPORT);
+  ret->addFlag(FLAG_LOCAL_ARGS);
+  ret->retType = dtVoid;
+  ret->cname = fnName;
+  ret->addFlag(FLAG_COMPILER_GENERATED);
+
+  mainModule->block->insertAtTail(new DefExpr(ret));
+
+  ret->insertAtTail(new CallExpr(mainModule->initFn));
+
+  // also init other modules mentioned on command line
+  forv_Vec(ModuleSymbol, mod, gModuleSymbols) {
+    if (mod->hasFlag(FLAG_MODULE_FROM_COMMAND_LINE_FILE) &&
+        mod != mainModule) {
+      ret->insertAtTail(new CallExpr(mod->initFn));
+    }
+  }
+
+  normalize(ret);
+
+  return ret;
+}
 
 static void buildChplEntryPoints() {
   //
@@ -881,14 +914,8 @@ static void buildChplEntryPoints() {
   // We have to initialize the main module explicitly.
   // It will initialize all the modules it uses, recursively.
   if (!fClientServerLibrary) {
-    chpl_gen_main->insertAtTail(new CallExpr(mainModule->initFn));
-    // also init other modules mentioned on command line
-    forv_Vec(ModuleSymbol, mod, gModuleSymbols) {
-      if (mod->hasFlag(FLAG_MODULE_FROM_COMMAND_LINE_FILE) &&
-          mod != mainModule) {
-        chpl_gen_main->insertAtTail(new CallExpr(mod->initFn));
-      }
-    }
+    auto initCmdModsFn = buildInitProgramCommandLineModulesFn();
+    chpl_gen_main->insertAtTail(new CallExpr(initCmdModsFn));
 
   } else {
     // Create an extern definition for the multilocale library server's main

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -13329,6 +13329,33 @@ static void printUnusedFunctions() {
 #endif
 }
 
+static bool shouldProcessForCallGraph(CallExpr* call, FnSymbol* fn) {
+  bool isCallOrFnInUserModule = fn->getModule()->modTag == MOD_USER ||
+                                call->getModule()->modTag == MOD_USER;
+  bool isFnInternal = fn->getModule()->modTag == MOD_INTERNAL;
+  bool isInitCmdLineModulesFn =
+    fn->name == astr("chpl_initProgramCommandLineModules") && isFnInternal;
+
+  if (isInitCmdLineModulesFn ||
+      (isCallOrFnInUserModule && !isFnInternal &&
+       !fn->hasFlag(FLAG_COMPILER_GENERATED) &&
+       !fn->hasFlag(FLAG_COMPILER_NESTED_FUNCTION))) {
+
+    if (!strncmp("chpl_", fn->name, 5) &&
+        !fn->hasFlag(FLAG_MODULE_INIT) &&
+        !isInitCmdLineModulesFn) {
+      // skip any functions that are internal (start with "chpl_")
+      // except for the init function for the module, which needs
+      // to be traversed to find top-level calls in the module
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
 //
 // Print a representation of the call graph of the program.
 // This needs to be done after function resolution so we can follow calls
@@ -13367,20 +13394,7 @@ static void printCallGraph(FnSymbol* startPoint, int indent, std::set<FnSymbol*>
   for_vector(BaseAST, ast, asts) {
     if (CallExpr* call = toCallExpr(ast)) {
       if (FnSymbol* fn = call->resolvedFunction()) {
-        if ((fn->getModule()->modTag == MOD_USER ||
-             call->getModule()->modTag == MOD_USER) &&
-            fn->getModule()->modTag != MOD_INTERNAL &&
-            !fn->hasFlag(FLAG_COMPILER_GENERATED) &&
-            !fn->hasFlag(FLAG_COMPILER_NESTED_FUNCTION)) {
-
-          if (strncmp("chpl_", fn->name, 5) == 0 &&
-              !fn->hasFlag(FLAG_MODULE_INIT)) {
-            // skip any functions that are internal (start with "chpl_")
-            // except for the init function for the module, which needs
-            // to be traversed to find top-level calls in the module
-            continue;
-          }
-
+        if (shouldProcessForCallGraph(call, fn)) {
           FnSymbol* instFn = fn;
           if (FnSymbol* gfn = fn->instantiatedFrom) {
             instFn = gfn;


### PR DESCRIPTION
This PR moves the process of invoking initializers for user modules into a new internal `export` procedure named `chpl_initProgramCommandLineModules`. This is in preparation for future dynamic loading code which needs to be able to invoke these initializers in the proper fashion.

Reviewed by @jabraham17. Thanks!