### PR TITLE
Fix formatting of `--fast` in List docs

### DIFF
--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1008,7 +1008,7 @@ module List {
       .. warning::
 
         Calling this method on an empty list will cause the currently running
-        program to halt. If the `--fast` flag is used, no safety checks will
+        program to halt. If the ``--fast`` flag is used, no safety checks will
         be performed.
 
       :return: A reference to the first item in this list.
@@ -1042,7 +1042,7 @@ module List {
       .. warning::
 
         Calling this method on an empty list will cause the currently running
-        program to halt. If the `--fast` flag is used, no safety checks will
+        program to halt. If the ``--fast`` flag is used, no safety checks will
         be performed.
 
       :return: A reference to the last item in this list.
@@ -1353,7 +1353,7 @@ module List {
       .. warning::
 
         Calling this method on an empty list will cause the currently running
-        program to halt. If the `--fast` flag is used, no safety checks will
+        program to halt. If the ``--fast`` flag is used, no safety checks will
         be performed.
 
       :return: The element popped.
@@ -1380,7 +1380,7 @@ module List {
 
         Calling this method on an empty list or with values of `idx` that
         are out of bounds will cause the currently running program to halt.
-        If the `--fast` flag is used, no safety checks will be performed.
+        If the ``--fast`` flag is used, no safety checks will be performed.
 
       :arg idx: The index of the element to remove.
       :type idx: `int`
@@ -1519,9 +1519,9 @@ module List {
 
       .. warning::
 
-        Calling this method with values of `start` or `end` that are out of bounds
-        will cause the currently running program to halt. If the `--fast` flag is
-        used, no safety checks will be performed.
+        Calling this method with values of `start` or `end` that are out of
+        bounds will cause the currently running program to halt. If the
+        ``--fast`` flag is used, no safety checks will be performed.
 
       :arg x: An element to search for.
       :type x: `eltType`


### PR DESCRIPTION
Fixes the formatting of `--fast` in the List docs.

Since before it was only using a single backtick, the `--` for the flag would be rendered as a long dash, not two short dashes

The fix is to properly use two backticks

[Not reviewed - trivial]