### PR TITLE
Implement promotion for procedure pointers

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1527,7 +1527,11 @@ const char* FunctionType::toStringMangledForCodegen() const {
     auto f = this->formal(i);
     oss << qualifierMnemonicMangled(f->qual());
     oss << intentTagMnemonicMangled(f->intent());
-    oss << typeToStringMangled(f->type()) << "_";
+    if (f->isGeneric()) {
+      oss << "unknown";
+    } else {
+      oss << typeToStringMangled(f->type()) << "_";
+    }
     if (f->name()) oss << f->name();
     oss << "_";
   }

--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -147,7 +147,8 @@ bool canDispatch(Type*     actualType,
                  FnSymbol* fn          = NULL,
                  bool*     promotes    = NULL,
                  bool*     paramNarrows= NULL,
-                 bool      paramCoerce = false);
+                 bool      paramCoerce = false,
+                 FunctionType* fnType = nullptr);
 
 
 void parseExplainFlag(char* flag, int* line, ModuleSymbol** module);

--- a/compiler/optimizations/inferConstRefs.cpp
+++ b/compiler/optimizations/inferConstRefs.cpp
@@ -406,8 +406,10 @@ static bool inferConstRef(Symbol* sym) {
         isConstRef = false;
       }
     }
-    else if (isPassedToRefFormalInIndirectCall(use, call)) {
-      isConstRef = false;
+    else if (call->isIndirectCall()) {
+      if (isPassedToRefFormalInIndirectCall(use, call)) {
+        isConstRef = false;
+      }
     }
     else if (parent && isMoveOrAssign(parent)) {
       if (!canRHSBeConstRef(parent, use)) {

--- a/compiler/passes/StreamlineProcPtrTypesForCodegen.cpp
+++ b/compiler/passes/StreamlineProcPtrTypesForCodegen.cpp
@@ -33,7 +33,8 @@ namespace {
 }
 
 Type* Pass::computeAdjustedType(Type* t) const {
-  if (auto ft = toFunctionType(t->getValType())) {
+  if (auto ft = toFunctionType(t->getValType());
+      ft && !ft->isGeneric()) {
     auto ret = ft->getWithStreamlinedComponents();
     return ret;
   }

--- a/compiler/passes/resolveIntents.cpp
+++ b/compiler/passes/resolveIntents.cpp
@@ -512,7 +512,8 @@ static FunctionType* computeConcreteIntentsForFunctionType(FunctionType* ft) {
 class ResolveIntentsForProcPtrTypes : public AdjustSymbolTypes {
  public:
   Type* computeAdjustedType(Type* t) const override {
-    if (auto ft = toFunctionType(t->getValType())) {
+    if (auto ft = toFunctionType(t->getValType());
+        ft && !ft->isGeneric()) {
       auto ret = computeConcreteIntentsForFunctionType(ft);
       return ret;
     }

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1745,7 +1745,6 @@ bool doCanDispatch(Type*     actualType,
                    bool*     paramNarrows,
                    bool      paramCoerce,
                    FunctionType* fnType) {
-  if (fn) INT_ASSERT(fnType);
 
   if (actualType == formalType)
     return true;
@@ -1807,10 +1806,16 @@ bool doCanDispatch(Type*     actualType,
   auto scalar = actualType->isRef() ?
                   actualType->getValType()->scalarPromotionType :
                   actualType->scalarPromotionType;
-  if (fnType &&
-      !badName &&
-      fnType->returnIntent()          != RET_TYPE    &&
-      fnType->returnIntent()          != RET_PARAM   &&
+  bool okReturnIntent = false;
+  if (fn) {
+    okReturnIntent = fn->retTag != RET_TYPE &&
+                     fn->retTag != RET_PARAM;
+  } else if (fnType) {
+    okReturnIntent = fnType->returnIntent() != RET_TYPE &&
+                     fnType->returnIntent() != RET_PARAM;
+  }
+  if (!badName &&
+      okReturnIntent &&
       scalar != NULL        &&
       doCanDispatch(scalar, NULL,
                     formalType, formalSym,
@@ -1837,9 +1842,6 @@ bool canDispatch(Type*     actualType,
                  bool*     paramNarrows,
                  bool      paramCoerce,
                  FunctionType* fnType) {
-  if (fn && fnType == nullptr) {
-    fnType = FunctionType::get(fn);
-  }
   bool tmpPromotes     = false;
   bool tmpParamNarrows = false;
   bool retval          = doCanDispatch(actualType, actualSym,

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3408,6 +3408,8 @@ static bool resolveFunctionPointerCall(CallExpr* call) {
 
   bool onceForErrorHeader = true;
 
+  bool anyPromotes = false;
+
   // TODO: Can we rework 'ResolutionCandidate' to operate in terms of
   // function types? That might enable us to use that machinery here.
   for (int i = 0; i < ft->numFormals(); i++) {
@@ -3426,7 +3428,9 @@ static bool resolveFunctionPointerCall(CallExpr* call) {
     bool ok = canDispatch(actualType, actualSym, formalType, formalSym, fn,
                           &promotes,
                           &paramNarrows,
-                          paramCoerce);
+                          paramCoerce,
+                          ft);
+    anyPromotes = anyPromotes || promotes;
     if (!ok) {
       if (onceForErrorHeader) {
         USR_FATAL_CONT(call, "failed to resolve call");
@@ -3438,6 +3442,37 @@ static bool resolveFunctionPointerCall(CallExpr* call) {
                              toString(actualType),
                              toString(formalType));
     }
+  }
+
+  // Instead of refactoring promotion wrapping machinery, create a wrapper for
+  // this particular call and resolve it normally.
+  if (anyPromotes) {
+    static int promoWrapperId = 0;
+    auto name = astr("chpl_fnptr_promo_wrapper_", std::to_string(promoWrapperId++).c_str());
+    FnSymbol* fn = new FnSymbol(name);
+    fn->addFlag(FLAG_COMPILER_GENERATED);
+    CallExpr* wrappedCall = new CallExpr(call->baseExpr->copy());
+    for (int i = 0; i < ft->numFormals(); i++) {
+      auto formal = ft->formal(i);
+      ArgSymbol* arg = new ArgSymbol(formal->intent(), formal->name(), formal->type());
+      fn->insertFormalAtTail(arg);
+      wrappedCall->insertAtTail(new SymExpr(arg));
+    }
+
+    fn->retType = ft->returnType();
+    if (ft->returnType() != dtVoid) {
+      VarSymbol* ret = newTemp("fnptr_promo_wrapper_ret", ft->returnType());
+      fn->body->insertAtTail(new DefExpr(ret));
+      fn->body->insertAtTail(new CallExpr(PRIM_MOVE, ret, wrappedCall));
+      fn->body->insertAtTail(new CallExpr(PRIM_RETURN, ret));
+    } else {
+      fn->body->insertAtTail(wrappedCall);
+    }
+
+    call->getStmtExpr()->insertBefore(new DefExpr(fn));
+
+    call->baseExpr->replace(new SymExpr(fn));
+    resolveNormalCall(call);
   }
 
   return true;

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -1743,7 +1743,9 @@ bool doCanDispatch(Type*     actualType,
                    FnSymbol* fn,
                    bool*     promotes,
                    bool*     paramNarrows,
-                   bool      paramCoerce) {
+                   bool      paramCoerce,
+                   FunctionType* fnType) {
+  if (fn) INT_ASSERT(fnType);
 
   if (actualType == formalType)
     return true;
@@ -1798,18 +1800,25 @@ bool doCanDispatch(Type*     actualType,
     return true;
 
   // check if promotion is possible
-  if (fn                              != NULL        &&
-      fn->name                        != astrSassign &&
-      strcmp(fn->name, "these")       != 0           &&
-      fn->retTag                      != RET_TYPE    &&
-      fn->retTag                      != RET_PARAM   &&
-      actualType->scalarPromotionType != NULL        &&
-      doCanDispatch(actualType->scalarPromotionType, NULL,
+  // Note: Assumes that if `fn` is null and we have a `fnType`, that we're
+  // dealing with a proc ptr. In this case, `=` and `these` cannot be captured
+  // and so do not need to be accounted for.
+  bool badName = fn && (fn->name == astrSassign || strcmp(fn->name, "these") == 0);
+  auto scalar = actualType->isRef() ?
+                  actualType->getValType()->scalarPromotionType :
+                  actualType->scalarPromotionType;
+  if (fnType &&
+      !badName &&
+      fnType->returnIntent()          != RET_TYPE    &&
+      fnType->returnIntent()          != RET_PARAM   &&
+      scalar != NULL        &&
+      doCanDispatch(scalar, NULL,
                     formalType, formalSym,
                     fn,
                     promotes,
                     paramNarrows,
-                    false)) {
+                    false,
+                    fnType)) {
     *promotes = true;
     return true;
   }
@@ -1826,7 +1835,11 @@ bool canDispatch(Type*     actualType,
                  FnSymbol* fn,
                  bool*     promotes,
                  bool*     paramNarrows,
-                 bool      paramCoerce) {
+                 bool      paramCoerce,
+                 FunctionType* fnType) {
+  if (fn && fnType == nullptr) {
+    fnType = FunctionType::get(fn);
+  }
   bool tmpPromotes     = false;
   bool tmpParamNarrows = false;
   bool retval          = doCanDispatch(actualType, actualSym,
@@ -1834,7 +1847,8 @@ bool canDispatch(Type*     actualType,
                                        fn,
                                        &tmpPromotes,
                                        &tmpParamNarrows,
-                                       paramCoerce);
+                                       paramCoerce,
+                                       fnType);
 
   if (promotes     != NULL) {
     *promotes = tmpPromotes;


### PR DESCRIPTION
This PR adds support for promotion of procedure pointers.

The current infrastructure to support promotion does not work with procedure pointers directly. Instead of trying to refactor this code, we can wrap the indirect call in a function and invoke promotion generation on that function, like normal. A fix to canDispatch is also needed to account for ``FunctionType*``s.

Testing:
- [x] local paratest