### PR TITLE
Use explicit modules for all mason sources

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -110,9 +110,9 @@ lint-standard-modules: chplcheck FORCE
 		--disable-rule UnattachedCurly \
 		$(MODULES_TO_LINT)
 
-MASON_MODULES_TO_LINT = $(shell find $(CHPL_MAKE_HOME)/tools/mason -name '*.chpl')
+MASON_MODULES_TO_LINT = $(shell find $(CHPL_MAKE_HOME)/tools/mason -name '*.chpl' -not -path './ThirdParty/*')
 lint-mason: chplcheck FORCE
-	tools/chplcheck/chplcheck $(MASON_MODULES_TO_LINT)
+	tools/chplcheck/chplcheck --enable-rule UseExplicitModules --setting IncorrectIndentation.UnindentedModule=true $(MASON_MODULES_TO_LINT)
 
 mason-deps: FORCE
 	cd tools/mason && $(MAKE) deps

--- a/Makefile.devel
+++ b/Makefile.devel
@@ -110,7 +110,7 @@ lint-standard-modules: chplcheck FORCE
 		--disable-rule UnattachedCurly \
 		$(MODULES_TO_LINT)
 
-MASON_MODULES_TO_LINT = $(shell find $(CHPL_MAKE_HOME)/tools/mason -name '*.chpl' -not -path './ThirdParty/*')
+MASON_MODULES_TO_LINT = $(shell find $(CHPL_MAKE_HOME)/tools/mason -name '*.chpl' -not -path '$(CHPL_MAKE_HOME)/tools/mason/ThirdParty/*')
 lint-mason: chplcheck FORCE
 	tools/chplcheck/chplcheck --enable-rule UseExplicitModules --setting IncorrectIndentation.UnindentedModule=true $(MASON_MODULES_TO_LINT)
 

