### PR TITLE
Fixes two small mason issues

### DIFF
--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -248,7 +248,7 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string,
       cmd.pushBack(gitDepSrc);
 
       for flag in MasonPrereqs.chplFlags(depDir:path) {
-        log.debugf("+compflag ", flag);
+        log.debug("+compflag ", flag);
         cmd.pushBack(flag);
       }
     }

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -199,15 +199,16 @@ proc updateRegistry(skipUpdate: bool, show=true) throws {
     log.debugf("Updating registry %s (%s) at %s",
                 name, registry, registryHome);
 
-    if isDir(registryHome) {
+    const registryHomePath = registryHome:path;
+    if registryHomePath.isDir() {
       var pullRegistry = 'git pull -q origin';
       if show then writeln("Updating ", name);
-      gitC(registryHome, pullRegistry);
+      gitC(registryHomePath, pullRegistry);
     } else {
       // Registry has moved or does not exist
       if !(MASON_HOME:path / "src").isDir() then
         (MASON_HOME:path / "src").mkdir(parents=true);
-      const localRegistry:path = registryHome;
+      const localRegistry = registryHomePath;
       localRegistry.mkdir(parents=true);
       if show then writeln("Updating ", name);
       cloneSource(registry, localRegistry, quiet=true);

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -205,7 +205,8 @@ proc updateRegistry(skipUpdate: bool, show=true) throws {
       gitC(registryHome, pullRegistry);
     } else {
       // Registry has moved or does not exist
-      (MASON_HOME:path / "src").mkdir(parents=true);
+      if !(MASON_HOME:path / "src").isDir() then
+        (MASON_HOME:path / "src").mkdir(parents=true);
       const localRegistry:path = registryHome;
       localRegistry.mkdir(parents=true);
       if show then writeln("Updating ", name);

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -83,7 +83,7 @@ proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock",
   const openFile = openReader(tomlPath:string, locking=false);
   const TomlFile = parseToml(openFile);
   openFile.close();
-  log.debugf("Parsed ", tomlPath:string);
+  log.debug("Parsed ", tomlPath:string);
 
   var updated = false;
   if tomlPath.isFile() {


### PR DESCRIPTION
Fixes two small mason issues I found while working with local mason registrys

* mason could fail with "dir exists" when trying to make the `src` dir
* 2 mason debug logs were using incorrect format strings

[Reviewed by @arifthpe]