### PR TITLE
Adjust test to handle strictness of GNU compiler flags

### DIFF
--- a/test/dynamic-loading/CodegenTimeArrays.chpl
+++ b/test/dynamic-loading/CodegenTimeArrays.chpl
@@ -6,17 +6,17 @@ extern {
 
   // Test to see what happens when we load or store into a struct.
   typedef struct holder {
-    void** global_serialize_table;
-    void** globals_registry;
-    char** mem_descs;
-    void** private_broadcast_table;
+    void* const*    global_serialize_table;
+    ptr_wide_ptr_t* globals_registry;
+    const char**    mem_descs;
+    void* const*    private_broadcast_table;
   } holder;
 
   // Pass in the values materialized from the addresses through Chapel.
-  void getter_chpl_global_serialize_table(void** x);
-  void getter_chpl_globals_registry(void** x);
-  void getter_chpl_mem_descs(char** x);
-  void getter_chpl_private_broadcast_table(void** x);
+  void getter_chpl_global_serialize_table(void* const x[]);
+  void getter_chpl_globals_registry(ptr_wide_ptr_t x[]);
+  void getter_chpl_mem_descs(const char* x[]);
+  void getter_chpl_private_broadcast_table(void* const x[]);
   void get_from_holder(holder* x);
 
   // Realize the addresses in C.
@@ -33,19 +33,19 @@ extern {
     printf("%s\n", msg );                                   \
   } while (0)
     
-  void getter_chpl_global_serialize_table(void** x) {
+  void getter_chpl_global_serialize_table(void* const x[]) {
     PRINTER(x, chpl_global_serialize_table);
   }
 
-  void getter_chpl_globals_registry(void** x) {
+  void getter_chpl_globals_registry(ptr_wide_ptr_t x[]) {
     PRINTER(x, chpl_globals_registry);
   }
 
-  void getter_chpl_mem_descs(char** x) {
+  void getter_chpl_mem_descs(const char* x[]) {
     PRINTER(x, chpl_mem_descs);
   }
 
-  void getter_chpl_private_broadcast_table(void** x) {
+  void getter_chpl_private_broadcast_table(void* const x[]) {
     PRINTER(x, chpl_private_broadcast_table);
   }
 
@@ -77,24 +77,23 @@ proc callTheGetter(param name: string, in x) {
 // chpl_mem_descs
 // chpl_private_broadcast_table
 proc test() {
-  extern const chpl_global_serialize_table:     c_ptr(c_ptr(void));
-  extern const chpl_globals_registry:           c_ptr(c_ptr(void));
-  extern const chpl_mem_descs:                  c_ptr(c_ptr(c_char));
-  extern const chpl_private_broadcast_table:    c_ptr(c_ptr(void));
-
-  callTheGetter('chpl_global_serialize_table',
-                 chpl_global_serialize_table);
-  callTheGetter('chpl_globals_registry',
-                 chpl_globals_registry);
-  callTheGetter('chpl_mem_descs', chpl_mem_descs);
-  callTheGetter('chpl_private_broadcast_table',
-                 chpl_private_broadcast_table);
+  extern const chpl_global_serialize_table:     c_ptr(void);
+  extern const chpl_globals_registry:           c_ptr(void);
+  extern const chpl_mem_descs:                  c_ptr(void);
+  extern const chpl_private_broadcast_table:    c_ptr(void);
 
   var x: holder;
-  x.global_serialize_table  = chpl_global_serialize_table;
-  x.globals_registry        = chpl_globals_registry;
-  x.mem_descs               = chpl_mem_descs;
-  x.private_broadcast_table = chpl_private_broadcast_table;
+  x.global_serialize_table  = chpl_global_serialize_table
+                            : x.global_serialize_table.type;
+  x.globals_registry        = chpl_globals_registry : x.globals_registry.type;
+  x.mem_descs               = chpl_mem_descs : x.mem_descs.type;
+  x.private_broadcast_table = chpl_private_broadcast_table
+                            : x.private_broadcast_table.type;
+
+  callTheGetter('chpl_global_serialize_table', x.global_serialize_table);
+  callTheGetter('chpl_globals_registry', x.globals_registry);
+  callTheGetter('chpl_mem_descs', x.mem_descs);
+  callTheGetter('chpl_private_broadcast_table', x.private_broadcast_table);
 
   get_from_holder(c_ptrTo(x));
 }


### PR DESCRIPTION
I introduced a test that exercises some arrays that are normally only used by the runtime. The test is mainly C code, and I only bothered to test it with the builtin Clang. Turns out the GNU compiler is a bit more strict.