### PR TITLE
dlopen: Fix a bug when code-generating some constant arrays under LLVM

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -61,6 +61,7 @@
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/DiagnosticPrinter.h"
+#include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/LLVMRemarkStreamer.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
@@ -1467,6 +1468,103 @@ static void protectNameFromC(Symbol* sym) {
   //  free(oldName);
 }
 
+#ifdef HAVE_LLVM
+// Returns 'true' if the global was declared but not defined.
+static bool errorIfGlobalDefinedLlvm(const char* name) {
+  auto info = gGenInfo;
+
+  if (auto gGet = info->module->getNamedGlobal(name)) {
+    if (auto gVar = llvm::cast_or_null<llvm::GlobalVariable>(gGet)) {
+      bool isDeclaration = gVar->isDeclaration();
+      bool hasInitializer = gVar->hasInitializer();
+      bool hasExternalLinkage = gVar->getLinkage() ==
+                                llvm::GlobalValue::ExternalLinkage;
+
+      if (!isDeclaration || hasInitializer || !hasExternalLinkage) {
+        // NOTE: No code should be defining this. It is possible for the
+        //       type to mismatch, that is, the first declaration might
+        //       be something like 'name: c_ptr(void)' instead of the proper
+        //       type. This is OK for our purposes because the LVT will
+        //       provide the proper type that we define later.
+        //
+        //       This does mean that uses prior to the definition will be
+        //       manipulated using an "incorrect type", but that is in
+        //       line with C semantics where you can fudge the type a bit.
+        INT_FATAL("Reserved symbol '%s' should not be defined", name);
+      }
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Create a new global with the same name and a new type and replace (all
+// uses of) the old global. In later versions of LLVM there is a method to
+// do this called 'replaceInitializer', but we don't seem to have that yet.
+// I cannot reimplement it 1-to-1 since it uses private/protected state.
+static llvm::GlobalVariable*
+replaceGlobalInitializerLlvm(llvm::GlobalVariable* global,
+                             llvm::Type* type,
+                             llvm::Constant* init) {
+  // Create a new global which is a duplicate of the existing one.
+  auto& mod = *global->getParent();
+  auto linkage = global->getLinkage();
+  auto name = global->getName();
+  auto ret = new llvm::GlobalVariable(mod, type, false, linkage, init, name);
+
+  ret->setAlignment(global->getAlign());
+
+  // Replace the old global with the new one.
+  //
+  // The documentation says that the replacement must have the same type.
+  // I think this code works because the type is an opaque "ptr", due to
+  // both being global variables.
+  global->replaceAllUsesWith(ret);
+  global->eraseFromParent();
+
+  // Re-set the new global's name, since there is now no name conflict.
+  ret->setName(name);
+
+  // If this doesn't hold, we have big (i.e., link-time) problems.
+  INT_ASSERT(ret->getName() == name);
+
+  return ret;
+}
+
+static void
+buildGlobalArrayLlvm(const char* name, llvm::Type* eltType, size_t size,
+                     const std::vector<llvm::Constant*>& entries,
+                     bool isConstant) {
+  auto info = gGenInfo;
+  auto mod = info->module;
+  bool hasEntries = !entries.empty();
+  size_t sizeToUse = hasEntries ? entries.size() : size;
+
+  bool declared = errorIfGlobalDefinedLlvm(name);
+  auto type = llvm::ArrayType::get(eltType, sizeToUse);
+  auto get = mod->getOrInsertGlobal(name, type);
+  auto var = llvm::cast<llvm::GlobalVariable>(get);
+
+  llvm::Constant* init = hasEntries ? llvm::ConstantArray::get(type, entries)
+                                    : llvm::Constant::getNullValue(type);
+
+  if (declared) {
+    var = replaceGlobalInitializerLlvm(var, type, init);
+  } else {
+    var->setInitializer(init);
+  }
+
+  bool isUnsigned = true;
+  info->lvt->addGlobalValue(name, var, GEN_VAL, isUnsigned, dtCVoidPtr);
+
+  if (isConstant) {
+    var->setConstant(true);
+  }
+}
+#endif
+
 static void genGlobalSerializeTable(GenInfo* info) {
   FILE* hdrfile = info->cfile;
   std::vector<CallExpr*> serializeCalls;
@@ -1506,39 +1604,24 @@ static void genGlobalSerializeTable(GenInfo* info) {
     fprintf(hdrfile, "\n};\n");
   } else if (!gCodegenGPU) {
 #ifdef HAVE_LLVM
-    auto global_serializeTableEntryType =
-      getPointerType(info->module->getContext());
+    auto name = "chpl_global_serialize_table";
+    auto eltType = getPointerType(info->module->getContext());
+    bool isConstant = false;
 
-    std::vector<llvm::Constant *> global_serializeTable;
-
+    // Build up the table entries.
+    std::vector<llvm::Constant*> entries;
     for_vector(CallExpr, call, serializeCalls) {
       SymExpr* se = toSymExpr(call->get(1));
       INT_ASSERT(se);
 
-      llvm::Value* ptrCast = info->irBuilder->CreatePointerCast(
-                               info->lvt->getValue(se->symbol()->cname).val,
-                               global_serializeTableEntryType);
+      auto ptrCast = info->irBuilder->CreatePointerCast(
+                             info->lvt->getValue(se->symbol()->cname).val,
+                             eltType);
       trackLLVMValue(ptrCast);
-      global_serializeTable.push_back(llvm::cast<llvm::Constant>(ptrCast));
+      entries.push_back(llvm::cast<llvm::Constant>(ptrCast));
     }
 
-    if(llvm::GlobalVariable *GVar = llvm::cast_or_null<llvm::GlobalVariable>(
-          info->module->getNamedGlobal("chpl_global_serialize_table"))) {
-      GVar->eraseFromParent();
-    }
-
-    llvm::ArrayType *global_serializeTableType =
-      llvm::ArrayType::get(global_serializeTableEntryType,
-                          global_serializeTable.size());
-    llvm::GlobalVariable *global_serializeTableGVar =
-      llvm::cast<llvm::GlobalVariable>(
-          info->module->getOrInsertGlobal("chpl_global_serialize_table",
-                                          global_serializeTableType));
-    global_serializeTableGVar->setInitializer(
-        llvm::ConstantArray::get(
-          global_serializeTableType, global_serializeTable));
-    info->lvt->addGlobalValue("chpl_global_serialize_table",
-                              global_serializeTableGVar, GEN_VAL, true, dtCVoidPtr);
+    buildGlobalArrayLlvm(name, eltType, entries.size(), entries, isConstant);
 #endif
   }
 }
@@ -2063,55 +2146,37 @@ static void codegen_header(std::set<const char*> & cnames,
   flushStatements();
 
   genGlobalInt("chpl_numGlobalsOnHeap", numGlobalsOnHeap, true);
-  int globals_registry_static_size = (numGlobalsOnHeap ? numGlobalsOnHeap : 1);
+  int globalsRegistrySize = (numGlobalsOnHeap ? numGlobalsOnHeap : 1);
+
   if( hdrfile ) {
     fprintf(hdrfile, "\nextern ptr_wide_ptr_t chpl_globals_registry[%d];\n",
-                    globals_registry_static_size);
+                     globalsRegistrySize);
   } else {
 #ifdef HAVE_LLVM
-    llvm::Type* ptr_wide_ptr_t = info->lvt->getType("ptr_wide_ptr_t");
-    INT_ASSERT(ptr_wide_ptr_t);
+    auto name = "chpl_globals_registry";
+    auto eltType = info->lvt->getType("ptr_wide_ptr_t");
+    bool isConstant = false;
 
-    if(llvm::GlobalVariable *GVar = llvm::cast_or_null<llvm::GlobalVariable>(
-          info->module->getNamedGlobal("chpl_globals_registry"))) {
-      GVar->eraseFromParent();
-    }
-    llvm::Type* globValType =
-      llvm::ArrayType::get(ptr_wide_ptr_t, globals_registry_static_size);
-    llvm::GlobalVariable *chpl_globals_registryGVar =
-      llvm::cast<llvm::GlobalVariable>(
-          info->module->getOrInsertGlobal("chpl_globals_registry",
-                                          globValType));
-    chpl_globals_registryGVar->setInitializer(
-        llvm::Constant::getNullValue(globValType));
-    info->lvt->addGlobalValue("chpl_globals_registry",
-                              chpl_globals_registryGVar, GEN_VAL, true, /* chplType= */ nullptr);
+    INT_ASSERT(eltType);
+
+    buildGlobalArrayLlvm(name, eltType, globalsRegistrySize, {}, isConstant);
 #endif
   }
   if( hdrfile ) {
       fprintf(hdrfile, "\nextern const char* chpl_mem_descs[];\n");
     } else {
 #ifdef HAVE_LLVM
-    std::vector<llvm::Constant *> memDescTable;
+    // Build up the values of the array.
+    std::vector<llvm::Constant*> entries;
     forv_Vec(const char*, memDesc, memDescsVec) {
-      memDescTable.push_back(llvm::cast<llvm::GlobalVariable>(
+      entries.push_back(llvm::cast<llvm::GlobalVariable>(
             new_CStringSymbol(memDesc)->codegen().val)->getInitializer());
     }
-    llvm::ArrayType *memDescTableType = llvm::ArrayType::get(
-        getPointerType(info->module->getContext()),
-        memDescTable.size());
 
-    if(llvm::GlobalVariable *GVar =llvm::cast_or_null<llvm::GlobalVariable>(
-          info->module->getNamedGlobal("chpl_mem_descs"))) {
-      GVar->eraseFromParent();
-    }
-
-    llvm::GlobalVariable *chpl_memDescsGVar = llvm::cast<llvm::GlobalVariable>(
-        info->module->getOrInsertGlobal("chpl_mem_descs", memDescTableType));
-    chpl_memDescsGVar->setInitializer(
-        llvm::ConstantArray::get(memDescTableType, memDescTable));
-    chpl_memDescsGVar->setConstant(true);
-    info->lvt->addGlobalValue("chpl_mem_descs", chpl_memDescsGVar, GEN_VAL, true, dtStringC);
+    auto name = "chpl_mem_descs";
+    auto eltType = getPointerType(info->module->getContext());
+    bool isConstant = true;
+    buildGlobalArrayLlvm(name, eltType, entries.size(), entries, isConstant);
 #endif
   }
 
@@ -2124,11 +2189,12 @@ static void codegen_header(std::set<const char*> & cnames,
     fprintf(hdrfile, "\nextern void* const chpl_private_broadcast_table[];\n");
   } else if(!gCodegenGPU) {
 #ifdef HAVE_LLVM
-    auto private_broadcastTableEntryType =
-      getPointerType(info->module->getContext());
+    auto eltType = getPointerType(info->module->getContext());
+    auto name = "chpl_private_broadcast_table";
+    bool isConstant = false;
 
-    std::vector<llvm::Constant *> private_broadcastTable;
-
+    // Build up the table entries.
+    std::vector<llvm::Constant*> entries;
     int broadcastID = 0;
     forv_Vec(CallExpr, call, gCallExprs) {
       if (call->isPrimitive(PRIM_PRIVATE_BROADCAST)) {
@@ -2137,33 +2203,19 @@ static void codegen_header(std::set<const char*> & cnames,
 
         llvm::Value* ptrCast = info->irBuilder->CreatePointerCast(
                                  info->lvt->getValue(se->symbol()->cname).val,
-                                 private_broadcastTableEntryType);
+                                 eltType);
         trackLLVMValue(ptrCast);
-        private_broadcastTable.push_back(llvm::cast<llvm::Constant>(ptrCast));
+        entries.push_back(llvm::cast<llvm::Constant>(ptrCast));
         // To preserve operand order, this should be insertAtTail.
         call->insertAtHead(new_IntSymbol(broadcastID++));
       }
     }
 
-    if(llvm::GlobalVariable *GVar = llvm::cast_or_null<llvm::GlobalVariable>(
-          info->module->getNamedGlobal("chpl_private_broadcast_table"))) {
-      GVar->eraseFromParent();
-    }
+    buildGlobalArrayLlvm(name, eltType, entries.size(), entries, isConstant);
 
-    llvm::ArrayType *private_broadcastTableType =
-      llvm::ArrayType::get(private_broadcastTableEntryType,
-                          private_broadcastTable.size());
-    llvm::GlobalVariable *private_broadcastTableGVar =
-      llvm::cast<llvm::GlobalVariable>(
-          info->module->getOrInsertGlobal("chpl_private_broadcast_table",
-                                          private_broadcastTableType));
-    private_broadcastTableGVar->setInitializer(
-        llvm::ConstantArray::get(
-          private_broadcastTableType, private_broadcastTable));
-    info->lvt->addGlobalValue("chpl_private_broadcast_table",
-                              private_broadcastTableGVar, GEN_VAL, true, dtCVoidPtr);
     genGlobalInt("chpl_private_broadcast_table_len",
-                 private_broadcastTable.size(), false);
+                 entries.size(),
+                 false);
 #endif
   }
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1519,6 +1519,7 @@ replaceGlobalInitializerLlvm(llvm::GlobalVariable* global,
   // Set some more properties...
   ret->setVisibility(global->getVisibility());
   ret->setAlignment(global->getAlign());
+  ret->setDSOLocal(global->isDSOLocal());
 
   // Replace the old global with the new one.
   //
@@ -1539,6 +1540,7 @@ replaceGlobalInitializerLlvm(llvm::GlobalVariable* global,
   return ret;
 }
 
+// If 'entries' is non-empty, use 'entries.size()'. Otherwise use 'size'.
 static void
 buildGlobalArrayLlvm(const char* name, llvm::Type* eltType, size_t size,
                      const std::vector<llvm::Constant*>& entries,
@@ -1561,6 +1563,13 @@ buildGlobalArrayLlvm(const char* name, llvm::Type* eltType, size_t size,
   } else {
     var->setInitializer(init);
   }
+
+  // Either way, track the value. We replaced it or it was just created.
+  trackLLVMValue(var);
+
+  //
+  // TODO: Attach or copy over debugging info?
+  //
 
   bool isUnsigned = true;
   info->lvt->addGlobalValue(name, var, GEN_VAL, isUnsigned, dtCVoidPtr);

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1508,12 +1508,16 @@ static llvm::GlobalVariable*
 replaceGlobalInitializerLlvm(llvm::GlobalVariable* global,
                              llvm::Type* type,
                              llvm::Constant* init) {
+  // Copy the name into a 'std::string' because we will use it later.
+  std::string name = global->getName().str();
+
   // Create a new global which is a duplicate of the existing one.
   auto& mod = *global->getParent();
   auto linkage = global->getLinkage();
-  auto name = global->getName();
   auto ret = new llvm::GlobalVariable(mod, type, false, linkage, init, name);
 
+  // Set some more properties...
+  ret->setVisibility(global->getVisibility());
   ret->setAlignment(global->getAlign());
 
   // Replace the old global with the new one.
@@ -1525,9 +1529,11 @@ replaceGlobalInitializerLlvm(llvm::GlobalVariable* global,
   global->eraseFromParent();
 
   // Re-set the new global's name, since there is now no name conflict.
+  // This call updates the symbol table kept by the module.
   ret->setName(name);
 
-  // If this doesn't hold, we have big (i.e., link-time) problems.
+  // If these don't hold, we have big (i.e., link-time) problems.
+  INT_ASSERT(ret->getLinkage() == llvm::GlobalValue::ExternalLinkage);
   INT_ASSERT(ret->getName() == name);
 
   return ret;


### PR DESCRIPTION
Fix a bug in nighty testing by refactoring how some constant arrays are code-generated. The bug was exposed by #28677.

Future dynamic loading work will need to write the following sort of pattern for some constant arrays that are defined only during codegen:

```chapel
// This is actually a constant array. But this "fudging" of the type is valid.
extern const chpl_globals_registry: c_ptr(void);
extern proc useTheSymbolAddressInC(name: c_ptrConst(c_char), addr: c_ptr(void));
useTheSymbolAddressInC('chpl_globals_registry', chpl_globals_registry);
```
```c
// The actual type of the symbol as it appears in C...
extern void* chpl_globals_registry[];
void useTheSymbolAddressInC(const char* name, void* addr) {
  if (!strcmp(name, "chpl_globals_registry")) {
    void* ptr1 = (void*) chpl_globals_registry;
    void* ptr2 = addr;
    assert(ptr1 == ptr2);
  }
}
```

That is, _Chapel code_ which fetches the array symbol and passes off its address to C. In order for future dynamic loading code to function, it is critical that these "array-like symbols" behave the same in both C code and Chapel code, particularly when being copied around. If the symbol address doesn't appear the same in C as it does in Chapel, then it means something is going wrong with Chapel code generation.

In a previous PR #28677, I achieved compatibility by setting the arrays to be `GEN_VAL` instead of `GEN_PTR` in the "layered value table" (a symbol table) that we maintain over LLVM+Clang symbols.

However, the way the test (introduced in that PR) was written exposed a bug. For the C code portion of the test, I relied on an `extern` block of C code. It turns out that we end up bundling all the extern C code and Chapel code into the same LLVM module.

This is a problem because the Chapel compiler encounters the declaration and uses of the array symbol within the `extern` block _first_ in compilation. The code that _defines_ the array (which in LLVM amounts to setting its initializer using `setInitializer`), does not account for the possibility that it is being used and simply did the following:

```cpp
    if(llvm::GlobalVariable *GVar = llvm::cast_or_null<llvm::GlobalVariable>(
          info->module->getNamedGlobal("chpl_globals_registry"))) {
      GVar->eraseFromParent();
    }
```

Erasing the existing global variable from the LLVM module and dropping all uses of it on the floor. It then built a new global with an identical name.

This bug is _very_ tricky to catch without compiling and using a debug build of LLVM (by setting `CHPL_LLVM_DEVELOPER=1`). In release builds, the LLVM bitcode verifier does not seem to catch the fact that we are dropping the existing global on the floor while uses remain. This is only caught when an assert in the debug build fires.

The fix for this issue is to be a bit more principled:

- Make sure to copy the old global's name into a type that will persist, e.g., `std::string`.
- Create a new, seemingly identical global variable and insert it into the module. Because this is the definition, the global may have a different type (see the code above: the code in Chapel uses `c_ptr(void)` while the code in C uses `void*[]` - in this case the actual type is a fixed length constant array).
- Replace all uses of the old global variable with the new one.
- Then call `eraseFromParent` to remove the old global.
- Finally, set the name of the new global _again_ because any name conflict has been resolved (by default LLVM will append a number to any symbols that name conflict with existing ones, and we must avoid that because this is a global `extern` variable).

Note that it is possible for existing declarations of the symbol to have one type and the definition to have another. This is OK and completely expected. Much like in C, we expect the developer not to shoot themselves in the foot when using this behavior. We do not adjust prior uses of the symbol in LLVM (and this is even more of a non-issue today since LLVM now uses only opaque pointers), so it is "undefined behavior" if the existing type does not make sense (i.e., it is not compatible with a (decayed) array type in C).

While here, refactor the creation of these array constants to call a helper method in order to remove a bunch of redundancy.

A fun bugfix-for-a-bugfix was to make sure to copy the old global's name into a `std::string` so that it would persist after `global->eraseFromParent()` was called. This leak was only exposed on my Mac machine for some reason!

Note that there is also a helper `codegenGlobalConstArray` which performs similar generation - I may well need to adjust its implementation to call the code introduced here, but I'll leave that as future work.

TESTING

- [x] `standard`
- [x] `COMM=gasnet`

Reviewed by @jabraham17. Thanks much!