### PR TITLE
Use `--system-launcher-passthrough` for deadline

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -246,7 +246,7 @@ def LauncherTimeoutArgs(seconds, maxQueueTime=0):
         if maxQueueTime > 0:
             # deadline is the walltime + max time in queue
             time = maxQueueTime + seconds
-            fmtdeadline = "--deadline=now+{}seconds".format(time)
+            fmtdeadline = "--system-launcher-flags='--deadline=now+{}seconds'".format(time)
             args.append(fmtdeadline)
         return args
 

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -246,7 +246,11 @@ def LauncherTimeoutArgs(seconds, maxQueueTime=0):
         if maxQueueTime > 0:
             # deadline is the walltime + max time in queue
             time = maxQueueTime + seconds
-            fmtdeadline = "--system-launcher-flags='--deadline=now+{}seconds'".format(time)
+            fmtdeadline = (
+                "--system-launcher-flags='--deadline=now+{}seconds'".format(
+                    time
+                )
+            )
             args.append(fmtdeadline)
         return args
 


### PR DESCRIPTION
Wrap `--deadline` in `--system-launcher-passthrough`, since the Chapel slurm wrapper doesn't recognize `--deadline`.

[Reviewed by @arifthpe]