### PR TITLE
Add max wait time for slurm tests

### DIFF
--- a/util/cron/test-hpe-cray-ex-ofi.bash
+++ b/util/cron/test-hpe-cray-ex-ofi.bash
@@ -11,6 +11,9 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="hpe-cray-ex-ofi"
 export CHPL_RT_COMM_OFI_EXPECTED_PROVIDER="cxi"
 export CHPL_RT_MAX_HEAP_SIZE=16g
 export CHPL_LAUNCHER_PARTITION=bardpeak
+# limited nodes, wait no more than 1hr in queue before moving on to next test
+export CHPL_TEST_MAX_QUEUE_TIME=3600
+
 
 
 # test a small subset of all tests due to limited resources

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -1168,7 +1168,7 @@ def main():
     globalTimeout = int(os.getenv("CHPL_TEST_TIMEOUT", defaultTimeout))
 
     # global maxQueueTime, in seconds
-    globallMaxQueueTime = int(os.getenv("CHPL_TEST_MAX_QUEUE_TIME", 0))
+    globalMaxQueueTime = int(os.getenv("CHPL_TEST_MAX_QUEUE_TIME", 0))
 
     # get a threshold for which to report long running tests
     if os.getenv("CHPL_TEST_EXEC_TIME_WARN_LIMIT"):
@@ -2716,7 +2716,7 @@ def main():
                 # lastexecopts really must be last, so add any launcher timeout now
                 if useLauncherTimeout:
                     args += LauncherTimeoutArgs(
-                        timeout, maxQueueTime=globallMaxQueueTime
+                        timeout, maxQueueTime=globalMaxQueueTime
                     )
                 if lastexecopts:
                     args += lastexecopts

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -235,13 +235,21 @@ def SuckOutputWithTimeout(stream, timeout):
     return buffer
 
 
-def LauncherTimeoutArgs(seconds):
+def LauncherTimeoutArgs(seconds, maxQueueTime=0):
     if useLauncherTimeout == "pbs" or useLauncherTimeout == "slurm":
         # --walltime=hh:mm:ss
         m, s = divmod(seconds, 60)
         h, m = divmod(m, 60)
         fmttime = "--walltime={0:02d}:{1:02d}:{2:02d}".format(h, m, s)
-        return [fmttime]
+        args = [fmttime]
+
+        if maxQueueTime >= 0:
+            # deadline is the walltime + max time in queue
+            time = maxQueueTime + seconds
+            fmtdeadline = "--deadline=now+{}seconds".format(time)
+            args.append(fmtdeadline)
+        return args
+
     else:
         Fatal(
             "LauncherTimeoutArgs encountered an unknown format spec: "
@@ -1158,6 +1166,9 @@ def main():
     else:
         defaultTimeout = 300
     globalTimeout = int(os.getenv("CHPL_TEST_TIMEOUT", defaultTimeout))
+
+    # global maxQueueTime, in seconds
+    gloablMaxQueueTime = int(os.getenv("CHPL_TEST_MAX_QUEUE_TIME", 0))
 
     # get a threshold for which to report long running tests
     if os.getenv("CHPL_TEST_EXEC_TIME_WARN_LIMIT"):
@@ -2704,7 +2715,9 @@ def main():
                     args += shlex.split(envExecopts)
                 # lastexecopts really must be last, so add any launcher timeout now
                 if useLauncherTimeout:
-                    args += LauncherTimeoutArgs(timeout)
+                    args += LauncherTimeoutArgs(
+                        timeout, maxQueueTime=gloablMaxQueueTime
+                    )
                 if lastexecopts:
                     args += lastexecopts
                 # sys.stdout.write("args=%s\n"%(args))

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -1168,7 +1168,7 @@ def main():
     globalTimeout = int(os.getenv("CHPL_TEST_TIMEOUT", defaultTimeout))
 
     # global maxQueueTime, in seconds
-    gloablMaxQueueTime = int(os.getenv("CHPL_TEST_MAX_QUEUE_TIME", 0))
+    globallMaxQueueTime = int(os.getenv("CHPL_TEST_MAX_QUEUE_TIME", 0))
 
     # get a threshold for which to report long running tests
     if os.getenv("CHPL_TEST_EXEC_TIME_WARN_LIMIT"):
@@ -2716,7 +2716,7 @@ def main():
                 # lastexecopts really must be last, so add any launcher timeout now
                 if useLauncherTimeout:
                     args += LauncherTimeoutArgs(
-                        timeout, maxQueueTime=gloablMaxQueueTime
+                        timeout, maxQueueTime=globallMaxQueueTime
                     )
                 if lastexecopts:
                     args += lastexecopts

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -243,7 +243,7 @@ def LauncherTimeoutArgs(seconds, maxQueueTime=0):
         fmttime = "--walltime={0:02d}:{1:02d}:{2:02d}".format(h, m, s)
         args = [fmttime]
 
-        if maxQueueTime >= 0:
+        if maxQueueTime > 0:
             # deadline is the walltime + max time in queue
             time = maxQueueTime + seconds
             fmtdeadline = "--deadline=now+{}seconds".format(time)


### PR DESCRIPTION
Adds a new environment variable to set a max time for waiting in a slurm queue before canceling the job

This will hopefully prevent 1 test from waiting for nodes forever and crashing the entire test run

This PR sets a conservative 1 hour max wait time, this may still be too long and should be decreased if needed

[Reviewed by @arifthpe]