--- a/tools/mason/Manifest.chpl
+++ b/tools/mason/Manifest.chpl
@@ -23,179 +23,179 @@
   Mason.toml file as a Chapel record, rather than relying on raw TOML reads.
 */
 module Manifest {
-  use List;
-  import IO.format;
+use List;
+import IO.format;
 
-  import MasonUtils;
+import MasonUtils;
 
-  import ThirdParty.TemplateString.templateString;
+import ThirdParty.TemplateString.templateString;
 
-  record manifestFile {
-    // required
-    var name: string;
-    var version: string;
-    var chplVersion: string;
-    var license: string;
-    var pkgType: packageType;
+record manifestFile {
+  // required
+  var name: string;
+  var version: string;
+  var chplVersion: string;
+  var license: string;
+  var pkgType: packageType;
 
-    // TODO: can only have 1 owned class
-    // https://github.com/chapel-lang/chapel/issues/22261
-    var dependencies: list(owned ChapelDependency?);
-    var system: list(owned SystemDependency?);
-    var external: list(owned ExternalDependency?);
+  // TODO: can only have 1 owned class
+  // https://github.com/chapel-lang/chapel/issues/22261
+  var dependencies: list(owned ChapelDependency?);
+  var system: list(owned SystemDependency?);
+  var external: list(owned ExternalDependency?);
 
-    // optional
-    var source: string;
-    var authors: list(string);
-    var copyrightYear: string;
-    var compopts: list(string);
-    var docopts: list(string);
-    var tests: list(test);
-    var examples: list(example);
+  // optional
+  var source: string;
+  var authors: list(string);
+  var copyrightYear: string;
+  var compopts: list(string);
+  var docopts: list(string);
+  var tests: list(test);
+  var examples: list(example);
+}
+
+proc type manifestFile.defaultNewPkg(name: string,
+                                      pkgType = packageType.default) throws {
+  var b = new manifestFile();
+  b.name = name;
+  b.version = "0.1.0";
+  b.chplVersion = MasonUtils.getChapelVersionStr();
+  b.license = "None";
+  b.pkgType = pkgType;
+  return b;
+}
+
+proc manifestFile.toToml(): string throws {
+  const baseToml: templateString = """
+    [brick]
+    name="{{name}}"
+    version="{{version}}"
+    chplVersion="{{chplVersion}}"
+    license="{{license}}"
+    type="{{packageType}}"
+  """.dedent().strip(trailing=false);
+  var s = baseToml(["name"=>this.name,
+                      "version"=>this.version,
+                      "chplVersion"=>this.chplVersion,
+                      "license"=>this.license,
+                      "packageType"=>this.pkgType:string]);
+
+  if source != "" then
+    s += '\nsource = %"S'.format(source);
+  if !authors.isEmpty() {
+    s += "\nauthors = [" +
+      ", ".join(for author in authors do '%"S'.format(author)) + "]";
+  }
+  if copyrightYear != "" then
+    s += '\ncopyrightYear = %"S'.format(copyrightYear);
+  if !compopts.isEmpty() {
+    s += "\ncompopts = [" +
+      ", ".join(for compopt in compopts do '%"S'.format(compopt)) + "]";
+  }
+  if !docopts.isEmpty() {
+    s += "\ndocopts = [" +
+      ", ".join(for docopt in docopts do '%"S'.format(docopt)) + "]";
+  }
+  if !tests.isEmpty() {
+    s += "tests = [" +
+      ", ".join(for test in tests do '%"S'.format(test.toToml())) + "]";
+  }
+  if !examples.isEmpty() {
+    s += "examples = [" +
+      ", ".join(for example in examples do '%"S'.format(example.name)) + "]";
+    s += "\n\n".join(for example in examples do example.toToml());
   }
 
-  proc type manifestFile.defaultNewPkg(name: string,
-                                       pkgType = packageType.default) throws {
-    var b = new manifestFile();
-    b.name = name;
-    b.version = "0.1.0";
-    b.chplVersion = MasonUtils.getChapelVersionStr();
-    b.license = "None";
-    b.pkgType = pkgType;
-    return b;
+  if dependencies.isEmpty() {
+    s += "\n[dependencies]\n";
+  } else {
+    s += "\n[dependencies]\n" +
+      "\n".join(for dep in dependencies do dep!.toToml());
   }
 
-  proc manifestFile.toToml(): string throws {
-    const baseToml: templateString = """
-      [brick]
-      name="{{name}}"
-      version="{{version}}"
-      chplVersion="{{chplVersion}}"
-      license="{{license}}"
-      type="{{packageType}}"
-    """.dedent().strip(trailing=false);
-    var s = baseToml(["name"=>this.name,
-                        "version"=>this.version,
-                        "chplVersion"=>this.chplVersion,
-                        "license"=>this.license,
-                        "packageType"=>this.pkgType:string]);
+  if !system.isEmpty() {
+    s += "\n\n[system]\n" +
+      "\n".join(for dep in system do dep!.toToml());
+  }
+  if !external.isEmpty() {
+    s += "\n\n[external]\n" +
+      "\n".join(for dep in external do dep!.toToml());
+  }
 
-    if source != "" then
-      s += '\nsource = %"S'.format(source);
-    if !authors.isEmpty() {
-      s += "\nauthors = [" +
-        ", ".join(for author in authors do '%"S'.format(author)) + "]";
-    }
-    if copyrightYear != "" then
-      s += '\ncopyrightYear = %"S'.format(copyrightYear);
-    if !compopts.isEmpty() {
-      s += "\ncompopts = [" +
-        ", ".join(for compopt in compopts do '%"S'.format(compopt)) + "]";
-    }
-    if !docopts.isEmpty() {
-      s += "\ndocopts = [" +
-        ", ".join(for docopt in docopts do '%"S'.format(docopt)) + "]";
-    }
-    if !tests.isEmpty() {
-      s += "tests = [" +
-        ", ".join(for test in tests do '%"S'.format(test.toToml())) + "]";
-    }
-    if !examples.isEmpty() {
-      s += "examples = [" +
-        ", ".join(for example in examples do '%"S'.format(example.name)) + "]";
-      s += "\n\n".join(for example in examples do example.toToml());
-    }
+  return s;
+}
 
-    if dependencies.isEmpty() {
-      s += "\n[dependencies]\n";
-    } else {
-      s += "\n[dependencies]\n" +
-        "\n".join(for dep in dependencies do dep!.toToml());
-    }
+enum packageType {
+  application, library, light
+}
+proc type packageType.default do return this.application;
 
-    if !system.isEmpty() {
-      s += "\n\n[system]\n" +
-        "\n".join(for dep in system do dep!.toToml());
-    }
-    if !external.isEmpty() {
-      s += "\n\n[external]\n" +
-        "\n".join(for dep in external do dep!.toToml());
-    }
 
+class Dependency {
+  var name: string;
+  proc toToml(): string throws {
+    return name;
+  }
+}
+class ChapelDependency: Dependency { }
+class MasonDependency : ChapelDependency {
+  var version: string;
+  override proc toToml(): string throws {
+    return '%s = %"S'.format(name, version);
+  }
+}
+class GitDependency: Dependency {
+  var git: string;
+  var branch: string;
+  var rev: string;
+
+  override proc toToml(): string throws {
+    var s = '%s = { git = %"S'.format(name, git);
+    if branch != "" then s += ', branch = %"S'.format(branch);
+    if rev != "" then s += ', rev = %"S'.format(rev);
+    s += " }";
     return s;
   }
+}
+class SystemDependency: Dependency {
+  var version: string;
 
-  enum packageType {
-    application, library, light
+  override proc toToml(): string throws {
+    return '%s = %"S'.format(name, version);
   }
-  proc type packageType.default do return this.application;
+}
+class ExternalDependency: Dependency {
+  var spec: string;
 
+  override proc toToml(): string throws {
+    return '%s = %"S'.format(name, spec);
+  }
+}
 
-  class Dependency {
-    var name: string;
-    proc toToml(): string throws {
-      return name;
-    }
+record test {
+  var name: string;
+  proc toToml(): string throws {
+    return name;
   }
-  class ChapelDependency: Dependency { }
-  class MasonDependency : ChapelDependency {
-    var version: string;
-    override proc toToml(): string throws {
-      return '%s = %"S'.format(name, version);
+}
+record example {
+  var name: string;
+  var compopts: list(string);
+  var execopts: list(string);
+  proc toToml(): string throws {
+    if compopts.isEmpty() && execopts.isEmpty() then
+      return "";
+    var s = "[examples.%s]".format(name);
+    if !compopts.isEmpty() {
+      s += "\ncompopts = [" +
+        ", ".join(for c in compopts do '%"S'.format(c)) + "]";
     }
-  }
-  class GitDependency: Dependency {
-    var git: string;
-    var branch: string;
-    var rev: string;
-
-    override proc toToml(): string throws {
-      var s = '%s = { git = %"S'.format(name, git);
-      if branch != "" then s += ', branch = %"S'.format(branch);
-      if rev != "" then s += ', rev = %"S'.format(rev);
-      s += " }";
-      return s;
+    if !execopts.isEmpty() {
+      s += "\nexecopts = [" +
+        ", ".join(for e in execopts do '%"S'.format(e)) + "]";
     }
+    return s;
   }
-  class SystemDependency: Dependency {
-    var version: string;
-
-    override proc toToml(): string throws {
-      return '%s = %"S'.format(name, version);
-    }
-  }
-  class ExternalDependency: Dependency {
-    var spec: string;
-
-    override proc toToml(): string throws {
-      return '%s = %"S'.format(name, spec);
-    }
-  }
-
-  record test {
-    var name: string;
-    proc toToml(): string throws {
-      return name;
-    }
-  }
-  record example {
-    var name: string;
-    var compopts: list(string);
-    var execopts: list(string);
-    proc toToml(): string throws {
-      if compopts.isEmpty() && execopts.isEmpty() then
-        return "";
-      var s = "[examples.%s]".format(name);
-      if !compopts.isEmpty() {
-        s += "\ncompopts = [" +
-          ", ".join(for c in compopts do '%"S'.format(c)) + "]";
-      }
-      if !execopts.isEmpty() {
-        s += "\nexecopts = [" +
-          ", ".join(for e in execopts do '%"S'.format(e)) + "]";
-      }
-      return s;
-    }
-  }
+}
 
 }

--- a/tools/mason/Mason.chpl
+++ b/tools/mason/Mason.chpl
@@ -157,6 +157,15 @@ proc main(args: [] string) throws {
   } catch ex: MasonError {
     stderr.writeln(ex.message());
     retCode = 1;
+  } catch ex: TaskErrors {
+    for e in ex {
+      if e then
+        stderr.writeln(e!.message());
+    }
+    retCode = 1;
+  } catch ex {
+    stderr.writeln("An unexpected error occurred: " + ex.message());
+    retCode = 1;
   }
   return retCode;
 }

--- a/tools/mason/Mason.chpl
+++ b/tools/mason/Mason.chpl
@@ -51,129 +51,129 @@ $CHPL_HOME/doc/rst/tools/mason/mason.rst
 
 */
 module Mason {
-  use ArgumentParser;
-  use FileSystem;
-  use Map;
-  use MasonBuild;
-  use MasonDoc;
-  use MasonEnv;
-  use MasonExternal;
-  use MasonHelp;
-  use MasonModify;
-  use MasonPublish;
-  use MasonRun;
-  use MasonSearch;
-  use MasonSystem;
-  use MasonTest;
-  use MasonUpdate;
-  use MasonUtils;
-  use MasonModules;
-  import MasonNewInit;
+use ArgumentParser;
+use FileSystem;
+use Map;
+use MasonBuild;
+use MasonDoc;
+use MasonEnv;
+use MasonExternal;
+use MasonHelp;
+use MasonModify;
+use MasonPublish;
+use MasonRun;
+use MasonSearch;
+use MasonSystem;
+use MasonTest;
+use MasonUpdate;
+use MasonUtils;
+use MasonModules;
+import MasonNewInit;
 
-  import MasonLogger;
-  use List;
+import MasonLogger;
+use List;
 
-  proc main(args: [] string) throws {
+proc main(args: [] string) throws {
 
-    var parser = new argumentParser(helpHandler = new MasonHelpHandler());
+  var parser = new argumentParser(helpHandler = new MasonHelpHandler());
 
-    var subCmds = new map(string, shared Argument);
+  var subCmds = new map(string, shared Argument);
 
-    // define all the supported subcommand strings here
-    var cmds = ["add","build","clean","doc","env","external","init","publish",
-                "new","rm","run","search","system","test","update",
-                "help","version","modules"];
-    for cmd in cmds {
-      subCmds.add(cmd,parser.addSubCommand(cmd));
+  // define all the supported subcommand strings here
+  var cmds = ["add","build","clean","doc","env","external","init","publish",
+              "new","rm","run","search","system","test","update",
+              "help","version","modules"];
+  for cmd in cmds {
+    subCmds.add(cmd,parser.addSubCommand(cmd));
+  }
+
+  var versionFlag = parser.addFlag(name="versionFlag",
+                                  opts=["-V","--version"],
+                                  defaultValue=false);
+
+  var colorFlag = parser.addOption(name="color",
+                                  opts=["--color"],
+                                  defaultValue="auto");
+
+  parser.parseArgs(args);
+
+  // TODO: Can printVersion take an exit code?
+  if versionFlag.valueAsBool() {
+    printVersion();
+    return 0;
+  }
+
+  try {
+    MasonLogger.setColorMode(
+      MasonLogger.colorModeFromString(colorFlag.value()));
+  } catch {
+    writeln("Unknown color mode: '", colorFlag.value(), "'. ",
+            "Valid options are 'auto', 'always', and 'never'.");
+    masonHelp();
+    return 1;
+  }
+
+  var usedCmd:string;
+  var cmdList:list(string);
+  // identify which, if any, subcommand was used and collect its arguments
+  for (cmd, arg) in zip(subCmds.keys(), subCmds.values()) {
+    if arg.hasValue() {
+      usedCmd = cmd;
+      cmdList = new list(arg.values());
+      break;
     }
-
-    var versionFlag = parser.addFlag(name="versionFlag",
-                                    opts=["-V","--version"],
-                                    defaultValue=false);
-
-    var colorFlag = parser.addOption(name="color",
-                                    opts=["--color"],
-                                    defaultValue="auto");
-
-    parser.parseArgs(args);
-
-    // TODO: Can printVersion take an exit code?
-    if versionFlag.valueAsBool() {
-      printVersion();
-      return 0;
-    }
-
-    try {
-      MasonLogger.setColorMode(
-        MasonLogger.colorModeFromString(colorFlag.value()));
-    } catch {
-      writeln("Unknown color mode: '", colorFlag.value(), "'. ",
-              "Valid options are 'auto', 'always', and 'never'.");
-      masonHelp();
-      return 1;
-    }
-
-    var usedCmd:string;
-    var cmdList:list(string);
-    // identify which, if any, subcommand was used and collect its arguments
-    for (cmd, arg) in zip(subCmds.keys(), subCmds.values()) {
-      if arg.hasValue() {
-        usedCmd = cmd;
-        cmdList = new list(arg.values());
-        break;
+  }
+  var cmdArgs = cmdList.toArray();
+  var retCode = 0;
+  // pass the arguments to the appropriate subcommand
+  try! {
+    select (usedCmd) {
+      when "add" do masonModify(cmdArgs);
+      when "build" do masonBuild(cmdArgs);
+      when "clean" do masonClean(cmdArgs);
+      when "doc" do masonDoc(cmdArgs);
+      when "env" do masonEnv(cmdArgs);
+      when "external" do masonExternal(cmdArgs);
+      when "help" do masonHelp();
+      when "init" do MasonNewInit.masonInit(cmdArgs);
+      when "new" do MasonNewInit.masonNew(cmdArgs);
+      // when "init" do masonInit(cmdArgs);
+      // when "new" do masonNew(cmdArgs);
+      when "publish" do masonPublish(cmdArgs);
+      when "rm" do masonModify(cmdArgs);
+      when "run" do masonRun(cmdArgs);
+      when "search" do retCode = masonSearch(cmdArgs);
+      when "system" do retCode = masonSystem(cmdArgs);
+      when "test" do masonTest(cmdArgs);
+      when "update" do masonUpdate(cmdArgs);
+      when "modules" do masonModules(cmdArgs);
+      when "version" do printVersion();
+      otherwise {
+        writeln("No subcommand provided");
+        masonHelp();
+        retCode = 1;
       }
     }
-    var cmdArgs = cmdList.toArray();
-    var retCode = 0;
-    // pass the arguments to the appropriate subcommand
-    try! {
-      select (usedCmd) {
-        when "add" do masonModify(cmdArgs);
-        when "build" do masonBuild(cmdArgs);
-        when "clean" do masonClean(cmdArgs);
-        when "doc" do masonDoc(cmdArgs);
-        when "env" do masonEnv(cmdArgs);
-        when "external" do masonExternal(cmdArgs);
-        when "help" do masonHelp();
-        when "init" do MasonNewInit.masonInit(cmdArgs);
-        when "new" do MasonNewInit.masonNew(cmdArgs);
-        // when "init" do masonInit(cmdArgs);
-        // when "new" do masonNew(cmdArgs);
-        when "publish" do masonPublish(cmdArgs);
-        when "rm" do masonModify(cmdArgs);
-        when "run" do masonRun(cmdArgs);
-        when "search" do retCode = masonSearch(cmdArgs);
-        when "system" do retCode = masonSystem(cmdArgs);
-        when "test" do masonTest(cmdArgs);
-        when "update" do masonUpdate(cmdArgs);
-        when "modules" do masonModules(cmdArgs);
-        when "version" do printVersion();
-        otherwise {
-          writeln("No subcommand provided");
-          masonHelp();
-          retCode = 1;
-        }
-      }
-    } catch ex: MasonError {
-      stderr.writeln(ex.message());
-      retCode = 1;
-    }
-    return retCode;
+  } catch ex: MasonError {
+    stderr.writeln(ex.message());
+    retCode = 1;
   }
+  return retCode;
+}
 
 
-  proc masonClean(args) throws {
-    var parser = new argumentParser(helpHandler=new MasonCleanHelpHandler());
+proc masonClean(args) throws {
+  var parser = new argumentParser(helpHandler=new MasonCleanHelpHandler());
 
-    parser.parseArgs(args);
-    const cwd = here.cwd();
+  parser.parseArgs(args);
+  const cwd = here.cwd();
 
-    const projectHome = getProjectHome(cwd);
-    runCommand("rm -rf " + projectHome + "/target");
-  }
+  const projectHome = getProjectHome(cwd);
+  runCommand("rm -rf " + projectHome + "/target");
+}
 
 
-  proc printVersion() {
-    writeln("mason " + MASON_VERSION);
-  }
+proc printVersion() {
+  writeln("mason " + MASON_VERSION);
+}
 }

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+/**/
+module MasonBuild {
+
 import MasonPrereqs;
 
 use ArgumentParser;
@@ -592,4 +595,6 @@ proc invalidateFingerprint(projectName:string, fingerprintDir: string) {
   if isFile(fingerprintFile) {
     FileSystem.remove(fingerprintFile);
   }
+}
+
 }

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -122,9 +122,11 @@ proc buildProgram(release: bool, show: bool, force: bool, skipUpdate: bool,
   if !isFile(lockPath) then
     throw new owned MasonError("Cannot build: no Mason.lock found");
 
-  const toParse = open(lockPath, ioMode.r);
-  defer toParse.close();
-  var lockFile = parseToml(toParse);
+  var lockFile: shared Toml;
+  {
+    const toParse = open(lockPath, ioMode.r);
+    lockFile = parseToml(toParse);
+  }
   const projectName = lockFile["root.name"]!.s;
 
   var binLoc = 'debug';
@@ -278,7 +280,7 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string,
 
 /* Generates a list of tuples that holds the git repo
    url and the name for local mason dependency pool */
-proc genSourceList(lockFile: borrowed Toml) {
+proc genSourceList(lockFile: borrowed Toml) throws {
   var sourceList: list(srcSource);
   var gitList: list(gitSource);
   log.info("Generating source list");
@@ -542,7 +544,7 @@ proc getInterestingEnvVars(): string {
 
 proc computeFingerprint(
   commandLineCompopts: list(string) = new list(string)
-): string {
+): string throws {
   var fingerprint = "";
   fingerprint += "MasonVersion=" + MASON_VERSION + "\n";
   fingerprint += "ChapelVersion=" + getChapelVersionStr() + "\n";
@@ -560,7 +562,7 @@ proc computeFingerprint(
 */
 proc checkFingerprint(projectName:string,
                       fingerprintDir: string,
-                      fingerprint: string): bool {
+                      fingerprint: string): bool throws {
   const fingerprintFile = joinPath(fingerprintDir,
                                    "%s-%s".format(projectName, "fingerprint"));
   if !isFile(fingerprintFile) {
@@ -588,7 +590,7 @@ proc checkFingerprint(projectName:string,
   }
 }
 
-proc invalidateFingerprint(projectName:string, fingerprintDir: string) {
+proc invalidateFingerprint(projectName:string, fingerprintDir: string) throws {
   const fingerprintFile = joinPath(fingerprintDir,
                                    "%s-%s".format(projectName, "fingerprint"));
   log.debugf("Invalidating fingerprint '%s'", fingerprintFile);

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+/**/
+module MasonDoc {
+
 use ArgumentParser;
 use FileSystem;
 use IO;
@@ -116,4 +119,6 @@ proc getTomlDocopts(lock: borrowed Toml): list(string) throws {
   }
 
   return docopts;
+}
+
 }

--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+/**/
+module MasonEnv {
+
 use ArgumentParser;
 use List;
 use MasonUtils;
@@ -205,4 +208,6 @@ private proc getRegNameFromLoc(location: string): string throws {
   } else {
     return strippedLoc[lastSlashPos+1..];
   }
+}
+
 }

--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -41,7 +41,7 @@ proc MASON_HOME : string {
   each name in MASON_REGISTRY.
 */
 @chplcheck.ignore("CamelCaseFunctions")
-proc MASON_CACHED_REGISTRY {
+proc MASON_CACHED_REGISTRY throws {
   const masonRegistry = MASON_REGISTRY;
   const masonHome = MASON_HOME;
   var cachedRegistry: list(string);
@@ -136,7 +136,7 @@ proc MASON_LICENSE_CACHE_PATH: string {
   return licenseCache;
 }
 
-proc masonEnv(args) {
+proc masonEnv(args) throws {
 
   var parser = new argumentParser(helpHandler=new MasonEnvHelpHandler());
 

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -36,6 +36,7 @@ use TOML;
 import MasonLogger;
 import MasonPrereqs;
 import ThirdParty.Pathlib.path;
+use ThirdParty.Pathlib.IOHelpers;
 
 private var log = MasonLogger.getLogger("mason example");
 
@@ -54,7 +55,7 @@ proc runExamples(show: bool, run: bool, build: bool, release: bool,
 
   // Get buildInfo: dependencies, path to src code, compopts,
   // names of examples, example compopts
-  var buildInfo = getBuildInfo(projectHome, skipUpdate, build);
+  var buildInfo = getBuildInfo(projectHome:path, skipUpdate, build);
   const projectName = basename(stripExt(buildInfo.projectPath, ".chpl"));
   //TODO: This build info is weird and only used here, we should
   //      move away from this
@@ -151,16 +152,18 @@ record examplesBuildInfo {
   if build is false, it only computes the example names and the path to the
   project source code. the rest of the information is left blank
 */
-private proc getBuildInfo(projectHome: string,
+private proc getBuildInfo(projectHome: path,
                           skipUpdate: bool,
                           build: bool): examplesBuildInfo throws {
 
-  const toml = open(Path.joinPath(projectHome, "Mason.toml"), ioMode.r);
-  defer toml.close();
-  const tomlFile = parseToml(toml);
+  var tomlFile: shared Toml;
+  {
+    const toml = open(projectHome / "Mason.toml", ioMode.r);
+    tomlFile = parseToml(toml);
+  }
 
   // get the example names from lockfile or from example directory
-  const exampleNames = getExamples(tomlFile.borrow(), projectHome);
+  const exampleNames = getExamples(tomlFile.borrow(), projectHome:string);
 
   var sourceList: list(srcSource);
   var gitList: list(gitSource);
@@ -168,16 +171,18 @@ private proc getBuildInfo(projectHome: string,
   var perExampleOptions = getExampleOptions(tomlFile.borrow(), exampleNames);
 
   const project = tomlFile["brick.name"]!.s;
-  const projectPath = Path.joinPath(projectHome, "src", project + ".chpl");
+  const projectPath = projectHome / "src" / (project + ".chpl");
 
   if build {
-    const lock = open(Path.joinPath(projectHome, "Mason.lock"), ioMode.r);
-    defer lock.close();
-    const lockFile = parseToml(lock);
+    var lockFile: shared Toml;
+    {
+      const lock = open(projectHome / "Mason.lock", ioMode.r);
+      lockFile = parseToml(lock);
+    }
     // Get project source code and dependencies
     (sourceList, gitList) = genSourceList(lockFile);
-    const depPath = Path.joinPath(MASON_HOME, 'src');
-    const gitDepPath = Path.joinPath(MASON_HOME, 'git');
+    const depPath = MASON_HOME:path / 'src';
+    const gitDepPath = MASON_HOME:path / 'git';
 
 
     getSrcCode(sourceList, skipUpdate, false);
@@ -201,14 +206,13 @@ private proc getBuildInfo(projectHome: string,
       const nameVer = "%s-%s".format(name, version);
       // version of -1 specifies a git dep
       if version != "-1" {
-        const depDir = Path.joinPath(depPath, nameVer);
-        const depSrc = Path.replaceExt(Path.joinPath(depDir, "src", name),
-                                        "chpl");
+        const depDir = depPath / nameVer;
+        const depSrc = (depDir / "src" / name).withSuffix(".chpl");
 
         log.debugf("Adding source dependency %s's flags", name);
-        compopts.pushBack(depSrc);
+        compopts.pushBack(depSrc:string);
 
-        for flag in MasonPrereqs.chplFlags(depDir:path) {
+        for flag in MasonPrereqs.chplFlags(depDir) {
           log.debug("+compflag ", flag);
           compopts.pushBack(flag);
         }
@@ -219,11 +223,11 @@ private proc getBuildInfo(projectHome: string,
     // see https://github.com/chapel-lang/chapel/issues/25926
     @chplcheck.ignore("UnusedLoopIndex")
     for (_x, name, branch, _y) in gitSource.iterList(gitList) {
-      const depDir = Path.joinPath(gitDepPath, name + "-" + branch);
-      const gitDepSrc = Path.joinPath(depDir, "src", name + ".chpl");
-      compopts.pushBack(gitDepSrc);
+      const depDir = gitDepPath / (name + "-" + branch);
+      const gitDepSrc = (depDir / "src" / name).withSuffix(".chpl");
+      compopts.pushBack(gitDepSrc:string);
 
-      for flag in MasonPrereqs.chplFlags(depDir:path) {
+      for flag in MasonPrereqs.chplFlags(depDir) {
         log.debug("+compflag ", flag);
         compopts.pushBack(flag);
       }
@@ -244,7 +248,7 @@ private proc getBuildInfo(projectHome: string,
     }
   }
 
-  return new examplesBuildInfo(sourceList, gitList, projectPath,
+  return new examplesBuildInfo(sourceList, gitList, projectPath:string,
                                compopts, exampleNames, perExampleOptions);
 }
 
@@ -277,7 +281,7 @@ private proc getExampleOptions(
 }
 
 // Cleans out example dir from a previous run
-private proc setupExampleDir(projectHome: string) {
+private proc setupExampleDir(projectHome: string) throws {
 
   const exampleDir = joinPath(projectHome, "target/example/");
   if !isDir(exampleDir) {
@@ -286,7 +290,7 @@ private proc setupExampleDir(projectHome: string) {
 }
 
 // prevent building one example from removing all.
-private proc removeExampleBinary(projectHome: string, exampleName: string) {
+private proc removeExampleBinary(projectHome: string, exampleName: string) throws {
 
   const exampleDir = joinPath(projectHome, "target/example/");
   if isDir(exampleDir) {
@@ -342,7 +346,7 @@ private proc runExampleBinary(projectHome: string, exampleName: string,
   const exampleResult = runWithStatus(command.toArray(), capture=false);
 }
 
-private proc getExamples(toml: Toml, projectHome: string) {
+private proc getExamples(toml: Toml, projectHome: string) throws {
   var exampleNames: list(string);
   const examplePath = joinPath(projectHome, "example");
 
@@ -400,7 +404,7 @@ proc printAvailableExamples() throws {
 proc exampleModified(projectHome: string,
                      projectName: string,
                      exampleName: string,
-                     commandLineCompopts: list(string)) {
+                     commandLineCompopts: list(string)) throws {
   const example = basename(stripExt(exampleName, ".chpl"));
   const exampleBinPath = joinPath(projectHome, "target/example", example);
   const examplePath = joinPath(projectHome, "example");

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -282,7 +282,6 @@ private proc getExampleOptions(
 
 // Cleans out example dir from a previous run
 private proc setupExampleDir(projectHome: string) throws {
-
   const exampleDir = joinPath(projectHome, "target/example/");
   if !isDir(exampleDir) {
     makeTargetFiles("debug", projectHome);
@@ -290,8 +289,9 @@ private proc setupExampleDir(projectHome: string) throws {
 }
 
 // prevent building one example from removing all.
-private proc removeExampleBinary(projectHome: string, exampleName: string) throws {
-
+private proc removeExampleBinary(
+  projectHome: string, exampleName: string
+) throws {
   const exampleDir = joinPath(projectHome, "target/example/");
   if isDir(exampleDir) {
     const exampleBinPath = joinPath(exampleDir, exampleName);

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+/**/
+module MasonExample {
 
 use ArgumentParser;
 use FileSystem;
@@ -421,4 +423,6 @@ proc exampleModified(projectHome: string,
       } else
         return true;
   }
+}
+
 }

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -37,14 +37,14 @@ import ThirdParty.Pathlib.path;
 private var log = MasonLogger.getLogger("mason external");
 
 // We could consider bumping this version up as needed.
-const minSpackVersion = new versionInfo('1.0.0');
+const minSpackVersion = new versionInfo(1, 0, 0);
 const major = minSpackVersion.major:string;
 const minor = minSpackVersion.minor:string;
 const spackBranch = 'releases/v' + '.'.join(major, minor);
 const spackDefaultPath = MASON_HOME + "/spack";
 const spackRegistryDefaultPath = MASON_HOME + "/spack-registry";
 
-proc masonExternal(args: [] string) {
+proc masonExternal(args: [] string) throws {
 
   var parser = new argumentParser(helpHandler=new MasonExternalHelpHandler());
 
@@ -267,7 +267,7 @@ private proc updateSpackCommandLine() {
   Replaces package repository path of repos.yaml file at
   /spack/etc/spack/defaults with that of spack-registry
 */
-private proc generateYAML() {
+private proc generateYAML() throws {
   const yamlFilePath = SPACK_ROOT + '/etc/spack/defaults/repos.yaml';
   if isFile(yamlFilePath) {
     remove(yamlFilePath);
@@ -288,7 +288,7 @@ private proc printSpackVersion() {
 }
 
 /* Returns spack version */
-proc getSpackVersion(): versionInfo {
+proc getSpackVersion(): versionInfo throws {
   const command = "spack --version";
   @functionStatic
   ref tmpVersion = getSpackResult(command,true).strip();
@@ -307,7 +307,7 @@ private proc listSpkgs() {
 }
 
 /* Queries spack for package existence */
-private proc searchSpkgs(args: [] string) {
+private proc searchSpkgs(args: [] string) throws {
   var parser = new argumentParser(helpHandler=
                                   new MasonExternalSearchHelpHandler());
 
@@ -343,7 +343,7 @@ private proc listInstalled() {
 
 /* User facing function to show packages installed on
    system. Takes all spack arguments ex. -df <package> */
-private proc findSpkg(args: [] string) {
+private proc findSpkg(args: [] string) throws {
   var parser = new argumentParser(helpHandler=
                                   new MasonExternalFindHelpHandler());
 
@@ -358,7 +358,7 @@ private proc findSpkg(args: [] string) {
 }
 
 /* Entry point into the various info subcommands */
-private proc spkgInfo(args: [] string) {
+private proc spkgInfo(args: [] string) throws {
 
   var parser = new argumentParser(helpHandler=
                                   new MasonExternalInfoHelpHandler());
@@ -391,7 +391,7 @@ private proc printArch() {
 
 
 /* Queries system to see if package is installed on system */
-proc spkgInstalled(spec: string) {
+proc spkgInstalled(spec: string) throws {
   const command = "spack find -df --show-full-compiler " + spec;
   const pkgInfo = getSpackResult(command, quiet=true);
   var found = false;
@@ -406,7 +406,7 @@ proc spkgInstalled(spec: string) {
 
 
 /* Entry point into the various compiler functions */
-private proc compiler(args: [] string) {
+private proc compiler(args: [] string) throws {
 
   var parser = new argumentParser(helpHandler=new MasonCompilerHelpHandler());
 
@@ -501,53 +501,49 @@ proc getSpkgInfo(spec: string, dependencies: list(string)): shared Toml throws {
   var spkgToml: [spkgDom] shared Toml?;
   var spkgInfo = new shared Toml(spkgToml);
 
-  try {
-    const specFields = getSpecFields(spec);
-    var pkgName = specFields[0];
-    var version = specFields[1];
-    var compiler = specFields[2];
+  const specFields = getSpecFields(spec);
+  var pkgName = specFields[0];
+  var version = specFields[1];
+  var compiler = specFields[2];
 
-    // Remove variants from spec
-    var simpleSpec = pkgName + '@' + version + '%' + compiler;
+  // Remove variants from spec
+  var simpleSpec = pkgName + '@' + version + '%' + compiler;
 
-    if spkgInstalled(simpleSpec) {
-      const spkgPath = getSpkgPath(simpleSpec);
-      const libs = joinPath(spkgPath, "lib");
-      const includePath = joinPath(spkgPath, "include");
-      const other = joinPath(spkgPath, "other");
+  if spkgInstalled(simpleSpec) {
+    const spkgPath = getSpkgPath(simpleSpec);
+    const libs = joinPath(spkgPath, "lib");
+    const includePath = joinPath(spkgPath, "include");
+    const other = joinPath(spkgPath, "other");
 
-      if isDir(other) {
-        spkgInfo.set("other", other);
-      }
-      spkgInfo.set("name", pkgName);
-      spkgInfo.set("version", version);
-      spkgInfo.set("compiler", compiler);
-      spkgInfo.set("libs", libs);
-      spkgInfo.set("include", includePath);
-
-      for dep in dependencies {
-        var depSpec = dep.split("@", 1);
-        var name = depSpec[0];
-
-        // put dep into current packages dep list
-        depList.pushBack(new shared Toml(name));
-
-        // get dependencies of dep
-        var depsOfDep = getSpkgDependencies(dep);
-
-        // get a toml that contains the dependency info and put it
-        // in a subtable of the current dependencies table
-        spkgInfo.set(name, getSpkgInfo(dep, depsOfDep));
-      }
-      if depList.size > 0 {
-        // Temporarily use toArray here to avoid supporting list.
-        spkgInfo.set("dependencies", depList.toArray());
-      }
-    } else {
-      throw new MasonError("No package installed by the name of: " + pkgName);
+    if isDir(other) {
+      spkgInfo.set("other", other);
     }
-  } catch e: MasonError {
-    writeln(e.message());
+    spkgInfo.set("name", pkgName);
+    spkgInfo.set("version", version);
+    spkgInfo.set("compiler", compiler);
+    spkgInfo.set("libs", libs);
+    spkgInfo.set("include", includePath);
+
+    for dep in dependencies {
+      var depSpec = dep.split("@", 1);
+      var name = depSpec[0];
+
+      // put dep into current packages dep list
+      depList.pushBack(new shared Toml(name));
+
+      // get dependencies of dep
+      var depsOfDep = getSpkgDependencies(dep);
+
+      // get a toml that contains the dependency info and put it
+      // in a subtable of the current dependencies table
+      spkgInfo.set(name, getSpkgInfo(dep, depsOfDep));
+    }
+    if depList.size > 0 {
+      // Temporarily use toArray here to avoid supporting list.
+      spkgInfo.set("dependencies", depList.toArray());
+    }
+  } else {
+    throw new MasonError("No package installed by the name of: " + pkgName);
   }
   return spkgInfo;
 }

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+/**/
+module MasonExternal {
+
 use ArgumentParser;
 use FileSystem;
 use List;
@@ -680,4 +683,6 @@ proc uninstallSpkg(args: [] string) throws {
   if status != 0 {
     throw new owned MasonError("Package could not be uninstalled");
   }
+}
+
 }

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -20,6 +20,7 @@
 
 
 /* A help module for the mason package manager */
+module MasonHelp {
 
 use ArgumentParser;
 use Help;
@@ -738,4 +739,6 @@ proc masonModulesHelp() {
                                   being used programmatically.
   """.dedent().strip();
   writeln(s);
+}
+
 }

--- a/tools/mason/MasonLogger.chpl
+++ b/tools/mason/MasonLogger.chpl
@@ -18,67 +18,68 @@
  * limitations under the License.
  */
 
+/**/
 module MasonLogger {
-  use ThirdParty.Log;
-  import ThirdParty.TerminalColors.{style, styledText, red, yellow, blue};
+use ThirdParty.Log;
+import ThirdParty.TerminalColors.{style, styledText, red, yellow, blue};
 
-  import Time.dateTime;
-  import IO.format;
+import Time.dateTime;
+import IO.format;
 
-  private var color = ColorMode.AUTO;
-  private var logStream = new shared LogStream();
-  private var logFormat = new shared MasonLogFormat("%NAME%: %m%");
-  private var pad = 0;
+private var color = ColorMode.AUTO;
+private var logStream = new shared LogStream();
+private var logFormat = new shared MasonLogFormat("%NAME%: %m%");
+private var pad = 0;
 
-  proc colorModeFromString(s: string): ColorMode throws {
-    const lower = s.toLower();
-    if lower == "true" || lower == "always" then
-      return ColorMode.ALWAYS;
-    else if lower == "false" || lower == "never" then
-      return ColorMode.NEVER;
-    else if lower == "auto" then
-      return ColorMode.AUTO;
-    else
-      throw new Error("Invalid value: '"+ s +"'");
+proc colorModeFromString(s: string): ColorMode throws {
+  const lower = s.toLower();
+  if lower == "true" || lower == "always" then
+    return ColorMode.ALWAYS;
+  else if lower == "false" || lower == "never" then
+    return ColorMode.NEVER;
+  else if lower == "auto" then
+    return ColorMode.AUTO;
+  else
+    throw new Error("Invalid value: '"+ s +"'");
+}
+
+proc setColorMode(c: ColorMode) {
+  color = c;
+  logFormat.setUseColor(c, logStream);
+}
+
+class MasonLogFormat: LogFormat {
+  proc init(args...) {
+    super.init((...args));
   }
-
-  proc setColorMode(c: ColorMode) {
-    color = c;
-    logFormat.setUseColor(c, logStream);
+  override proc format(
+    timestamp: dateTime, level: LogLevel,
+    moduleName: string, routineName: string, lineNumber: int,
+    loggerName: string, message: string): string {
+    const paddedName = try! ("%<"+pad:string+"s").format(loggerName);
+    return super.format(timestamp, level,
+                        moduleName, routineName, lineNumber,
+                        paddedName, message);
   }
-
-  class MasonLogFormat: LogFormat {
-    proc init(args...) {
-      super.init((...args));
-    }
-    override proc format(
-      timestamp: dateTime, level: LogLevel,
-      moduleName: string, routineName: string, lineNumber: int,
-      loggerName: string, message: string): string {
-      const paddedName = try! ("%<"+pad:string+"s").format(loggerName);
-      return super.format(timestamp, level,
-                          moduleName, routineName, lineNumber,
-                          paddedName, message);
-    }
-    override proc styleForLogName(level: LogLevel): styledText {
-      var s = style().bold();
-      if level == LogLevel.ERROR then
-        s = s.fg(red());
-      else if level == LogLevel.WARNING then
-        s = s.fg(yellow());
-      else if level == LogLevel.DEBUG then
-        s = s.fg(blue());
-      return s;
-    }
+  override proc styleForLogName(level: LogLevel): styledText {
+    var s = style().bold();
+    if level == LogLevel.ERROR then
+      s = s.fg(red());
+    else if level == LogLevel.WARNING then
+      s = s.fg(yellow());
+    else if level == LogLevel.DEBUG then
+      s = s.fg(blue());
+    return s;
   }
+}
 
-  proc getLogger(name: string): logger {
-    pad = max(pad, name.size);
-    return new logger(name,
-                      colorMode=color,
-                      logLevelEnvVar="MASON_LOG_LEVEL",
-                      stream=logStream,
-                      format=logFormat);
-  }
+proc getLogger(name: string): logger {
+  pad = max(pad, name.size);
+  return new logger(name,
+                    colorMode=color,
+                    logLevelEnvVar="MASON_LOG_LEVEL",
+                    stream=logStream,
+                    format=logFormat);
+}
 }
 

--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -241,7 +241,7 @@ private proc masonExternalRemove(toml: shared Toml, toRm: string) throws {
 }
 
 /* Generate the modified Mason.toml */
-proc generateToml(toml: borrowed Toml, tomlPath: string) {
+proc generateToml(toml: borrowed Toml, tomlPath: string) throws {
   const tomlFile = open(tomlPath, ioMode.cw);
   const tomlWriter = tomlFile.writer(locking=false);
   tomlWriter.writeln(toml);

--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+/**/
+module MasonModify {
+
 use ArgumentParser;
 use FileSystem;
 use Map;
@@ -261,4 +264,6 @@ private proc checkDepName(dep: string) throws {
     throw new MasonError("Bad package name '" + dep +
                          "' - only Chapel identifiers are legal package names");
   }
+}
+
 }

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+/**/
+module MasonModules {
 
 use ArgumentParser;
 use FileSystem;
@@ -131,4 +133,6 @@ proc masonModules(args: [] string) throws {
                            "Valid options are 'json' and 'text'.");
     }
   }
+}
+
 }

--- a/tools/mason/MasonNewInit.chpl
+++ b/tools/mason/MasonNewInit.chpl
@@ -18,343 +18,344 @@
  * limitations under the License.
  */
 
+/**/
 module MasonNewInit {
 
-  import IO;
-  import IO.format;
-  import HaltWrappers;
-  import ArgumentParser.{argumentParser, Argument};
-  import List.list;
+import IO;
+import IO.format;
+import HaltWrappers;
+import ArgumentParser.{argumentParser, Argument};
+import List.list;
 
-  import MasonUtils;
-  import MasonUtils.MasonError;
-  import MasonLogger;
-  import MasonHelp.{MasonNewHelpHandler, MasonInitHelpHandler};
-  import Manifest.{manifestFile, packageType};
+import MasonUtils;
+import MasonUtils.MasonError;
+import MasonLogger;
+import MasonHelp.{MasonNewHelpHandler, MasonInitHelpHandler};
+import Manifest.{manifestFile, packageType};
 
-  import ThirdParty.TemplateString.templateString;
-  import ThirdParty.Pathlib.path;
+import ThirdParty.TemplateString.templateString;
+import ThirdParty.Pathlib.path;
 
-  private var log = MasonLogger.getLogger("mason new/init");
+private var log = MasonLogger.getLogger("mason new/init");
 
-  class MasonPackageTemplate {
-    var manifest: manifestFile;
-    var directory: path;
+class MasonPackageTemplate {
+  var manifest: manifestFile;
+  var directory: path;
 
-    proc init(in manifest: manifestFile, directory: path) {
-      this.manifest = manifest;
-      this.directory = directory;
-    }
-
-    /*
-      Run basic checks before creating the project
-    */
-    proc checks(isNew: bool) throws {
-      if !MasonUtils.isIdentifier(manifest.name) {
-        throw new MasonError("Bad package name '" + manifest.name +
-           "' - only Chapel identifiers are legal package names.\n" +
-           "Use '--name <LegalName>' to specify a legal package name.");
-      }
-
-      if isNew && directory.isDir() {
-        throw new MasonError("A directory named '" +
-                              directory:string + "' already exists");
-      }
-
-      if !isNew && !directory.isDir() {
-        throw new  MasonError("Directory does not exist: " + directory:string +
-                              " Did you mean 'mason new' to create a " +
-                              "new project from scratch?");
-      }
-
-      if !isNew {
-        const isLightweight = manifest.pkgType == packageType.light;
-        if (directory / "Mason.toml").isFile() {
-          throw new MasonError(
-            "Mason.toml already exists for current project. " +
-            "Remove or rename the existing manifest file and rerun " +
-            "`mason init` to initialize a new project.");
-        } else if (directory / "src").isDir() && !isLightweight {
-          throw new MasonError(
-            "/src/ directory already exists for current project. " +
-            "Remove or rename the /src/ directory and rerun " +
-            "`mason init` to initialize a new project. " +
-            "Alternatively, run `mason init --light` to add only a " +
-            "manifest file.");
-        }
-      }
-    }
-
-    /*
-      Main project builder
-    */
-    proc makeProject() throws {
-      makeBasicToml();
-      makeSourceFiles();
-      writeln("Created new ", manifest.pkgType, " project: ", manifest.name);
-      if manifest.pkgType != packageType.light {
-        writeln("Tip: To convert existing code to a mason project, " +
-        "move the driver application to the `src/" + manifest.name + ".chpl`" +
-        " file. For adding other source code, using submodules is the " +
-        "recommended approach to avoid namespace collisions.");
-      }
-    }
-    /*
-      Create a git repo and related files (ie gitignore)
-    */
-    proc makeVCS(show: bool) throws {
-      makeGit(show);
-      makeGitignore();
-    }
-
-    proc makeSourceFiles() throws do HaltWrappers.pureVirtualMethodHalt();
-
-    proc makeBasicToml() throws {
-      const s = manifest.toToml();
-      var writer = IO.openWriter((directory / "Mason.toml"):string);
-      writer.write(s);
-    }
-    proc makeSrcDir() throws {
-      (directory / "src").mkdir();
-    }
-    proc makeGit(show: bool) throws {
-      if (directory / ".git").isDir() {
-        throw new MasonError("'" + directory:string +
-                      "' is already a git repository. " +
-                      "Use `--no-vcs` to create a project " +
-                      "without initializing a git repository.");
-      }
-      var cmd: list(string);
-      cmd.pushBack(["git", "init"]);
-      if !show then cmd.pushBack("-q");
-      cmd.pushBack(["-b", "main"]);
-      cmd.pushBack(directory:string);
-      MasonUtils.runCommand(cmd.toArray());
-    }
-    proc makeGitignore() throws {
-      const toIgnore = """
-        target/
-        Mason.lock
-        doc/
-      """.dedent().strip(trailing=false);
-
-      const file = directory / ".gitignore";
-      if file.isFile() {
-        log.warn(".gitignore already exists, " +
-                 "skipping creation of .gitignore file");
-        return;
-      }
-
-      var writer = IO.openWriter(file:string);
-      writer.write(toIgnore);
-    }
-
-  }
-  class MasonApplicationTemplate: MasonPackageTemplate {
-    proc init(in manifest: manifestFile, directory: path) {
-      super.init(manifest, directory);
-    }
-    override proc makeSourceFiles() throws {
-      const srcDir = directory / "src";
-      srcDir.mkdir();
-      const appTemp: templateString = """
-        /* Documentation for {{name}} */
-        module {{name}} {
-          proc main() {
-            writeln("New mason package: {{name}}");
-          }
-        }
-      """.dedent().strip(trailing=false);
-      var s = appTemp(["name"=>manifest.name]);
-      var writer =
-        IO.openWriter((srcDir / "%s.chpl".format(manifest.name)):string);
-      writer.write(s);
-    }
-  }
-  class MasonLibraryTemplate: MasonPackageTemplate {
-    proc init(in manifest: manifestFile, directory: path) {
-      super.init(manifest, directory);
-    }
-
-    override proc makeSourceFiles() throws {
-      const srcDir = directory / "src";
-      srcDir.mkdir();
-      const libTemp: templateString = """
-        /* Documentation for {{name}} */
-        module {{name}} {
-          // Your library here
-        }
-      """.dedent().strip(trailing=false);
-      var s = libTemp(["name"=>manifest.name]);
-      var writer =
-        IO.openWriter((srcDir / "%s.chpl".format(manifest.name)):string);
-      writer.write(s);
-    }
-  }
-  class MasonLightTemplate: MasonPackageTemplate {
-    proc init(in manifest: manifestFile, directory: path) {
-      super.init(manifest, directory);
-    }
-
-    override proc makeSourceFiles() throws {
-      // lightweight packages do not create a src/ directory or main source file
-    }
-
-    @chplcheck.ignore("UnusedFormal")
-    override proc makeVCS(show: bool) throws {
-      // TODO: this warning doesn't seem very useful since the default is always
-      // --vcs
-      // log.warn("Lightweight projects don't create git repositories");
-    }
-  }
-
-
-  private proc getTemplate(in manifest: manifestFile,
-                          directory: path): owned MasonPackageTemplate throws {
-    use packageType;
-    select manifest.pkgType {
-      when application do
-        return new MasonApplicationTemplate(manifest, directory);
-      when library do return new MasonLibraryTemplate(manifest, directory);
-      when light do return new MasonLightTemplate(manifest, directory);
-      otherwise do
-        HaltWrappers.exhaustiveSelectHalt("invalid packageType");
-    }
-  }
-
-  private proc determinePackageType(appFlag, libFlag, lightFlag) throws {
-    var isApplication = appFlag.valueAsBool();
-    var isLibrary = libFlag.valueAsBool();
-    var isLightweight = lightFlag.valueAsBool();
-    if isApplication + isLibrary + isLightweight > 1 then
-      throw new MasonError("A mason package cannot be of multiple types");
-
-    if isApplication then
-      return packageType.application;
-    else if isLibrary then
-      return packageType.library;
-    else if isLightweight then
-      return packageType.light;
-    else
-      return packageType.default;
-
-  }
-
-  private proc determinePackageNameAndPath(
-    isNew: bool,
-    nameOpt: Argument,
-    legalNameOpt: Argument
-  ): (string, path) throws {
-    var name = if nameOpt.hasValue() then nameOpt.value().strip() else "";
-    var directory: path;
-    if isNew && name == "" then
-      throw new MasonError("A package name must be specified");
-    if !isNew && name == "" {
-      directory = (".":path).resolve();
-    } else {
-      directory = name:path;
-    }
-    if legalNameOpt.hasValue() {
-      name = legalNameOpt.value().strip();
-    } else {
-      // reset the name to the basename of the directory
-      const tmp = if !directory.isAbsolute()
-        then (here.cwd() / directory)
-        else directory;
-      name = tmp.name;
-    }
-
-    return (name, directory);
-  }
-
-  private proc addSharedFlags(ref parser) throws {
-    var noVcsFlag = parser.addFlag(name="vcs",
-                                  opts=["--no-vcs"],
-                                  defaultValue=false);
-    var legalNameOpt = parser.addOption(name="legalname",
-                                        opts=["--name"]);
-
-    var showFlag = parser.addFlag(name="show", defaultValue=false);
-    var appFlag = parser.addFlag(name="app", defaultValue=false);
-    var libFlag = parser.addFlag(name="lib", defaultValue=false);
-    var lightFlag = parser.addFlag(name="light", defaultValue=false);
-
-    // TODO
-    // var exampleFlag = parser.addFlag(name="example",
-    //                                   opts=["--no-examples"],
-    //                                   defaultValue=true);
-    // var testFlag = parser.addFlag(name="test",
-    //                               opts=["--no-tests"],
-    //                               defaultValue=true);
-
-    return (noVcsFlag, legalNameOpt, showFlag, appFlag, libFlag, lightFlag);
+  proc init(in manifest: manifestFile, directory: path) {
+    this.manifest = manifest;
+    this.directory = directory;
   }
 
   /*
-    Creates a new library project at a given directory
-      mason new <projectName/directoryName>
+    Run basic checks before creating the project
   */
-  proc masonNew(args: [] string) throws {
-    var parser = new argumentParser(helpHandler=new MasonNewHelpHandler());
-    var projectNameArg = parser.addArgument(name="project name", numArgs=1);
-    var (noVcsFlag,
-         legalNameOpt,
-         showFlag,
-         appFlag,
-         libFlag,
-         lightFlag) = addSharedFlags(parser);
-    parser.parseArgs(args);
+  proc checks(isNew: bool) throws {
+    if !MasonUtils.isIdentifier(manifest.name) {
+      throw new MasonError("Bad package name '" + manifest.name +
+          "' - only Chapel identifiers are legal package names.\n" +
+          "Use '--name <LegalName>' to specify a legal package name.");
+    }
 
-    var show = showFlag.valueAsBool();
-    var noVcs = noVcsFlag.valueAsBool();
+    if isNew && directory.isDir() {
+      throw new MasonError("A directory named '" +
+                            directory:string + "' already exists");
+    }
 
-    var (name, directory) =
-      determinePackageNameAndPath(isNew=true,
-                                  nameOpt=projectNameArg,
-                                  legalNameOpt=legalNameOpt);
+    if !isNew && !directory.isDir() {
+      throw new  MasonError("Directory does not exist: " + directory:string +
+                            " Did you mean 'mason new' to create a " +
+                            "new project from scratch?");
+    }
 
-    var pkgType = determinePackageType(appFlag, libFlag, lightFlag);
-    var newPkgManifest = manifestFile.defaultNewPkg(name, pkgType);
-    var template = getTemplate(newPkgManifest, directory);
-
-    template.checks(isNew=true);
-    directory.mkdir(parents=true);
-    if !noVcs then
-      template.makeVCS(show);
-    template.makeProject();
+    if !isNew {
+      const isLightweight = manifest.pkgType == packageType.light;
+      if (directory / "Mason.toml").isFile() {
+        throw new MasonError(
+          "Mason.toml already exists for current project. " +
+          "Remove or rename the existing manifest file and rerun " +
+          "`mason init` to initialize a new project.");
+      } else if (directory / "src").isDir() && !isLightweight {
+        throw new MasonError(
+          "/src/ directory already exists for current project. " +
+          "Remove or rename the /src/ directory and rerun " +
+          "`mason init` to initialize a new project. " +
+          "Alternatively, run `mason init --light` to add only a " +
+          "manifest file.");
+      }
+    }
   }
 
   /*
-    Initializes a library project in a project directory
-      'mason init <dirName/path>''
-      or 'mason init (inside project directory)''
+    Main project builder
   */
-  proc masonInit(args: [] string) throws {
-    var parser = new argumentParser(helpHandler=new MasonInitHelpHandler());
-    var dirArg = parser.addArgument(name="directory", numArgs=0..1);
-    var (noVcsFlag,
-         legalNameOpt,
-         showFlag,
-         appFlag,
-         libFlag,
-         lightFlag) = addSharedFlags(parser);
-    parser.parseArgs(args);
-
-    var show = showFlag.valueAsBool();
-    var noVcs = noVcsFlag.valueAsBool();
-
-    var (name, directory) =
-      determinePackageNameAndPath(isNew=false,
-                                  nameOpt=dirArg,
-                                  legalNameOpt=legalNameOpt);
-
-    var pkgType = determinePackageType(appFlag, libFlag, lightFlag);
-    var newPkgManifest = manifestFile.defaultNewPkg(name, pkgType);
-    var template = getTemplate(newPkgManifest, directory);
-
-    template.checks(isNew=false);
-    if !noVcs then
-      template.makeVCS(show);
-    template.makeProject();
+  proc makeProject() throws {
+    makeBasicToml();
+    makeSourceFiles();
+    writeln("Created new ", manifest.pkgType, " project: ", manifest.name);
+    if manifest.pkgType != packageType.light {
+      writeln("Tip: To convert existing code to a mason project, " +
+      "move the driver application to the `src/" + manifest.name + ".chpl`" +
+      " file. For adding other source code, using submodules is the " +
+      "recommended approach to avoid namespace collisions.");
+    }
   }
+  /*
+    Create a git repo and related files (ie gitignore)
+  */
+  proc makeVCS(show: bool) throws {
+    makeGit(show);
+    makeGitignore();
+  }
+
+  proc makeSourceFiles() throws do HaltWrappers.pureVirtualMethodHalt();
+
+  proc makeBasicToml() throws {
+    const s = manifest.toToml();
+    var writer = IO.openWriter((directory / "Mason.toml"):string);
+    writer.write(s);
+  }
+  proc makeSrcDir() throws {
+    (directory / "src").mkdir();
+  }
+  proc makeGit(show: bool) throws {
+    if (directory / ".git").isDir() {
+      throw new MasonError("'" + directory:string +
+                    "' is already a git repository. " +
+                    "Use `--no-vcs` to create a project " +
+                    "without initializing a git repository.");
+    }
+    var cmd: list(string);
+    cmd.pushBack(["git", "init"]);
+    if !show then cmd.pushBack("-q");
+    cmd.pushBack(["-b", "main"]);
+    cmd.pushBack(directory:string);
+    MasonUtils.runCommand(cmd.toArray());
+  }
+  proc makeGitignore() throws {
+    const toIgnore = """
+      target/
+      Mason.lock
+      doc/
+    """.dedent().strip(trailing=false);
+
+    const file = directory / ".gitignore";
+    if file.isFile() {
+      log.warn(".gitignore already exists, " +
+                "skipping creation of .gitignore file");
+      return;
+    }
+
+    var writer = IO.openWriter(file:string);
+    writer.write(toIgnore);
+  }
+
+}
+class MasonApplicationTemplate: MasonPackageTemplate {
+  proc init(in manifest: manifestFile, directory: path) {
+    super.init(manifest, directory);
+  }
+  override proc makeSourceFiles() throws {
+    const srcDir = directory / "src";
+    srcDir.mkdir();
+    const appTemp: templateString = """
+      /* Documentation for {{name}} */
+      module {{name}} {
+        proc main() {
+          writeln("New mason package: {{name}}");
+        }
+      }
+    """.dedent().strip(trailing=false);
+    var s = appTemp(["name"=>manifest.name]);
+    var writer =
+      IO.openWriter((srcDir / "%s.chpl".format(manifest.name)):string);
+    writer.write(s);
+  }
+}
+class MasonLibraryTemplate: MasonPackageTemplate {
+  proc init(in manifest: manifestFile, directory: path) {
+    super.init(manifest, directory);
+  }
+
+  override proc makeSourceFiles() throws {
+    const srcDir = directory / "src";
+    srcDir.mkdir();
+    const libTemp: templateString = """
+      /* Documentation for {{name}} */
+      module {{name}} {
+        // Your library here
+      }
+    """.dedent().strip(trailing=false);
+    var s = libTemp(["name"=>manifest.name]);
+    var writer =
+      IO.openWriter((srcDir / "%s.chpl".format(manifest.name)):string);
+    writer.write(s);
+  }
+}
+class MasonLightTemplate: MasonPackageTemplate {
+  proc init(in manifest: manifestFile, directory: path) {
+    super.init(manifest, directory);
+  }
+
+  override proc makeSourceFiles() throws {
+    // lightweight packages do not create a src/ directory or main source file
+  }
+
+  @chplcheck.ignore("UnusedFormal")
+  override proc makeVCS(show: bool) throws {
+    // TODO: this warning doesn't seem very useful since the default is always
+    // --vcs
+    // log.warn("Lightweight projects don't create git repositories");
+  }
+}
+
+
+private proc getTemplate(in manifest: manifestFile,
+                        directory: path): owned MasonPackageTemplate throws {
+  use packageType;
+  select manifest.pkgType {
+    when application do
+      return new MasonApplicationTemplate(manifest, directory);
+    when library do return new MasonLibraryTemplate(manifest, directory);
+    when light do return new MasonLightTemplate(manifest, directory);
+    otherwise do
+      HaltWrappers.exhaustiveSelectHalt("invalid packageType");
+  }
+}
+
+private proc determinePackageType(appFlag, libFlag, lightFlag) throws {
+  var isApplication = appFlag.valueAsBool();
+  var isLibrary = libFlag.valueAsBool();
+  var isLightweight = lightFlag.valueAsBool();
+  if isApplication + isLibrary + isLightweight > 1 then
+    throw new MasonError("A mason package cannot be of multiple types");
+
+  if isApplication then
+    return packageType.application;
+  else if isLibrary then
+    return packageType.library;
+  else if isLightweight then
+    return packageType.light;
+  else
+    return packageType.default;
+
+}
+
+private proc determinePackageNameAndPath(
+  isNew: bool,
+  nameOpt: Argument,
+  legalNameOpt: Argument
+): (string, path) throws {
+  var name = if nameOpt.hasValue() then nameOpt.value().strip() else "";
+  var directory: path;
+  if isNew && name == "" then
+    throw new MasonError("A package name must be specified");
+  if !isNew && name == "" {
+    directory = (".":path).resolve();
+  } else {
+    directory = name:path;
+  }
+  if legalNameOpt.hasValue() {
+    name = legalNameOpt.value().strip();
+  } else {
+    // reset the name to the basename of the directory
+    const tmp = if !directory.isAbsolute()
+      then (here.cwd() / directory)
+      else directory;
+    name = tmp.name;
+  }
+
+  return (name, directory);
+}
+
+private proc addSharedFlags(ref parser) throws {
+  var noVcsFlag = parser.addFlag(name="vcs",
+                                opts=["--no-vcs"],
+                                defaultValue=false);
+  var legalNameOpt = parser.addOption(name="legalname",
+                                      opts=["--name"]);
+
+  var showFlag = parser.addFlag(name="show", defaultValue=false);
+  var appFlag = parser.addFlag(name="app", defaultValue=false);
+  var libFlag = parser.addFlag(name="lib", defaultValue=false);
+  var lightFlag = parser.addFlag(name="light", defaultValue=false);
+
+  // TODO
+  // var exampleFlag = parser.addFlag(name="example",
+  //                                   opts=["--no-examples"],
+  //                                   defaultValue=true);
+  // var testFlag = parser.addFlag(name="test",
+  //                               opts=["--no-tests"],
+  //                               defaultValue=true);
+
+  return (noVcsFlag, legalNameOpt, showFlag, appFlag, libFlag, lightFlag);
+}
+
+/*
+  Creates a new library project at a given directory
+    mason new <projectName/directoryName>
+*/
+proc masonNew(args: [] string) throws {
+  var parser = new argumentParser(helpHandler=new MasonNewHelpHandler());
+  var projectNameArg = parser.addArgument(name="project name", numArgs=1);
+  var (noVcsFlag,
+        legalNameOpt,
+        showFlag,
+        appFlag,
+        libFlag,
+        lightFlag) = addSharedFlags(parser);
+  parser.parseArgs(args);
+
+  var show = showFlag.valueAsBool();
+  var noVcs = noVcsFlag.valueAsBool();
+
+  var (name, directory) =
+    determinePackageNameAndPath(isNew=true,
+                                nameOpt=projectNameArg,
+                                legalNameOpt=legalNameOpt);
+
+  var pkgType = determinePackageType(appFlag, libFlag, lightFlag);
+  var newPkgManifest = manifestFile.defaultNewPkg(name, pkgType);
+  var template = getTemplate(newPkgManifest, directory);
+
+  template.checks(isNew=true);
+  directory.mkdir(parents=true);
+  if !noVcs then
+    template.makeVCS(show);
+  template.makeProject();
+}
+
+/*
+  Initializes a library project in a project directory
+    'mason init <dirName/path>''
+    or 'mason init (inside project directory)''
+*/
+proc masonInit(args: [] string) throws {
+  var parser = new argumentParser(helpHandler=new MasonInitHelpHandler());
+  var dirArg = parser.addArgument(name="directory", numArgs=0..1);
+  var (noVcsFlag,
+        legalNameOpt,
+        showFlag,
+        appFlag,
+        libFlag,
+        lightFlag) = addSharedFlags(parser);
+  parser.parseArgs(args);
+
+  var show = showFlag.valueAsBool();
+  var noVcs = noVcsFlag.valueAsBool();
+
+  var (name, directory) =
+    determinePackageNameAndPath(isNew=false,
+                                nameOpt=dirArg,
+                                legalNameOpt=legalNameOpt);
+
+  var pkgType = determinePackageType(appFlag, libFlag, lightFlag);
+  var newPkgManifest = manifestFile.defaultNewPkg(name, pkgType);
+  var template = getTemplate(newPkgManifest, directory);
+
+  template.checks(isNew=false);
+  if !noVcs then
+    template.makeVCS(show);
+  template.makeProject();
+}
 }

--- a/tools/mason/MasonPrereqs.chpl
+++ b/tools/mason/MasonPrereqs.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+/**/
+module MasonPrereqs {
+
 import FileSystem as FS;
 import List.list;
 import ThirdParty.Pathlib.path;
@@ -106,4 +109,6 @@ iter prereqs(const baseDir = path.cwd()): path {
   } else {
     log.debugf("%s don't exist.", prereqsDir:string);
   }
+}
+
 }

--- a/tools/mason/MasonPrereqs.chpl
+++ b/tools/mason/MasonPrereqs.chpl
@@ -37,11 +37,16 @@ proc install(baseDir: path, p: path) throws {
   log.info("Installing prerequisite ", p:string);
   const oldDir = path.cwd();
   p.chdir();
-  defer oldDir.chdir();
-  // TODO: I would love to use p.pushChdir(), but I don't trust
-  // error handling + context managers enough
-  // TODO check for errors
-  MasonUtils.runCommand(["make", "MASON_PACKAGE_HOME=" + baseDir:string]);
+  try {
+    // TODO: I would love to use p.pushChdir(), but I don't trust
+    // error handling + context managers enough
+    // TODO check for errors
+    MasonUtils.runCommand(["make", "MASON_PACKAGE_HOME=" + baseDir:string]);
+  } catch e {
+    oldDir.chdir();
+    throw e;
+  }
+  oldDir.chdir();
 }
 
 proc install() throws {
@@ -63,23 +68,29 @@ iter chplFlags(const baseDir = path.cwd()) throws {
     var makeOutput: string;
     const oldDir = path.cwd();
     prereq.chdir();
-    defer oldDir.chdir();
-    // TODO: I would love to use prereq.pushChdir(), but I don't trust
-    // error handling + context managers enough
-    makeOutput = MasonUtils.runCommand(cmd).strip();
+    try {
+      // TODO: I would love to use prereq.pushChdir(), but I don't trust
+      // error handling + context managers enough
+      makeOutput = MasonUtils.runCommand(cmd).strip();
 
-    for pFlag in makeOutput.split(" ") {
-      if pFlag.strip() != "" then
-        yield pFlag.strip();
+      for pFlag in makeOutput.split(" ") {
+        if pFlag.strip() != "" then
+          yield pFlag.strip();
+      }
+    } catch e {
+      oldDir.chdir();
+      throw e;
     }
+    oldDir.chdir();
   }
 }
 
 proc dirHasMakefile(dir: path) {
-  return (dir / "Makefile").isFile();
+  // TODO: in pathlib 0.3.0 isFile does not throw
+  return try! (dir / "Makefile").isFile();
 }
 
-iter prereqs(const baseDir = path.cwd()): path {
+iter prereqs(const baseDir = path.cwd()): path throws {
   const prereqsDir = "prereqs";
   const prereqsPath = baseDir / prereqsDir;
 

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -238,8 +238,10 @@ proc publishPackage(username: string,
     mkdir(safeDir);
   }
   defer {
-    // make sure we always cleanup
-    if !isLocal && exists(safeDir) then rmTree(safeDir + '/');
+    try {
+      // make sure we always cleanup
+      if !isLocal && exists(safeDir) then rmTree(safeDir + '/');
+    } catch { }
   }
 
   if !isLocal {
@@ -358,7 +360,7 @@ proc doesGitOriginExist() {
  */
 private proc usernameCheck(username: string) {
   const gitRemote = 'git ls-remote https://github.com/%s/mason-registry';
-  var usernameCheck = runWithStatus(gitRemote.format(username), true);
+  var usernameCheck = runWithStatus(try! gitRemote.format(username), true);
   return usernameCheck;
 }
 
@@ -366,13 +368,13 @@ private proc usernameCheck(username: string) {
  */
 private proc checkIfForkExists(username: string) {
   var getFork = 'git ls-remote https://github.com/%s/mason-registry';
-  var status = runWithStatus(getFork.format(username), false);
+  var status = runWithStatus(try! getFork.format(username), false);
   return status;
 }
 
 /* Gets the GitHub username of the user, by parsing from the remote origin url.
  */
-private proc getUsername(dir: string) {
+private proc getUsername(dir: string) throws {
   var usernameUrl = gitUrl(dir);
   var username: string;
   if usernameUrl.startsWith("http") {
@@ -388,7 +390,7 @@ private proc getUsername(dir: string) {
 }
 
 
-private proc getRemoteName(dir: string) {
+private proc getRemoteName(dir: string) throws {
   var url = gitUrl(dir).strip();
   var head = url.rfind("/") + 1;
   var remoteName = url(head..);
@@ -514,7 +516,7 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string,
  */
 proc check(p: string, ci: bool) throws {
   const spacer = '------------------------------------------------------';
-  const package = (ensureMasonProject(here.cwd(), 'Mason.toml') == 'true');
+  const package = ensureMasonProject(here.cwd(), 'Mason.toml');
   const projectCheckHome = here.cwd();
   var packageTest = true;
   var moduleTest = true;
@@ -831,7 +833,7 @@ private proc registryPathCheck(p: string,
 }
 
 /* Grabs the remote origin of the package */
-private proc getRemoteOrigin() {
+private proc getRemoteOrigin() throws {
   const packageDir = here.cwd();
   const gitRemoteOrigin =
     gitC(packageDir, 'git config --get remote.origin.url', true);
@@ -842,16 +844,13 @@ private proc getRemoteOrigin() {
   Makes sure that the directory `mason publish --check`
   is called in is a mason package
 */
-private proc ensureMasonProject(cwd : string, tomlName="Mason.toml") : string {
-  const (dirname, basename) = splitPath(cwd);
-  if dirname == '/' {
-    return 'false';
+private proc ensureMasonProject(cwd: string, tomlName="Mason.toml"): bool {
+  try {
+    getProjectHome(cwd, tomlName);
+  } catch {
+    return false;
   }
-  const tomlFile = joinPath(cwd, tomlName);
-  if exists(tomlFile) {
-    return 'true';
-  }
-  return ensureMasonProject(dirname, tomlName);
+  return true;
 }
 
 /*
@@ -878,7 +877,7 @@ private proc moduleCheck(projectHome : string) throws {
 }
 
 /* Checks package for examples */
-proc exampleCheck(projectHome: string) {
+proc exampleCheck(projectHome: string) throws {
   if isDir(projectHome + '/example') {
     const examples = listDir(projectHome + '/example');
     return examples.size > 0;
@@ -886,19 +885,19 @@ proc exampleCheck(projectHome: string) {
 }
 
 /* Checks package for tests */
-proc testCheck(projectHome: string) {
+proc testCheck(projectHome: string) throws {
   if isDir(projectHome + '/test') {
     const tests = listDir(projectHome + '/test');
     return tests.size > 0;
   } else return false;
 }
 /* Returns the mason env */
-private proc returnMasonEnv() {
+private proc returnMasonEnv() throws {
   const fakeArgs = ['env'];
   masonEnv(fakeArgs);
 }
 
-private proc falseIfRemotePath() {
+private proc falseIfRemotePath() throws {
   var registryInEnv = MASON_REGISTRY;
   for (_, registry) in registryInEnv {
     if registry.find(':') != -1 {
@@ -953,7 +952,7 @@ record tomlCheckResult {
 
   Returns (isValid, missingFields, mismatchedTypes)
 */
-proc masonTomlFileCheck(projectHome: string): tomlCheckResult {
+proc masonTomlFileCheck(projectHome: string): tomlCheckResult throws {
   const toParse = open(joinPath(projectHome, "Mason.toml"), ioMode.r);
   const tomlFile = parseToml(toParse);
   var missingFields: list(string);

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+/**/
+module MasonPublish {
 
 use ArgumentParser;
 use FileSystem;
@@ -973,4 +975,6 @@ proc masonTomlFileCheck(projectHome: string): tomlCheckResult {
       mismatchedTypes.pushBack(field);
   }
   return new tomlCheckResult(missingFields, mismatchedTypes);
+}
+
 }

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+/**/
+module MasonRun {
+
 use ArgumentParser;
 use FileSystem;
 use List;
@@ -194,4 +197,6 @@ private proc masonBuildRun(args: [] string) throws {
     for val in passArgs.values() do execopts.pushBack(val);
     runProjectBinary(show, release, execopts, nLocales=1);
   }
+}
+
 }

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+/**/
+module MasonSearch {
+
 use ArgumentParser;
 use FileSystem;
 use IO;
@@ -99,3 +102,4 @@ proc masonSearch(args: [] string): int throws {
   return if pkgs.size == 0 then 1 else 0;
 }
 
+}

--- a/tools/mason/MasonSystem.chpl
+++ b/tools/mason/MasonSystem.chpl
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+/**/
+module MasonSystem {
 
 use ArgumentParser;
 use List;
@@ -223,4 +225,6 @@ proc getPCDeps(exDeps: Toml) throws {
     exDepTree[name] = pkgInfo;
   }
   return exDepTree;
+}
+
 }

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -336,7 +336,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, filter: string,
 
       proc compile(test: string,
                    ref result: TestResult,
-                   ref testsCompiled: list(?)): (string, bool) {
+                   ref testsCompiled: list(?)): (string, bool) throws {
         var testPath: string;
         if isAbsPath(test) {
           testPath = test;
@@ -373,7 +373,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, filter: string,
         const success = compilation == 0;
 
         if !success {
-          stderr.writeln("compilation failed for " + test);
+          try! stderr.writeln("compilation failed for " + test);
           var errMsg = test + " failed to compile";
           if !show then
             errMsg += "\nTry running 'mason test --show' for more details";
@@ -426,7 +426,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, filter: string,
 
 
 private proc runTestBinary(outputLoc: string, testName: string, filter: string,
-                           ref result, show: bool) {
+                           ref result, show: bool) throws {
   const command = outputLoc;
   var testNames: list(string),
       failedTestNames: list(string),
@@ -454,7 +454,7 @@ private proc runTestBinary(outputLoc: string, testName: string, filter: string,
 
 
 private proc runTestBinaries(projectHome: string, testNames: list(string),
-                             filter: string, ref result, show: bool) {
+                             filter: string, ref result, show: bool) throws {
 
   const cwd = here.cwd();
   for test in testNames {
@@ -479,7 +479,7 @@ private proc printTestResults(ref result, timeElapsed) {
 }
 
 
-private proc getTests(lock: borrowed Toml, projectHome: string) {
+private proc getTests(lock: borrowed Toml, projectHome: string) throws {
   var testNames: list(string);
   const testPath = joinPath(projectHome, "test");
 

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+/**/
+module MasonTest {
 
 use ArgumentParser;
 use FileSystem;
@@ -831,4 +833,6 @@ proc addTestResult(ref result, ref localesCountMap, ref testNames,
       testNames.pushBack(testName);
     }
   }
+}
+
 }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+/**/
+module MasonUpdate {
+
 use FileSystem;
 use List;
 use Map;
@@ -615,4 +618,6 @@ private proc pullGitDeps(gitDeps, show=false) {
     }
   }
   return gitDepsWithRevision;
+}
+
 }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -154,7 +154,7 @@ proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock",
 
 
 /* Writes out the lock file */
-proc genLock(lock: borrowed Toml, lf: string) {
+proc genLock(lock: borrowed Toml, lf: string) throws {
   const lockFile = open(lf, ioMode.cw);
   const tomlWriter = lockFile.writer(locking=false);
   tomlWriter.writeln(lock);
@@ -162,7 +162,7 @@ proc genLock(lock: borrowed Toml, lf: string) {
   lockFile.close();
 }
 
-proc checkRegistryChanged() {
+proc checkRegistryChanged() throws {
   for ((_, registry), cached) in zip(MASON_REGISTRY, MASON_CACHED_REGISTRY) {
     if !isDir(cached) {
       return;
@@ -178,7 +178,7 @@ proc checkRegistryChanged() {
       writeln();
       writeln("Removing cached registry and sources to avoid conflicts");
 
-      proc tryRemove(name : string) {
+      proc tryRemove(name : string) throws {
         if isDir(name) {
           writeln("Removing ", name);
           rmTree(name);
@@ -217,7 +217,7 @@ proc updateRegistry(skipUpdate: bool, show=true) throws {
   }
 }
 
-proc verifyChapelVersion(brick:borrowed Toml) {
+proc verifyChapelVersion(brick:borrowed Toml) throws {
   const tupInfo = getChapelVersionInfo();
   const current = new versionInfo(tupInfo(0), tupInfo(1), tupInfo(2));
 
@@ -236,7 +236,7 @@ proc prettyVersionRange(low, hi) {
     return low.str() + ".." + hi.str();
 }
 
-proc chplVersionError(brick:borrowed Toml) {
+proc chplVersionError(brick:borrowed Toml) throws {
   const info = verifyChapelVersion(brick);
   if !info(0) {
     const low  = info(1);
@@ -378,7 +378,7 @@ private proc createDepTrees(depTree: Toml,
   return depTree;
 }
 
-private proc addGitDeps(depTree: Toml, ref gitDeps) {
+private proc addGitDeps(depTree: Toml, ref gitDeps) throws {
   //val url branch revision
   for key in gitDeps {
     if !depTree.pathExists(key[0]) {
@@ -405,7 +405,7 @@ private proc addGitDeps(depTree: Toml, ref gitDeps) {
    - differing major versions are not allowed
    - Always newest minor and patch
    - in accordance with semantic versioning  */
-private proc IVRS(A: borrowed Toml, B: borrowed Toml) {
+private proc IVRS(A: borrowed Toml, B: borrowed Toml) throws {
   const name = A["name"]!.s;
   const (okA, Alo, Ahi) = verifyChapelVersion(A);
   const (okB, Blo, Bhi) = verifyChapelVersion(B);
@@ -487,7 +487,9 @@ private proc retrieveDep(name: string, version: string) throws {
 }
 
 /* Returns the Mason.toml for each dep listed as a Toml */
-private proc getGitManifests(deps: list((string, string, string, string))) {
+private proc getGitManifests(
+  deps: list((string, string, string, string))
+) throws {
   var manifests: list(shared Toml);
   for dep in deps {
     var toAdd = retrieveGitDep(dep(0), dep(2));
@@ -498,7 +500,7 @@ private proc getGitManifests(deps: list((string, string, string, string))) {
 
 /* Responsible for parsing the Mason.toml that have been
    already pulled down from git dependencies */
-private proc retrieveGitDep(name: string, branch: string) {
+private proc retrieveGitDep(name: string, branch: string) throws {
   var baseDir = MASON_HOME +'/git/';
   const tomlPath = baseDir + "/"+name+"-"+branch+"/Mason.toml";
   if isFile(tomlPath) {
@@ -514,7 +516,7 @@ private proc retrieveGitDep(name: string, branch: string) {
 
 /* Checks if a dependency has deps; if so, the
    dependencies are returned as a (string, Toml) */
-private proc getDependencies(tomlTbl: Toml) {
+private proc getDependencies(tomlTbl: Toml) throws {
   var depsD: domain(1);
   var deps: list((string, shared Toml?));
   for k in tomlTbl.A.keys() {
@@ -527,7 +529,7 @@ private proc getDependencies(tomlTbl: Toml) {
   return deps;
 }
 
-private proc getGitDeps(tomlTbl: Toml) {
+private proc getGitDeps(tomlTbl: Toml) throws {
   var gitDeps: list((string, string, shared Toml?));
   const dependencies = tomlTbl["dependencies"]!;
   for k in dependencies.A.keys() {
@@ -539,7 +541,7 @@ private proc getGitDeps(tomlTbl: Toml) {
   return gitDeps;
 }
 
-private proc pullGitDeps(gitDeps, show=false) {
+private proc pullGitDeps(gitDeps, show=false) throws {
   if !isDir(MASON_HOME + '/git/') {
     mkdir(MASON_HOME + '/git/', parents=true);
   }

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -21,6 +21,9 @@
 
 
 /* A helper file of utilities for Mason */
+/**/
+module MasonUtils {
+
 private use CTypes;
 private use ChplConfig;
 public use FileSystem;
@@ -997,4 +1000,6 @@ record chplOptions {
 @chplcheck.ignore("CamelCaseFunctions")
 proc MASON_VERSION : string {
   return "0.2.0";
+}
+
 }

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -867,7 +867,9 @@ proc findLatest(packageDir: string): versionInfo throws {
 
 /* Reads the Chapel version specified by a mason project's
    TOML file and returns the min and max compatible versions */
-proc parseChplVersion(brick: borrowed Toml?): (versionInfo, versionInfo) throws {
+proc parseChplVersion(
+  brick: borrowed Toml?
+): (versionInfo, versionInfo) throws {
   use Regex;
 
   if brick == nil {

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -27,6 +27,7 @@ module MasonUtils {
 private use CTypes;
 private use ChplConfig;
 public use FileSystem;
+import FileSystem;
 private use List;
 private use Map;
 public use Subprocess;
@@ -45,7 +46,7 @@ proc getEnv(name: string): string {
   extern proc getenv(name : c_ptrConst(c_char)) : c_ptrConst(c_char);
   var cname = name.c_str();
   var value = getenv(cname);
-  return string.createCopyingBuffer(value);
+  return try! string.createCopyingBuffer(value);
 }
 
 
@@ -61,7 +62,7 @@ class MasonError : Error {
 
 
 /* Creates the rest of the project structure */
-proc makeTargetFiles(binLoc: string, projectHome: string) {
+proc makeTargetFiles(binLoc: string, projectHome: string) throws {
 
   const target = joinPath(projectHome, 'target');
   const srcBin = joinPath(target, binLoc);
@@ -79,7 +80,10 @@ proc makeTargetFiles(binLoc: string, projectHome: string) {
 
   const actualTest = joinPath(projectHome,'test');
   if isDir(actualTest) {
-    for dir in walkDirs(actualTest) {
+    // temp var to work around
+    // https://github.com/chapel-lang/chapel/issues/27855
+    const dirs = walkDirs(actualTest);
+    for dir in dirs {
       const internalDir = target+dir.replace(projectHome,"");
       if !isDir(internalDir) {
         mkdir(internalDir);
@@ -265,7 +269,7 @@ proc getSpackResult(cmd, quiet=false) : string throws {
     process.wait();
   } catch e {
     log.debugf("Caught unknown error ('%?') for command: %?", e, splitCmd);
-    throw new owned MasonError("Internal mason error");
+    throw new MasonError("Internal mason error");
   }
   return ret;
 }
@@ -280,24 +284,28 @@ proc runSpackCommand(command, quiet=false) {
     " && export PATH=\"$SPACK_ROOT/bin:$PATH\"" +
     " && . $SPACK_ROOT/share/spack/setup-env.sh && ";
 
-  var cmd = (prefix + command);
-  var sub = spawnshell(cmd, stdout=pipeStyle.pipe,
-                            stderr=pipeStyle.pipe, executable="bash");
+  try {
+    var cmd = (prefix + command);
+    var sub = spawnshell(cmd, stdout=pipeStyle.pipe,
+                              stderr=pipeStyle.pipe, executable="bash");
 
-  // quiet flag necessary for tests to be portable
-  if !quiet {
-    var line:string;
-    while sub.stdout.readLine(line) {
+    // quiet flag necessary for tests to be portable
+    if !quiet {
+      var line:string;
+      while sub.stdout.readLine(line) {
+        write(line);
+      }
+    }
+    sub.wait();
+
+    for line in sub.stderr.lines() {
       write(line);
     }
-  }
-  sub.wait();
 
-  for line in sub.stderr.lines() {
-    write(line);
+    return sub.exitCode;
+  } catch {
+    return -1;
   }
-
-  return sub.exitCode;
 }
 
 // TODO: Can we get away with the Chapel Version object instead?
@@ -322,7 +330,8 @@ record versionInfo {
     this.bug   = bug;
   }
 
-  proc init(str: string) {
+  proc init(str: string) throws {
+    init this;
     const s: [1..3] string = str.split(".");
     assert(s.size == 3);
 
@@ -453,21 +462,27 @@ proc getChapelVersionStr() throws {
 }
 
 // TODO: only exists because I don't want to rewrite everything to use path, yet
-proc gitC(newDir:string, command, quiet=false) throws {
+proc gitC(newDir:string, command, quiet=false): string throws {
   return gitC(newDir:path, command, quiet);
 }
-proc gitC(newDir:path, command, quiet=false) throws {
+proc gitC(newDir:path, command, quiet=false): string throws {
   const oldDir = path.cwd();
   newDir.chdir();
-  defer oldDir.chdir();
-  // TODO: I would love to use newDir.pushChdir(), but I don't trust
-  // error handling + context managers enough
-  var ret = runCommand(command, quiet=quiet);
+  var ret: string;
+  try {
+    // TODO: I would love to use newDir.pushChdir(), but I don't trust
+    // error handling + context managers enough
+    ret = runCommand(command, quiet=quiet);
+  } catch e {
+    oldDir.chdir();
+    throw e;
+  }
+  oldDir.chdir();
 
   return ret;
 }
 
-proc getProjectHome(cwd: string, tomlName="Mason.toml") : string throws {
+proc getProjectHome(cwd: string, tomlName="Mason.toml"): string throws {
   var dir = cwd:path;
   while true {
     if (dir/tomlName).exists() then
@@ -498,7 +513,12 @@ proc projectModified(projectHome, projectName, binLocation) : bool {
   const binaryPath = joinPath(projectHome, "target", binLocation, projectName);
   const tomlPath = joinPath(projectHome, "Mason.toml");
 
-  if isFile(binaryPath) {
+  var isFile = false;
+  try {
+    isFile = FileSystem.isFile(binaryPath);
+  } catch { }
+
+  if isFile {
     const binModTime = getLastModified(binaryPath);
     for file in findFiles(joinPath(projectHome, "src"), recursive=true) {
       var srcPath = joinPath(projectHome, "src", file);
@@ -594,8 +614,8 @@ proc getMasonDependencies(sourceList: list(srcSource),
     // see https://github.com/chapel-lang/chapel/issues/25926
     @chplcheck.ignore("UnusedLoopIndex")
     for (_x, name, version) in srcSource.iterList(sourceList) {
-      const depSrc = joinPath(depPath, "%s-%s".format(name, version),
-                              "src", "%s.chpl".format(name));
+      const depSrc = joinPath(depPath, try! "%s-%s".format(name, version),
+                              "src", name + ".chpl");
       masonCompopts.pushBack(depSrc);
     }
   }
@@ -607,8 +627,8 @@ proc getMasonDependencies(sourceList: list(srcSource),
     // see https://github.com/chapel-lang/chapel/issues/25926
     @chplcheck.ignore("UnusedLoopIndex")
     for (_x, name, branch, _y) in gitSource.iterList(gitList) {
-      const gitDepSrc = joinPath(gitDepPath, "%s-%s".format(name, branch),
-                                 "src", "%s.chpl".format(name));
+      const gitDepSrc = joinPath(gitDepPath, try! "%s-%s".format(name, branch),
+                                 "src", name + ".chpl");
       masonCompopts.pushBack(gitDepSrc);
     }
   }
@@ -617,7 +637,7 @@ proc getMasonDependencies(sourceList: list(srcSource),
 
 /* Checks to see if dependency has already been
    downloaded previously */
-proc depExists(dependency: string, repo='/src/') {
+proc depExists(dependency: string, repo='/src/') throws {
   var repos = MASON_HOME + repo;
   var exists = false;
   if !isDir(repos) then
@@ -813,7 +833,7 @@ proc getDepToml(depName: string, depVersion: string) throws {
 
 /* Search TOML files within a package directory to find the latest package
    version number that is supported with current Chapel version */
-proc findLatest(packageDir: string): versionInfo {
+proc findLatest(packageDir: string): versionInfo throws {
   use Path;
 
   var ret = versionInfo.zero();
@@ -847,7 +867,7 @@ proc findLatest(packageDir: string): versionInfo {
 
 /* Reads the Chapel version specified by a mason project's
    TOML file and returns the min and max compatible versions */
-proc parseChplVersion(brick: borrowed Toml?): (versionInfo, versionInfo) {
+proc parseChplVersion(brick: borrowed Toml?): (versionInfo, versionInfo) throws {
   use Regex;
 
   if brick == nil {
@@ -940,35 +960,40 @@ proc checkChplVersion(chplVersion) throws {
 }
 
 /* Print a TOML file. Expects full path. */
-proc showToml(tomlFile : string) {
+proc showToml(tomlFile: string) throws {
   const openFile = openReader(tomlFile, locking=false);
   const toml = parseToml(openFile);
   writeln(toml);
-  openFile.close();
 }
 
 /* Iterator to collect fields from a toml
    TODO custom fields returned */
 iter allFields(tomlTbl: Toml) {
   for (k,v) in zip(tomlTbl.A.keys(), tomlTbl.A.values()) {
-    if v!.tag == fieldtag.fieldToml then
-      continue;
-    else yield(k,v);
+    try {
+      if v!.tag == fieldtag.fieldToml then
+        continue;
+      else yield(k,v);
+    } catch { }
   }
 }
 
-proc isStringOrStringArray(toml: Toml) : bool {
-  if toml.tomlType == "string" {
-    return true;
-  } else if toml.tomlType == "array" {
-    const tomlArr = toml.arr;
-    for f in tomlArr {
-      if f == nil || f!.tomlType != "string" {
-        return false;
+proc isStringOrStringArray(toml: Toml): bool {
+  try {
+    if toml.tomlType == "string" {
+      return true;
+    } else if toml.tomlType == "array" {
+      const tomlArr = toml.arr;
+      for f in tomlArr {
+        if f == nil || f!.tomlType != "string" {
+          return false;
+        }
       }
+      return true;
+    } else {
+      return false;
     }
-    return true;
-  } else {
+  } catch {
     return false;
   }
 }

--- a/tools/mason/SpecParser.chpl
+++ b/tools/mason/SpecParser.chpl
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+/**/
+module SpecParser {
 
 private use List;
 use MasonUtils;
@@ -156,4 +158,6 @@ private proc parseSpec(ref tokenList: list(string)): 4*string throws {
   }
   return (package, packageVersion, compiler,
           " ".join(variants.these()).strip());
+}
+
 }

--- a/tools/mason/SpecParser.chpl
+++ b/tools/mason/SpecParser.chpl
@@ -53,20 +53,16 @@ config const debugSpecParser=false;
   Chapel for version ranges. They use ':' as a
   separator instead of '..'
  */
-proc getSpecFields(spec: string) {
+proc getSpecFields(spec: string) throws {
   var specFields: 4*string;
-  try! {
-    var tokenList = readSpec(spec);
-    const specInfo = parseSpec(tokenList);
-    var compiler = specInfo[2];
-    if compiler.size < 1 {
-      compiler = inferCompiler();
-    }
-    specFields = (specInfo[0], specInfo[1], compiler,
-                  specInfo[3]);
-  } catch e: MasonError {
-    stderr.writeln(e.message());
+  var tokenList = readSpec(spec);
+  const specInfo = parseSpec(tokenList);
+  var compiler = specInfo[2];
+  if compiler.size < 1 {
+    compiler = inferCompiler();
   }
+  specFields = (specInfo[0], specInfo[1], compiler,
+                specInfo[3]);
   return specFields;
 }
 
@@ -82,7 +78,7 @@ private proc inferCompiler() throws {
 
 
 /* Tokenize spec into list of tokens */
-private proc readSpec(spec: string): list(string) {
+private proc readSpec(spec: string): list(string) throws {
   const pkgVersion = "([A-Za-z0-9\\-\\@\\.\\:]+)",
         compilerVersion = "(\\%[A-Za-z0-9\\_\\@\\.\\-]+)",
         variantInclude = "(\\+[A-Za-z0-9\\-\\_]+)",

--- a/tools/mason/TestResult.chpl
+++ b/tools/mason/TestResult.chpl
@@ -28,141 +28,141 @@
   formatted traceback of the error that occurred.
 */
 module TestResult {
-  private use List;
-  import ChapelLocks;
-  class TestResult {
-    type tupType = 2*string;
-    var failures: list(tupType),
-        errors: list(tupType),
-        skipped: list(tupType);
-    var testsRun = 0;
-    var testsPassed = 0;
-    var shouldStop = false;
-    var separator1 = "="* 70,
-        separator2 = "-"* 70;
+private use List;
+import ChapelLocks;
+class TestResult {
+  type tupType = 2*string;
+  var failures: list(tupType),
+      errors: list(tupType),
+      skipped: list(tupType);
+  var testsRun = 0;
+  var testsPassed = 0;
+  var shouldStop = false;
+  var separator1 = "="* 70,
+      separator2 = "-"* 70;
 
-    // the lock is only taken when modifying the result, as thats the only
-    // time we need to be thread-safe
-    var lock = new ChapelLocks.chpl_LocalSpinlock();
+  // the lock is only taken when modifying the result, as thats the only
+  // time we need to be thread-safe
+  var lock = new ChapelLocks.chpl_LocalSpinlock();
 
-    // called when a test ran
-    proc testRan() {
-      this.testsRun += 1;
-    }
+  // called when a test ran
+  proc testRan() {
+    this.testsRun += 1;
+  }
 
-    /*Called when an error has occurred.*/
-    proc addError(testName: string, fileName: string, errMsg: string) {
-      manage lock {
-        this.testRan();
-        var fileAdd = fileName + ": " + testName;
-        this.errors.pushBack((fileAdd, errMsg));
-      }
-    }
-
-    /*called when error occured */
-    proc addFailure(testName: string, fileName: string, errMsg: string) {
-      manage lock {
-        this.testRan();
-        var fileAdd = fileName + ": " + testName;
-        this.failures.pushBack((fileAdd, errMsg));
-      }
-    }
-
-    /*Called when a test has completed successfully*/
-    proc addSuccess() {
-      manage lock {
-        this.testRan();
-        this.testsPassed += 1;
-      }
-    }
-
-    /*Called when a test is skipped.*/
-    proc addSkip(testName: string, fileName: string, errMsg: string) {
-      manage lock {
-        this.testRan();
-        var fileAdd = fileName + ": " + testName;
-        this.skipped.pushBack((fileAdd, errMsg));
-      }
-    }
-
-    /*Tells whether or not this result was a success.*/
-    proc wasSuccessful() {
-      return this.failures.size == 0 && this.errors.size == 0;
-    }
-
-    /* Indicates that the tests should be aborted. */
-    proc stop() {
-      this.shouldStop = true;
-    }
-
-    /*Count of test skipped*/
-    proc numSkippedTests() {
-      return this.skipped.size;
-    }
-
-    /*Count of test failed*/
-    proc numFailedTests() {
-      return this.failures.size;
-    }
-
-    /*Count of tests giving error*/
-    proc numErroredTests() {
-      return this.errors.size;
-    }
-
-    proc printErrors() {
-      writeln();
-      this.printErrorList("ERROR", this.errors);
-      this.printErrorList("FAIL", this.failures);
-      this.printErrorList("SKIPPED", this.skipped);
-    }
-
-    proc printErrorList(flavour, errors) {
-      for (test, err) in errors {
-        writeln(this.separator1);
-        writeln(flavour, " ", test);
-        writeln(this.separator2);
-        writeln(err);
-      }
-    }
-
-    /* Function to print the result*/
-    proc printResult(timeTaken: real) {
-      var skipped = this.numSkippedTests();
-      var run = this.testsRun - skipped;
-      if this.testsRun != 0 {
-        writeln("Ran ", run, " ", printTest(run)," in ",timeTaken," seconds");
-        writeln();
-        var infos: list((string));
-        if testsPassed != 0 then
-          infos.pushBack("passed = " + testsPassed: string);
-        if !this.wasSuccessful() {
-          write("FAILED");
-          var failed = this.numFailedTests(),
-            errored = this.numErroredTests();
-          if failed then
-            infos.pushBack("failures = " + failed: string);
-          if errored then
-            infos.pushBack("errors = " + errored: string);
-        } else
-          write("OK");
-        if skipped then
-          infos.pushBack("skipped = " + skipped: string);
-        if infos.size {
-          write(" (");
-          for info in infos do write(info, " ");
-          writeln(")");
-        }
-      } else {
-        writeln("No Tests Found");
-      }
-    }
-
-    proc printTest(count) {
-      if count > 1 {
-        return "tests";
-      }
-      return "test";
+  /*Called when an error has occurred.*/
+  proc addError(testName: string, fileName: string, errMsg: string) {
+    manage lock {
+      this.testRan();
+      var fileAdd = fileName + ": " + testName;
+      this.errors.pushBack((fileAdd, errMsg));
     }
   }
+
+  /*called when error occured */
+  proc addFailure(testName: string, fileName: string, errMsg: string) {
+    manage lock {
+      this.testRan();
+      var fileAdd = fileName + ": " + testName;
+      this.failures.pushBack((fileAdd, errMsg));
+    }
+  }
+
+  /*Called when a test has completed successfully*/
+  proc addSuccess() {
+    manage lock {
+      this.testRan();
+      this.testsPassed += 1;
+    }
+  }
+
+  /*Called when a test is skipped.*/
+  proc addSkip(testName: string, fileName: string, errMsg: string) {
+    manage lock {
+      this.testRan();
+      var fileAdd = fileName + ": " + testName;
+      this.skipped.pushBack((fileAdd, errMsg));
+    }
+  }
+
+  /*Tells whether or not this result was a success.*/
+  proc wasSuccessful() {
+    return this.failures.size == 0 && this.errors.size == 0;
+  }
+
+  /* Indicates that the tests should be aborted. */
+  proc stop() {
+    this.shouldStop = true;
+  }
+
+  /*Count of test skipped*/
+  proc numSkippedTests() {
+    return this.skipped.size;
+  }
+
+  /*Count of test failed*/
+  proc numFailedTests() {
+    return this.failures.size;
+  }
+
+  /*Count of tests giving error*/
+  proc numErroredTests() {
+    return this.errors.size;
+  }
+
+  proc printErrors() {
+    writeln();
+    this.printErrorList("ERROR", this.errors);
+    this.printErrorList("FAIL", this.failures);
+    this.printErrorList("SKIPPED", this.skipped);
+  }
+
+  proc printErrorList(flavour, errors) {
+    for (test, err) in errors {
+      writeln(this.separator1);
+      writeln(flavour, " ", test);
+      writeln(this.separator2);
+      writeln(err);
+    }
+  }
+
+  /* Function to print the result*/
+  proc printResult(timeTaken: real) {
+    var skipped = this.numSkippedTests();
+    var run = this.testsRun - skipped;
+    if this.testsRun != 0 {
+      writeln("Ran ", run, " ", printTest(run)," in ",timeTaken," seconds");
+      writeln();
+      var infos: list((string));
+      if testsPassed != 0 then
+        infos.pushBack("passed = " + testsPassed: string);
+      if !this.wasSuccessful() {
+        write("FAILED");
+        var failed = this.numFailedTests(),
+          errored = this.numErroredTests();
+        if failed then
+          infos.pushBack("failures = " + failed: string);
+        if errored then
+          infos.pushBack("errors = " + errored: string);
+      } else
+        write("OK");
+      if skipped then
+        infos.pushBack("skipped = " + skipped: string);
+      if infos.size {
+        write(" (");
+        for info in infos do write(info, " ");
+        writeln(")");
+      }
+    } else {
+      writeln("No Tests Found");
+    }
+  }
+
+  proc printTest(count) {
+    if count > 1 {
+      return "tests";
+    }
+    return "test";
+  }
+}
 }

--- a/tools/mason/ThirdParty.chpl
+++ b/tools/mason/ThirdParty.chpl
@@ -24,8 +24,8 @@
   `use ThirdParty.DependencyName`.
 */
 module ThirdParty {
-  include module Pathlib;
-  include module TemplateString;
-  include module Log;
-  include module TerminalColors;
+include module Pathlib;
+include module TemplateString;
+include module Log;
+include module TerminalColors;
 }

--- a/tools/mason/pullMasonDeps
+++ b/tools/mason/pullMasonDeps
@@ -50,8 +50,14 @@ echo "Patching includes to be relative..."
 for dep in $(ls $MASON_DIR/ThirdParty/*.chpl); do
   modName=$(basename $dep .chpl)
   for other in $(ls $MASON_DIR/ThirdParty/*.chpl); do
+  otherName=$(basename $other .chpl)
     if grep -q "import $modName" $other; then
-      sed "s/import $modName/import super.$modName/g" $other > $other.tmp && mv $other.tmp $other
+      if [ "$otherName" != "$modName" ]; then
+        sed "s/import $modName/import super.$modName/g" $other > $other.tmp && mv $other.tmp $other
+      else
+        # relative imports to ourselves need to use the parent module name
+        sed "s/import $modName/import ThirdParty.${modName}/g" $other > $other.tmp && mv $other.tmp $other
+      fi
     fi
   done
 done


### PR DESCRIPTION
Switches mason sources to all use explicit modules, to better enforce error handling (since explicit modules use relaxed error handling)

- [x] paratest

Note to reviewer: it may be easier to review commit by commit to avoid an overwhelming amount of whitespace changes. Each "resolve incorrect indent" commit is a whitespace only change.

[Reviewed by @benharsh]

