### PR TITLE
Attempt to quiet intermittent failures of raCommCheckLCG

### DIFF
--- a/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.execopts
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.execopts
@@ -1,1 +1,1 @@
---n=10 --printStats=false
+--n=11 --printStats=false

--- a/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.good
+++ b/test/multilocale/deitz/needMultiLocales/raCommCheckLCG.good
@@ -1,11 +1,11 @@
-Problem size = 1024 (2**10)
-Bytes per array = 8192
-Total memory required (GB) = 7.62939e-06
-Number of updates = 4096
+Problem size = 2048 (2**11)
+Bytes per array = 16384
+Total memory required (GB) = 1.52588e-05
+Number of updates = 8192
 
 Locale: (gets, puts, forks, fast forks, non-blocking forks)
-1: (execute_on = 768, execute_on_nb = 3)
-2: (execute_on = 768)
-3: (execute_on = 768)
-4: (execute_on = 768)
+1: (execute_on = 1536, execute_on_nb = 3)
+2: (execute_on = 1536)
+3: (execute_on = 1536)
+4: (execute_on = 1536)
 Validation: SUCCESS


### PR DESCRIPTION
From time to time, we seem to have bursts of verification failures for this test on some configurations, which don't seem obviously related to code changes we're making.  Our hypothesis is that the problem size is small enough that, as the number of cores (and therefore concurrency), increases on newer systems, the more likely there is to be races that thwart verification.

Here, I'm doubling the problem size, which also doubles the number of updates, but since the hardware parallelism is staying the same, hopefully it will spread the conflicts out far enough that the very occasional failures we're seeing will be much less prominent.

Resolves https://github.com/Cray/chapel-private/issues/7473

(he said optimistically)
