### PR TITLE
Fix reading .cls-commands file

### DIFF
--- a/tools/chpl-language-server/src/lsp_util.py
+++ b/tools/chpl-language-server/src/lsp_util.py
@@ -1528,7 +1528,9 @@ class WorkspaceConfig:
 
     def files(self) -> List[str]:
         files = set()
-        for file_cfg in self._files.values():
+        for key, file_cfg in self._files.items():
+            if key == "invocation":
+                continue
             files.update(file_cfg.get("files", []))
         if self.mason:
             files.update(self.mason.get_files())

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -125,7 +125,9 @@ class SourceFilesContext:
                 SourceFilesContext._create_file_at_path(name, contents)
 
     def _build_cls_commands(self, files: typing.Dict[str, str]):
-        commands = {}
+        commands = {
+            "invocation": ["chpl", "--dummy", "--invocation"]
+        }
         allfiles = []
         for name, contents in files.items():
             filepath = os.path.join(self.tempdir.name, name + ".chpl")

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -125,9 +125,7 @@ class SourceFilesContext:
                 SourceFilesContext._create_file_at_path(name, contents)
 
     def _build_cls_commands(self, files: typing.Dict[str, str]):
-        commands = {
-            "invocation": ["chpl", "--dummy", "--invocation"]
-        }
+        commands = {"invocation": ["chpl", "--dummy", "--invocation"]}
         allfiles = []
         for name, contents in files.items():
             filepath = os.path.join(self.tempdir.name, name + ".chpl")


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/chapel-lang/chapel/pull/28672 where the server would crash when trying to resolve all files with a .cls-commands.json file. This was due to a bad expectation of the format of .cls-commands.json files.

I also adjusted some of the tests to catch this sort of error in the future.

[Reviewed by @DanilaFe]