### PR TITLE
Require double quotes in Mason sources

### DIFF
--- a/Makefile.devel
+++ b/Makefile.devel
@@ -112,7 +112,7 @@ lint-standard-modules: chplcheck FORCE
 
 MASON_MODULES_TO_LINT = $(shell find $(CHPL_MAKE_HOME)/tools/mason -name '*.chpl' -not -path '$(CHPL_MAKE_HOME)/tools/mason/ThirdParty/*')
 lint-mason: chplcheck FORCE
-	tools/chplcheck/chplcheck --enable-rule UseExplicitModules --setting IncorrectIndentation.UnindentedModule=true $(MASON_MODULES_TO_LINT)
+	tools/chplcheck/chplcheck --add-rules $(CHPL_MAKE_HOME)/tools/mason/rules.py --enable-rule UseExplicitModules --setting IncorrectIndentation.UnindentedModule=true $(MASON_MODULES_TO_LINT)
 
 mason-deps: FORCE
 	cd tools/mason && $(MAKE) deps

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -129,9 +129,9 @@ proc buildProgram(release: bool, show: bool, force: bool, skipUpdate: bool,
   }
   const projectName = lockFile["root.name"]!.s;
 
-  var binLoc = 'debug';
+  var binLoc = "debug";
   if release then
-    binLoc = 'release';
+    binLoc = "release";
 
 
   // build on last modification
@@ -154,7 +154,7 @@ proc buildProgram(release: bool, show: bool, force: bool, skipUpdate: bool,
     // generate list of dependencies and get src code
     var (sourceList, gitList) = genSourceList(lockFile);
 
-    if lockFile.pathExists('external') {
+    if lockFile.pathExists("external") {
       spackInstalled();
     }
     getSrcCode(sourceList, skipUpdate, show);
@@ -188,14 +188,14 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string,
                 sourceList: list(srcSource),
                 gitList: list(gitSource)) : bool throws {
 
-  const depPath = Path.joinPath(MASON_HOME, 'src');
-  const gitDepPath = Path.joinPath(MASON_HOME, 'git');
+  const depPath = Path.joinPath(MASON_HOME, "src");
+  const gitDepPath = Path.joinPath(MASON_HOME, "git");
   const project = lockFile["root.name"]!.s;
   const pathToProj = Path.replaceExt(Path.joinPath(projectHome,
-                                                   'src',
-                                                   project), 'chpl');
+                                                   "src",
+                                                   project), "chpl");
 
-  const moveTo = Path.joinPath(projectHome, 'target', binLoc, project);
+  const moveTo = Path.joinPath(projectHome, "target", binLoc, project);
 
   if !isFile(pathToProj) {
     throw new MasonError("Mason could not find your project");
@@ -272,7 +272,7 @@ proc compileSrc(lockFile: borrowed Toml, binLoc: string,
     }
 
     // Confirming File Structure
-    return isFile(Path.joinPath(projectHome, 'target', binLoc, project));
+    return isFile(Path.joinPath(projectHome, "target", binLoc, project));
   }
   return false;
 }
@@ -381,7 +381,7 @@ proc getGitCode(gitList: list(gitSource),
   with (ref errors) {
     const nameVers = name + "-" + branch;
     const destination = baseDir / nameVers;
-    if !depExists(nameVers, '/git/') {
+    if !depExists(nameVers, "/git/") {
       if !skipUpdate {
         writeln("Downloading dependency: " + nameVers);
         try {
@@ -470,7 +470,7 @@ proc getTomlCompopts(lock: borrowed Toml): list(string) throws {
       }
   }
 
-  if const exDeps = lock.get['external'] {
+  if const exDeps = lock.get["external"] {
     for (_, depInfo) in zip(exDeps.A.keys(), exDeps.A.values()) {
       for (k,v) in allFields(depInfo!) {
         var val = v!;
@@ -483,7 +483,7 @@ proc getTomlCompopts(lock: borrowed Toml): list(string) throws {
       }
     }
   }
-  if const pkgDeps = lock.get['system'] {
+  if const pkgDeps = lock.get["system"] {
     for (_, depInfo) in zip(pkgDeps.A.keys(), pkgDeps.A.values()) {
       for (k,v) in allFields(depInfo!) {
         var val = v!;

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -37,7 +37,7 @@ proc masonDoc(args: [] string) throws {
   var passArgs = parser.addPassThrough();
   parser.parseArgs(args);
 
-  const tomlName = 'Mason.toml';
+  const tomlName = "Mason.toml";
   const cwd = here.cwd();
 
   const projectHome = getProjectHome(cwd, tomlName);
@@ -47,7 +47,7 @@ proc masonDoc(args: [] string) throws {
   var tomlFile = parseToml(toParse);
 
   const projectName = tomlFile["brick.name"]!.s;
-  const projectFile = projectName + '.chpl';
+  const projectFile = projectName + ".chpl";
 
   const version = tomlFile["brick.version"]!.s;
 
@@ -67,8 +67,8 @@ proc masonDoc(args: [] string) throws {
     copyrightYear = copyrightToml.s;
   }
 
-  if isDir(projectHome + '/src/') &&
-      isFile(projectHome + '/src/' + projectFile) {
+  if isDir(projectHome + "/src/") &&
+      isFile(projectHome + "/src/" + projectFile) {
     // Must use relative paths with chpldoc to prevent baking in abs paths
     here.chdir(projectHome);
 

--- a/tools/mason/MasonEnv.chpl
+++ b/tools/mason/MasonEnv.chpl
@@ -30,7 +30,7 @@ const regUrl: string = "https://github.com/chapel-lang/mason-registry";
 @chplcheck.ignore("CamelCaseFunctions")
 proc MASON_HOME : string {
   const envHome = getEnv("MASON_HOME");
-  const default = getEnv('HOME') + "/.mason";
+  const default = getEnv("HOME") + "/.mason";
   const masonHome = if envHome != "" then envHome else default;
 
   return masonHome;
@@ -57,12 +57,12 @@ proc MASON_CACHED_REGISTRY throws {
 */
 @chplcheck.ignore("CamelCaseFunctions")
 proc MASON_OFFLINE {
-  const offlineEnv = getEnv('MASON_OFFLINE');
+  const offlineEnv = getEnv("MASON_OFFLINE");
   const default = false;
   var offline = false;
 
-  if (offlineEnv == 'true') || (offlineEnv == 'True') ||
-     (offlineEnv == 'TRUE') || (offlineEnv == '1') {
+  if (offlineEnv == "true") || (offlineEnv == "True") ||
+     (offlineEnv == "TRUE") || (offlineEnv == "1") {
     offline = true;
   } else offline = default;
 
@@ -86,9 +86,9 @@ proc MASON_REGISTRY throws {
   if env == "" {
     registries.pushBack(default);
   } else {
-    for str in env.split(',') {
+    for str in env.split(",") {
       if str.strip().isEmpty() then continue;
-      const regArr = str.split('|');
+      const regArr = str.split("|");
       if regArr.size > 2 || regArr.size < 1 {
         const msg = "expected MASON_REGISTRY to contain a comma separated " +
                     "list of locations or 'name|location' pairs\n" + str;
@@ -181,13 +181,13 @@ proc masonEnv(args) throws {
     }
     writeln(star);
   }
-  var offlineString = 'false';
+  var offlineString = "false";
   if MASON_OFFLINE {
-    offlineString = 'true';
+    offlineString = "true";
   }
   printVar("MASON_HOME", MASON_HOME);
   printVar("MASON_REGISTRY", MASON_REGISTRY);
-  printVar('MASON_OFFLINE', offlineString);
+  printVar("MASON_OFFLINE", offlineString);
   printVar("SPACK_ROOT", SPACK_ROOT);
 
   if debug {

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -71,7 +71,7 @@ proc runExamples(show: bool, run: bool, build: bool, release: bool,
   if numExamples > 0 {
     for example in examplesToRun {
 
-      const examplePath = "".join(projectHome, '/example/', example);
+      const examplePath = "".join(projectHome, "/example/", example);
       const exampleName = basename(stripExt(example, ".chpl"));
 
       // retrieves compopts and execopts found per example in the toml file
@@ -181,8 +181,8 @@ private proc getBuildInfo(projectHome: path,
     }
     // Get project source code and dependencies
     (sourceList, gitList) = genSourceList(lockFile);
-    const depPath = MASON_HOME:path / 'src';
-    const gitDepPath = MASON_HOME:path / 'git';
+    const depPath = MASON_HOME:path / "src";
+    const gitDepPath = MASON_HOME:path / "git";
 
 
     getSrcCode(sourceList, skipUpdate, false);
@@ -234,7 +234,7 @@ private proc getBuildInfo(projectHome: path,
     }
 
     // get system deps
-    if const pkgDeps = lockFile.get['system'] {
+    if const pkgDeps = lockFile.get["system"] {
       for (_, depInfo) in zip(pkgDeps.A.keys(), pkgDeps.A.values()) {
         for (k,v) in allFields(depInfo!) {
           var val = v!;
@@ -352,7 +352,7 @@ private proc getExamples(toml: Toml, projectHome: string) throws {
 
   if const examplesToml = toml.get("examples.examples") {
     var examples = examplesToml.toString();
-    var strippedExamples = examples.split(',').strip('[]');
+    var strippedExamples = examples.split(",").strip("[]");
     for example in strippedExamples {
       const t = example.strip().strip('"');
       exampleNames.pushBack(t);

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -40,7 +40,7 @@ private var log = MasonLogger.getLogger("mason external");
 const minSpackVersion = new versionInfo(1, 0, 0);
 const major = minSpackVersion.major:string;
 const minor = minSpackVersion.minor:string;
-const spackBranch = 'releases/v' + '.'.join(major, minor);
+const spackBranch = "releases/v" + ".".join(major, minor);
 const spackDefaultPath = MASON_HOME + "/spack";
 const spackRegistryDefaultPath = MASON_HOME + "/spack-registry";
 
@@ -78,8 +78,8 @@ proc masonExternal(args: [] string) throws {
     if setupFlag.valueAsBool() {
       // if MASON_OFFLINE is set, then cannot install spack
       if MASON_OFFLINE {
-        throw new MasonError('Cannot setup Spack when MASON_OFFLINE ' +
-                             'is set to true');
+        throw new MasonError("Cannot setup Spack when MASON_OFFLINE " +
+                             "is set to true");
       }
 
       // If spack and spack registry is present with latest version, print
@@ -160,8 +160,8 @@ proc masonExternal(args: [] string) throws {
         when "info" do spkgInfo(cmdArgs);
         when "find" do findSpkg(cmdArgs);
         otherwise {
-          writeln('error: no such subcommand %s'.format(usedCmd));
-          writeln('try mason external --help');
+          writeln("error: no such subcommand %s".format(usedCmd));
+          writeln("try mason external --help");
           exit(1);
         }
       }
@@ -241,8 +241,8 @@ proc gitCheckOutSpack(tag: string) {
 
 /* git fetch command run at SPACK_ROOT */
 proc gitFetch(branch: string) {
-  const command = 'git ' + '-C ' + SPACK_ROOT + ' fetch -q ' +
-                  ' --depth 1 origin ' + branch;
+  const command = "git " + "-C " + SPACK_ROOT + " fetch -q " +
+                  " --depth 1 origin " + branch;
   const status = runWithStatus(command);
   if status != 0 then return -1;
   else return 0;
@@ -250,9 +250,9 @@ proc gitFetch(branch: string) {
 
 /* Updates the spack directory used for spack commands */
 private proc updateSpackCommandLine() {
-  const releaseTag = 'v' + minSpackVersion.str();
-  var tag = 'refs/tags/' + releaseTag;
-  tag = tag + ':' + tag;
+  const releaseTag = "v" + minSpackVersion.str();
+  var tag = "refs/tags/" + releaseTag;
+  tag = tag + ":" + tag;
   const statusFetch = gitFetch(tag);
   const statusCheckOut = gitCheckOutSpack(releaseTag);
   if statusFetch != 0 || statusCheckOut != 0 then return -1;
@@ -268,13 +268,13 @@ private proc updateSpackCommandLine() {
   /spack/etc/spack/defaults with that of spack-registry
 */
 private proc generateYAML() throws {
-  const yamlFilePath = SPACK_ROOT + '/etc/spack/defaults/repos.yaml';
+  const yamlFilePath = SPACK_ROOT + "/etc/spack/defaults/repos.yaml";
   if isFile(yamlFilePath) {
     remove(yamlFilePath);
   }
   const reposOverride =
-    'repos:\n'+
-    '  - ' + MASON_HOME + '/spack-registry/var/spack/repos/builtin \n';
+    "repos:\n"+
+    "  - " + MASON_HOME + "/spack-registry/var/spack/repos/builtin \n";
   var yamlFile = open(yamlFilePath,ioMode.cw);
   var yamlWriter = yamlFile.writer(locking=false);
   yamlWriter.write(reposOverride);
@@ -507,7 +507,7 @@ proc getSpkgInfo(spec: string, dependencies: list(string)): shared Toml throws {
   var compiler = specFields[2];
 
   // Remove variants from spec
-  var simpleSpec = pkgName + '@' + version + '%' + compiler;
+  var simpleSpec = pkgName + "@" + version + "%" + compiler;
 
   if spkgInstalled(simpleSpec) {
     const spkgPath = getSpkgPath(simpleSpec);
@@ -586,8 +586,8 @@ proc getSpkgDependencies(spec: string): list(string) throws {
 
 /* Get package name from spec */
 private proc specName(spec: string): string throws {
-  const fields = spec.split('%');
-  const subfields = fields[0].split('@');
+  const fields = spec.split("%");
+  const subfields = fields[0].split("@");
   const name = subfields[0];
   return name;
 }
@@ -600,7 +600,7 @@ private proc resolveSpec(spec: string): string throws {
   const command = "spack spec --no-install-status %s | head -n1".format(spec);
   const output = getSpackResult(command, quiet=true);
 
-  if output == '' {
+  if output == "" {
     throw new MasonError("Package not found: " + spec);
   }
 

--- a/tools/mason/MasonModify.chpl
+++ b/tools/mason/MasonModify.chpl
@@ -66,7 +66,7 @@ proc masonModify(args: [] string) throws {
 proc modifyToml(add: bool, spec: string, external: bool, system: bool,
                 skipCheck: bool, projectHome: string, tf="Mason.toml") throws {
 
-  const tomlPath = '/'.join(projectHome, tf);
+  const tomlPath = "/".join(projectHome, tf);
   const openFile = openReader(tomlPath, locking=false);
   const toml = parseToml(openFile);
   var newToml: shared Toml?;
@@ -81,10 +81,10 @@ proc modifyToml(add: bool, spec: string, external: bool, system: bool,
         throw new MasonError("Dependency formatted incorrectly.\n"+
                             "Format: package@version");
       }
-      (dependency, _, version) = spec.partition('@');
+      (dependency, _, version) = spec.partition("@");
     } else {
-      if spec.find('@') != -1 {
-        (dependency, _, version) = spec.partition('@');
+      if spec.find("@") != -1 {
+        (dependency, _, version) = spec.partition("@");
       } else {
         dependency = spec;
         version = "*";
@@ -126,8 +126,8 @@ proc modifyToml(add: bool, spec: string, external: bool, system: bool,
   } else {
     // Removing a dependency
     var depName: string;
-    if spec.find('@') != -1 {
-      const split = spec.split('@');
+    if spec.find("@") != -1 {
+      const split = spec.split("@");
       depName = split[0];
     } else depName = spec;
     const dependency = depName;

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -88,8 +88,8 @@ proc masonModules(args: [] string) throws {
   getSrcCode(sourceList, skipUpdate, false);
   getGitCode(gitList, skipUpdate, false);
 
-  const depPath = MASON_HOME:path / 'src';
-  const gitDepPath = MASON_HOME:path / 'git';
+  const depPath = MASON_HOME:path / "src";
+  const gitDepPath = MASON_HOME:path / "git";
   var modules: list(path);
   // can't use _ since it will leak
   // see https://github.com/chapel-lang/chapel/issues/25926

--- a/tools/mason/MasonPublish.chpl
+++ b/tools/mason/MasonPublish.chpl
@@ -136,16 +136,16 @@ proc masonPublish(args: [] string) throws {
 
   if ((MASON_OFFLINE  && !update) || noUpdate) && !falseIfRemotePath() {
     if !isLocal then
-      throw new MasonError('You cannot publish to a remote repository ' +
-                           'when MASON_OFFLINE is set to true or ' +
+      throw new MasonError("You cannot publish to a remote repository " +
+                           "when MASON_OFFLINE is set to true or " +
                            '"--no-update" is passed, override with --update');
     else
       updateRegistry(skipUpdate);
   }
 
   if !isLocal && !doesGitOriginExist() && !dry {
-    throw new MasonError('Your package must have a git origin remote ' +
-                         'in order to publish to a remote registry.');
+    throw new MasonError("Your package must have a git origin remote " +
+                         "in order to publish to a remote registry.");
   }
 
   if checkRegistryPath(registryPath, isLocal) {
@@ -186,8 +186,8 @@ proc isRegistryPathLocal(registryPath : string) throws {
 proc checkRegistryPath(registryPath : string, trueIfLocal : bool) throws {
   try! {
     if registryPath == MASON_HOME then return true;
-    if !exists('.git') {
-      throw new MasonError(registryPath + ' is not a local git repository.');
+    if !exists(".git") {
+      throw new MasonError(registryPath + " is not a local git repository.");
     }
     if trueIfLocal {
       if exists(registryPath) && exists(registryPath + "/Bricks/") {
@@ -197,7 +197,7 @@ proc checkRegistryPath(registryPath : string, trueIfLocal : bool) throws {
                              " is not a valid path to a local mason-registry.");
       }
     } else {
-      var command = ('git ls-remote ' + registryPath).split();
+      var command = ("git ls-remote " + registryPath).split();
       var checkRemote = spawn(command, stdout=pipeStyle.pipe);
       checkRemote.wait();
       if checkRemote.exitCode == 0 then return true;
@@ -222,25 +222,25 @@ proc publishPackage(username: string,
   var stream = new randomStream(int, false);
   var uniqueDir = stream.next(): string;
   const name = getPackageName();
-  var safeDir = '';
+  var safeDir = "";
 
   if isLocal then safeDir = registryPath;
   else {
-    safeDir = MASON_HOME + '/tmp/' + name + '-' + uniqueDir;
+    safeDir = MASON_HOME + "/tmp/" + name + "-" + uniqueDir;
   }
 
   if !isLocal {
-    if !exists(MASON_HOME + '/tmp') then mkdir(MASON_HOME + '/tmp');
+    if !exists(MASON_HOME + "/tmp") then mkdir(MASON_HOME + "/tmp");
     if exists(safeDir) {
       // a previous publish failed, clobber the dir
-      rmTree(safeDir + '/');
+      rmTree(safeDir + "/");
     }
     mkdir(safeDir);
   }
   defer {
     try {
       // make sure we always cleanup
-      if !isLocal && exists(safeDir) then rmTree(safeDir + '/');
+      if !isLocal && exists(safeDir) then rmTree(safeDir + "/");
     } catch { }
   }
 
@@ -251,25 +251,25 @@ proc publishPackage(username: string,
 
   const version = addPackageToBricks(packageLocation, safeDir, name, isLocal);
   const message =
-    'Adding %s package to registry via mason publish'.format(version);
-  var commitCmd = ['git', 'commit', '-q', '-m', message];
+    "Adding %s package to registry via mason publish".format(version);
+  var commitCmd = ["git", "commit", "-q", "-m", message];
 
   if !isLocal {
     gitC(safeDir + "/mason-registry", "git add .");
-    gitC(safeDir + '/mason-registry', commitCmd);
+    gitC(safeDir + "/mason-registry", commitCmd);
     gitC(safeDir + "/mason-registry",
-          'git push -q --set-upstream origin ' + name);
-    const masonRegRemoteName = getRemoteName(safeDir + '/mason-registry');
+          "git push -q --set-upstream origin " + name);
+    const masonRegRemoteName = getRemoteName(safeDir + "/mason-registry");
     const url = "https://github.com/%s/%s/pull/new/%s".format(
                                                         username,
                                                         masonRegRemoteName,
                                                         name);
-    writeln('Successfully published package to ' + registryPath);
+    writeln("Successfully published package to " + registryPath);
     writef("Go to '%s' to open a Pull Request to the mason-registry\n", url);
   } else {
-    gitC(safeDir, 'git add Bricks/' + name);
+    gitC(safeDir, "git add Bricks/" + name);
     gitC(safeDir, commitCmd);
-    writeln('Successfully published package to ' + registryPath);
+    writeln("Successfully published package to " + registryPath);
   }
 }
 
@@ -298,29 +298,29 @@ proc dryRun(username: string, registryPath : string, isLocal : bool) throws {
       exit(0);
     } else {
       if !fork then
-        throw new MasonError('mason-registry is not forked on your GitHub');
+        throw new MasonError("mason-registry is not forked on your GitHub");
       else
-        throw new MasonError('Package does not gave a git origin');
+        throw new MasonError("Package does not gave a git origin");
     }
   } else {
-    const spacer = '------------------------------------------------------';
-    writeln('Checking Registry with ' + registryPath + ' path.');
+    const spacer = "------------------------------------------------------";
+    writeln("Checking Registry with " + registryPath + " path.");
     var registryTest = registryPathCheck(registryPath, username, false);
     writeln(spacer);
-    writeln('The current mason environment is:');
+    writeln("The current mason environment is:");
     returnMasonEnv();
     var reg = MASON_REGISTRY;
 
-    if reg.size == 1 && reg[0] == ('mason-registry', regUrl) then
-      writeln('   In order to use a local registry, ' +
-              'ensure that MASON_REGISTRY points to the path.');
+    if reg.size == 1 && reg[0] == ("mason-registry", regUrl) then
+      writeln("   In order to use a local registry, " +
+              "ensure that MASON_REGISTRY points to the path.");
 
     if checkRegistryPath(registryPath, isLocal) {
-      writeln('Package can be published to local registry');
+      writeln("Package can be published to local registry");
       exit(0);
     } else {
       throw new MasonError(registryPath +
-                           ' is not a valid registryPath to a local registry.');
+                           " is not a valid registryPath to a local registry.");
     }
   }
 }
@@ -339,8 +339,8 @@ proc cloneMasonReg(username: string,
     cloneSource(url, dest, quiet=false);
   } catch {
     throw new MasonError(
-      'Error cloning the fork of mason-registry. ' +
-      'Make sure you have forked the mason-registry on GitHub');
+      "Error cloning the fork of mason-registry. " +
+      "Make sure you have forked the mason-registry on GitHub");
   }
 }
 
@@ -359,7 +359,7 @@ proc doesGitOriginExist() {
 /* Opens Spawn call to get username for the mason registry fork
  */
 private proc usernameCheck(username: string) {
-  const gitRemote = 'git ls-remote https://github.com/%s/mason-registry';
+  const gitRemote = "git ls-remote https://github.com/%s/mason-registry";
   var usernameCheck = runWithStatus(try! gitRemote.format(username), true);
   return usernameCheck;
 }
@@ -367,7 +367,7 @@ private proc usernameCheck(username: string) {
 /* Runs Commands to see if Fork of mason-registry exists under the username
  */
 private proc checkIfForkExists(username: string) {
-  var getFork = 'git ls-remote https://github.com/%s/mason-registry';
+  var getFork = "git ls-remote https://github.com/%s/mason-registry";
   var status = runWithStatus(try! getFork.format(username), false);
   return status;
 }
@@ -420,8 +420,8 @@ proc branchMasonReg(name: string, safeDir: string) throws {
     const dir = safeDir:path / "mason-registry";
     checkoutSource(dir, name, createBranch=true);
   } catch {
-    throw new MasonError('Error branching the registry, make sure you have a ' +
-                         'remote origin set up');
+    throw new MasonError("Error branching the registry, make sure you have a " +
+                         "remote origin set up");
   }
 }
 
@@ -431,11 +431,11 @@ proc getPackageName() throws {
   try! {
     const toParse = open("Mason.toml", ioMode.r);
     var tomlFile = (parseToml(toParse));
-    const name = tomlFile['brick.name']!.s;
+    const name = tomlFile["brick.name"]!.s;
     return name;
   } catch {
-    throw new MasonError('Issue getting the name of your package, ' +
-                         'ensure your package is a mason project.');
+    throw new MasonError("Issue getting the name of your package, " +
+                         "ensure your package is a mason project.");
   }
 }
 
@@ -445,39 +445,39 @@ proc getPackageName() throws {
  */
 private proc addPackageToBricks(projectLocal: string, safeDir: string,
                                 name: string, isLocal: bool) throws {
-  if isLocal && !exists(joinPath(safeDir, '.git')) {
+  if isLocal && !exists(joinPath(safeDir, ".git")) {
     throw new MasonError(
-      'Unable to publish your package to the registry, ' +
-      'make sure your package is a git repository.');
+      "Unable to publish your package to the registry, " +
+      "make sure your package is a git repository.");
   }
 
   const bricksDir = if !isLocal
-                      then joinPath(safeDir, 'mason-registry', 'Bricks')
-                      else joinPath(safeDir, 'Bricks');
+                      then joinPath(safeDir, "mason-registry", "Bricks")
+                      else joinPath(safeDir, "Bricks");
 
   if !isLocal && !exists(bricksDir) {
-    throw new MasonError('Registry does not have the expected structure. ' +
-                         'Ensure your registry has a Bricks directory.');
+    throw new MasonError("Registry does not have the expected structure. " +
+                         "Ensure your registry has a Bricks directory.");
   }
 
   const projectBrickDir = joinPath(bricksDir, name);
   const toParse = open(joinPath(projectLocal, "Mason.toml"), ioMode.r);
   var tomlFile = (parseToml(toParse));
-  const versionNum = tomlFile!['brick.version']!.s;
+  const versionNum = tomlFile!["brick.version"]!.s;
   const versionToml = joinPath(projectBrickDir, versionNum + ".toml");
 
   if !exists(projectBrickDir) {
     mkdir(projectBrickDir);
   }
   if exists(versionToml) {
-    throw new MasonError('A package with that name and version number ' +
-                         'already exists in the Bricks.');
+    throw new MasonError("A package with that name and version number " +
+                         "already exists in the Bricks.");
   }
 
   // check the tag, if it already exists, throw an error
   var tagExists = false;
-  var tagName = 'v' + versionNum;
-  var result = gitC(projectLocal, ['git', 'tag', '--list', tagName]).strip();
+  var tagName = "v" + versionNum;
+  var result = gitC(projectLocal, ["git", "tag", "--list", tagName]).strip();
   tagExists = result == tagName;
 
   if tagExists {
@@ -501,12 +501,12 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string,
     tomlWriter.close();
   }
   // create the tag
-  gitC(projectLocal, ['git', 'tag', '-a', tagName, '-m', name]);
+  gitC(projectLocal, ["git", "tag", "-a", tagName, "-m", name]);
   writeln("Created git tag: ", tagName,
           ". Make sure to push this tag to your remote when you ",
           "publish to the registry with 'git push origin --tags'");
 
-  return name + '@' + versionNum;
+  return name + "@" + versionNum;
 }
 
 /*
@@ -515,8 +515,8 @@ private proc addPackageToBricks(projectLocal: string, safeDir: string,
   published to a registry.
  */
 proc check(p: string, ci: bool) throws {
-  const spacer = '------------------------------------------------------';
-  const package = ensureMasonProject(here.cwd(), 'Mason.toml');
+  const spacer = "------------------------------------------------------";
+  const package = ensureMasonProject(here.cwd(), "Mason.toml");
   const projectCheckHome = here.cwd();
   var packageTest = true;
   var moduleTest = true;
@@ -528,117 +528,117 @@ proc check(p: string, ci: bool) throws {
   var masonFieldsTest = true;
   var licenseTest = true;
 
-  writeln('Mason Project Check:');
+  writeln("Mason Project Check:");
   if !package {
-    writeln('   Could not find your configuration file (Mason.toml) (FAILED)');
-    writeln('   Ensure your project is a mason package');
+    writeln("   Could not find your configuration file (Mason.toml) (FAILED)");
+    writeln("   Ensure your project is a mason package");
     packageTest = false;
   } else {
-    writeln('   Package is a Mason package and has a Mason.toml (PASSED)');
+    writeln("   Package is a Mason package and has a Mason.toml (PASSED)");
   }
   writeln(spacer);
 
   if package {
-    writeln('Main Module Check:');
+    writeln("Main Module Check:");
     if moduleCheck(projectCheckHome) {
-      writeln('   Your package has one main module whose name matches ' +
-              'the package name. (PASSED)');
+      writeln("   Your package has one main module whose name matches " +
+              "the package name. (PASSED)");
     } else {
-      writeln('   Packages must have a single main module whose name matches ' +
-              'the package name. (FAILED)');
+      writeln("   Packages must have a single main module whose name matches " +
+              "the package name. (FAILED)");
       moduleTest = false;
     }
     writeln(spacer);
   }
 
   if package {
-    writeln('Checking for fields in manifest file:');
+    writeln("Checking for fields in manifest file:");
     const manifestResults = masonTomlFileCheck(projectCheckHome);
     if manifestResults.isValid() {
-      writeln('   All fields present in manifest file, can be published ' +
-              'to a registry. (PASSED)');
+      writeln("   All fields present in manifest file, can be published " +
+              "to a registry. (PASSED)");
     } else if manifestResults.missingFields.size > 0 {
-      writeln('   Missing fields in manifest file (Mason.toml). (FAILED)');
-      writeln('   The missing fields are as follows: ');
+      writeln("   Missing fields in manifest file (Mason.toml). (FAILED)");
+      writeln("   The missing fields are as follows: ");
       for field in manifestResults.missingFields do
-        writeln('   %s'.format(field));
+        writeln("   %s".format(field));
       masonFieldsTest = false;
     } else if manifestResults.mismatchedTypes.size > 0 {
-      writeln('   Mismatched field types in manifest file (Mason.toml). ',
-              '(FAILED)');
-      writeln('   The fields with mismatched types are as follows: ');
+      writeln("   Mismatched field types in manifest file (Mason.toml). ",
+              "(FAILED)");
+      writeln("   The fields with mismatched types are as follows: ");
       for field in manifestResults.mismatchedTypes do
-        writeln('   %s'.format(field));
+        writeln("   %s".format(field));
       masonFieldsTest = false;
     }
     writeln(spacer);
   }
 
   if package {
-    writeln('Checking for examples:');
+    writeln("Checking for examples:");
     if exampleCheck(projectCheckHome) {
-      writeln('   Found examples in the package, ',
-              'can be published to a registry. (PASSED)');
+      writeln("   Found examples in the package, ",
+              "can be published to a registry. (PASSED)");
     } else {
-      writeln('   No examples found in package. (WARNING)');
+      writeln("   No examples found in package. (WARNING)");
       exampleTest = false;
     }
     writeln(spacer);
   }
 
   if package {
-    writeln('Checking for tests:');
+    writeln("Checking for tests:");
     if testCheck(projectCheckHome) {
-      writeln('   Found tests in the package, can be published to a ' +
-              'registry. (PASSED)');
+      writeln("   Found tests in the package, can be published to a " +
+              "registry. (PASSED)");
     } else {
-      writeln('   No tests found in package. (FAILED)');
+      writeln("   No tests found in package. (FAILED)");
       testTest = false;
     }
     writeln(spacer);
   }
 
   if package {
-    writeln('Checking git tag version formatting:');
+    writeln("Checking git tag version formatting:");
     const tagResults = gitTagVersionCheck(projectCheckHome);
     if tagResults[0] {
-      writeln('   Valid git tag version formatting, can be published to a ' +
-              'registry. (PASSED)');
+      writeln("   Valid git tag version formatting, can be published to a " +
+              "registry. (PASSED)");
     } else {
-      writeln('   Invalid git tag version formatting. (FAILED)');
+      writeln("   Invalid git tag version formatting. (FAILED)");
       const listTags = tagResults[1];
       const foundVersion = tagResults[2];
-      writeln('   Expected tag version: %s'.format(foundVersion));
-      writeln('   Tags found: ');
-      for tag in listTags do writeln('   %s'.format(tag));
+      writeln("   Expected tag version: %s".format(foundVersion));
+      writeln("   Tags found: ");
+      for tag in listTags do writeln("   %s".format(tag));
       gitTagTest = false;
     }
     writeln(spacer);
   }
 
   if package {
-    writeln('Checking for license:');
+    writeln("Checking for license:");
     var validLicenseCheck = checkLicense(projectCheckHome);
     if validLicenseCheck[0] {
-      writeln('   Found valid license in manifest file. (PASSED)');
+      writeln("   Found valid license in manifest file. (PASSED)");
     } else {
       writeln('   Invalid license name: "' +
               validLicenseCheck[1] + '". Please use a valid name from ' +
-              'SPDX license list. (FAILED)');
+              "SPDX license list. (FAILED)");
       licenseTest = false;
     }
     writeln(spacer);
   }
 
   if package && !ci {
-    writeln('Git Remote Check:');
+    writeln("Git Remote Check:");
     if doesGitOriginExist() {
-      writeln('   Package has a git remote origin and can be published ' +
-              'to a remote registry (PASSED)');
-      writeln('   Remote Origin: ' + getRemoteOrigin());
+      writeln("   Package has a git remote origin and can be published " +
+              "to a remote registry (PASSED)");
+      writeln("   Remote Origin: " + getRemoteOrigin());
     } else {
-      writeln('   Package has no remote origin and cannot be publish to a ' +
-              'registry with path:' + p + ' (FAILED)');
+      writeln("   Package has no remote origin and cannot be publish to a " +
+              "registry with path:" + p + " (FAILED)");
       remoteTest = false;
     }
     writeln(spacer);
@@ -665,39 +665,39 @@ proc check(p: string, ci: bool) throws {
   writeln();
   writeln();
   writeln();
-  writeln('RESULTS');
+  writeln("RESULTS");
   writeln(spacer);
 
   if packageTest && remoteTest && moduleTest && testTest &&
     licenseTest && gitTagTest && masonFieldsTest {
-    writeln('(PASSED) Your package is ready to publish');
+    writeln("(PASSED) Your package is ready to publish");
   } else {
     if !packageTest {
       writeln(
-        '(FAILED) Your package does not have to proper package structure');
+        "(FAILED) Your package does not have to proper package structure");
     }
     if !moduleTest {
-      writeln('(FAILED) Your package has more than one main module');
+      writeln("(FAILED) Your package has more than one main module");
     }
     if !masonFieldsTest {
-      writeln('(FAILED) Your package has missing fields in manifest file ' +
-              '(Mason.toml)');
+      writeln("(FAILED) Your package has missing fields in manifest file " +
+              "(Mason.toml)");
     }
     if !licenseTest {
-      writeln('(FAILED) Your package does not have valid license name.');
+      writeln("(FAILED) Your package does not have valid license name.");
     }
     if !exampleTest {
-      writeln('(WARNING) Your package does not have examples');
+      writeln("(WARNING) Your package does not have examples");
     }
     if !testTest {
-      writeln('(FAILED) Your package does not have tests');
+      writeln("(FAILED) Your package does not have tests");
     }
     if !remoteTest {
-      writeln('(FAILED) Your package has no remote origin and cannot be ' +
-              'published');
+      writeln("(FAILED) Your package has no remote origin and cannot be " +
+              "published");
     }
     if !gitTagTest {
-      writeln('(FAILED) Your package has invalid git tag version formatting');
+      writeln("(FAILED) Your package has invalid git tag version formatting");
     }
   }
 
@@ -711,7 +711,7 @@ proc check(p: string, ci: bool) throws {
       attemptToBuild();
       exit(0);
     } else {
-      writeln('New package does not have the proper structure.');
+      writeln("New package does not have the proper structure.");
       exit(1);
     }
   }
@@ -763,8 +763,8 @@ private proc checkLicense(projectHome: string) throws {
     // get the license list and validate license identifier
     const licenseList = refreshLicenseList();
     for licenses in licenseList {
-      const licenseName: string = licenses.strip('.txt', trailing=true);
-      if licenseName == defaultLicense || defaultLicense == 'None' {
+      const licenseName: string = licenses.strip(".txt", trailing=true);
+      if licenseName == defaultLicense || defaultLicense == "None" {
         foundValidLicense = true;
         break;
       }
@@ -777,12 +777,12 @@ private proc checkLicense(projectHome: string) throws {
 /* Attempts to build the package/
  */
 private proc attemptToBuild() throws {
-  var sub = spawn(['mason','build','--force'], stdout=pipeStyle.pipe);
+  var sub = spawn(["mason","build","--force"], stdout=pipeStyle.pipe);
   sub.wait();
   if sub.exitCode == 1 {
-    writeln('(FAILED) Please make sure your package builds');
+    writeln("(FAILED) Please make sure your package builds");
   } else {
-    writeln('(PASSED) Package builds successfully.');
+    writeln("(PASSED) Package builds successfully.");
   }
 }
 
@@ -797,33 +797,33 @@ private proc registryPathCheck(p: string,
   if p == MASON_HOME {
     var forkCheck = usernameCheck(username);
     if forkCheck == 0 {
-      writeln('   The mason-registry is forked under username: ' +
-              username + ' (PASSED)');
+      writeln("   The mason-registry is forked under username: " +
+              username + " (PASSED)");
       return true;
     } else {
-      writeln('   You must have a fork of the mason-registry to ' +
-              'publish a package (FAILED)');
+      writeln("   You must have a fork of the mason-registry to " +
+              "publish a package (FAILED)");
       return false;
     }
   } else {
     if trueIfLocal {
-      const isLocalGit = exists(p + '/.git');
-      const hasBricks = exists(p + '/Bricks/');
+      const isLocalGit = exists(p + "/.git");
+      const hasBricks = exists(p + "/Bricks/");
       if !isLocalGit {
-        writeln('   Registry with path ' +
-                p + ' is not a git repository. (FAILED)');
+        writeln("   Registry with path " +
+                p + " is not a git repository. (FAILED)");
         writeln("   Local registries must be git repositories " +
                 "in order to publish");
         return false;
       } else if !hasBricks {
-        writeln('   The registry with path ' +
-                p + ' does not have proper registry structure (FAILED)');
+        writeln("   The registry with path " +
+                p + " does not have proper registry structure (FAILED)");
         writeln("   A registry must have a /Bricks/ " +
                 "directory to be a valid registry");
         return false;
       } else {
-        writeln('   The local registry with path ' +
-                p + ' is a valid registry to be publish too (PASSED)');
+        writeln("   The local registry with path " +
+                p + " is a valid registry to be publish too (PASSED)");
         return true;
       }
     } else {
@@ -836,7 +836,7 @@ private proc registryPathCheck(p: string,
 private proc getRemoteOrigin() throws {
   const packageDir = here.cwd();
   const gitRemoteOrigin =
-    gitC(packageDir, 'git config --get remote.origin.url', true);
+    gitC(packageDir, "git config --get remote.origin.url", true);
   return gitRemoteOrigin;
 }
 
@@ -869,38 +869,38 @@ private proc ensureMasonProject(cwd: string, tomlName="Mason.toml"): bool {
 
 */
 private proc moduleCheck(projectHome : string) throws {
-  const files = listDir(projectHome + '/src', dirs=false),
-        modules = for f in files do if f.endsWith('.chpl') then f;
+  const files = listDir(projectHome + "/src", dirs=false),
+        modules = for f in files do if f.endsWith(".chpl") then f;
   if modules.size != 1 then return false;
-  if modules[0] != getPackageName() + '.chpl' then return false;
+  if modules[0] != getPackageName() + ".chpl" then return false;
   return true;
 }
 
 /* Checks package for examples */
 proc exampleCheck(projectHome: string) throws {
-  if isDir(projectHome + '/example') {
-    const examples = listDir(projectHome + '/example');
+  if isDir(projectHome + "/example") {
+    const examples = listDir(projectHome + "/example");
     return examples.size > 0;
   } else return false;
 }
 
 /* Checks package for tests */
 proc testCheck(projectHome: string) throws {
-  if isDir(projectHome + '/test') {
-    const tests = listDir(projectHome + '/test');
+  if isDir(projectHome + "/test") {
+    const tests = listDir(projectHome + "/test");
     return tests.size > 0;
   } else return false;
 }
 /* Returns the mason env */
 private proc returnMasonEnv() throws {
-  const fakeArgs = ['env'];
+  const fakeArgs = ["env"];
   masonEnv(fakeArgs);
 }
 
 private proc falseIfRemotePath() throws {
   var registryInEnv = MASON_REGISTRY;
   for (_, registry) in registryInEnv {
-    if registry.find(':') != -1 {
+    if registry.find(":") != -1 {
       return false;
     }
   }

--- a/tools/mason/MasonRun.chpl
+++ b/tools/mason/MasonRun.chpl
@@ -99,8 +99,8 @@ proc runProjectBinary(show: bool, release: bool,
   const project = tomlFile["brick.name"]!.s;
 
   // Find the Binary and execute
-  if isDir(joinPath(projectHome, 'target')) {
-    var execs = ' '.join(execopts.these());
+  if isDir(joinPath(projectHome, "target")) {
+    var execs = " ".join(execopts.these());
 
     // decide which binary(release or debug) to run
     var command: list(string);

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -79,18 +79,18 @@ proc masonSearch(args: [] string): int throws {
   if show {
     if pkgs.size == 1 {
       const pkg = pkgs[0];
-      writeln('Displaying the latest version: ' +
-              pkg.name + '@' + pkg.version.str());
-      const brickPath = joinPath(pkg.registry, 'Bricks',
-                                 pkg.name, pkg.version.str() + '.toml');
+      writeln("Displaying the latest version: " +
+              pkg.name + "@" + pkg.version.str());
+      const brickPath = joinPath(pkg.registry, "Bricks",
+                                 pkg.name, pkg.version.str() + ".toml");
       showToml(brickPath);
     } else if pkgs.size == 0 {
       throw new MasonError('"%s" returned no packages\n'.format(query) +
-                           '--show requires the search to return one package');
+                           "--show requires the search to return one package");
     } else if pkgs.size > 1 {
-      var msg = '';
-      if query == '.*' {
-        msg += 'You must specify a package to show the manifest\n';
+      var msg = "";
+      if query == ".*" {
+        msg += "You must specify a package to show the manifest\n";
       } else {
         msg += '"%s"  returned more than one package.\n'.format(query);
       }

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -112,7 +112,7 @@ proc masonTest(args: [] string) throws {
     var flagInArgs = false;
     for arg in otherArgs.values() {
       // try to get option values meant for compilation
-      if flagInArgs && !arg.startsWith('-') {
+      if flagInArgs && !arg.startsWith("-") {
         compopts.pushBack(arg);
         flagInArgs=false;
       } else if isFile(arg) && arg.endsWith(".chpl") {
@@ -122,7 +122,7 @@ proc masonTest(args: [] string) throws {
       } else if isDir(arg) {
         // assume this is a test directory
         dirs.pushBack(arg);
-      } else if arg.startsWith('-') {
+      } else if arg.startsWith("-") {
         // assume a flag for compiler
         compopts.pushBack(arg);
         flagInArgs=true;
@@ -173,7 +173,7 @@ proc masonTest(args: [] string) throws {
           if testName.find(subString) != -1 {
             isSubString = true;
             if inProjectDir {
-              files.pushBack("".join('test/', testName));
+              files.pushBack("".join("test/", testName));
             } else {
               files.pushBack(testName);
             }
@@ -194,8 +194,8 @@ proc masonTest(args: [] string) throws {
       if !searchSubStrings.isEmpty() {
         var testNames: list(string);
 
-        if isDir('.') {
-          var tests = findFiles(startdir='.', recursive=subdir);
+        if isDir(".") {
+          var tests = findFiles(startdir=".", recursive=subdir);
           for test in tests {
             if test.endsWith(".chpl") {
               testNames.pushBack(test);
@@ -230,8 +230,8 @@ private proc runTests(show: bool, run: bool, parallel: bool, filter: string,
 
     // Get project source code and dependencies
     const (sourceList, gitList) = genSourceList(lockFile);
-    const depPath = Path.joinPath(MASON_HOME, 'src');
-    const gitDepPath = Path.joinPath(MASON_HOME, 'git');
+    const depPath = Path.joinPath(MASON_HOME, "src");
+    const gitDepPath = Path.joinPath(MASON_HOME, "git");
 
     getSrcCode(sourceList, skipUpdate, show);
     getGitCode(gitList, skipUpdate, show);
@@ -289,7 +289,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, filter: string,
     }
 
     // get system deps
-    if const pkgDeps = lockFile.get['system'] {
+    if const pkgDeps = lockFile.get["system"] {
       for (_, depInfo) in zip(pkgDeps.A.keys(), pkgDeps.A.values()) {
         for (k,v) in allFields(depInfo!) {
           var val = v!;
@@ -344,7 +344,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, filter: string,
           if customTest then
             testPath = "".join(cwd,"/",test);
           else
-            testPath = "".join('test/', test);
+            testPath = "".join("test/", test);
         }
         log.info("Testing ", testPath);
         const testName = basename(stripExt(test, ".chpl"));
@@ -485,7 +485,7 @@ private proc getTests(lock: borrowed Toml, projectHome: string) throws {
 
   if const testsToml = lock.get("root.tests") {
     var tests = testsToml.toString();
-    var strippedTests = tests.split(',').strip('[]');
+    var strippedTests = tests.split(",").strip("[]");
     for test in strippedTests {
       const t = test.strip().strip('"');
       testNames.pushBack(t);

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -90,8 +90,8 @@ proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock",
 
   var updated = false;
   if tomlPath.isFile() {
-    if TomlFile.pathExists('dependencies') {
-      if force || TomlFile['dependencies']!.A.size > 0 {
+    if TomlFile.pathExists("dependencies") {
+      if force || TomlFile["dependencies"]!.A.size > 0 {
         log.info("Updating registry");
         updateRegistry(skipUpdate, show);
         updated = true;
@@ -108,7 +108,7 @@ proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock",
 
   if !skipUpdate {
     log.info("Will do external update");
-    if isDir(SPACK_ROOT) && TomlFile.pathExists('external') {
+    if isDir(SPACK_ROOT) && TomlFile.pathExists("external") {
       if getSpackVersion() < minSpackVersion then
         throw new MasonError("Mason has been updated. " +
                               "To install Spack, run: mason external --setup.");
@@ -204,7 +204,7 @@ proc updateRegistry(skipUpdate: bool, show=true) throws {
 
     const registryHomePath = registryHome:path;
     if registryHomePath.isDir() {
-      var pullRegistry = 'git pull -q origin';
+      var pullRegistry = "git pull -q origin";
       if show then writeln("Updating ", name);
       gitC(registryHomePath, pullRegistry);
     } else {
@@ -430,8 +430,8 @@ private proc IVRS(A: borrowed Toml, B: borrowed Toml) throws {
 
   if version1 == version2 then return A;
 
-  var vers1 = version1.split('.');
-  var vers2 = version2.split('.');
+  var vers1 = version1.split(".");
+  var vers2 = version2.split(".");
   var v1 = vers1(0): int;
   var v2 = vers2(0): int;
   if vers1(0) != vers2(0) {
@@ -485,7 +485,7 @@ private proc retrieveDep(name: string, version: string) throws {
   }
 
   throw new MasonError("No toml file found in mason-registry for " +
-                       name +'-'+ version);
+                       name +"-"+ version);
 }
 
 /* Returns the Mason.toml for each dep listed as a Toml */
@@ -503,7 +503,7 @@ private proc getGitManifests(
 /* Responsible for parsing the Mason.toml that have been
    already pulled down from git dependencies */
 private proc retrieveGitDep(name: string, branch: string) throws {
-  var baseDir = MASON_HOME +'/git/';
+  var baseDir = MASON_HOME +"/git/";
   const tomlPath = baseDir + "/"+name+"-"+branch+"/Mason.toml";
   if isFile(tomlPath) {
     var tomlFile = open(tomlPath, ioMode.r);
@@ -512,7 +512,7 @@ private proc retrieveGitDep(name: string, branch: string) throws {
   }
 
   stderr.writeln("No toml file found in git dependency for " +
-                 name + '-' + branch);
+                 name + "-" + branch);
   exit(1);
 }
 
@@ -544,8 +544,8 @@ private proc getGitDeps(tomlTbl: Toml) throws {
 }
 
 private proc pullGitDeps(gitDeps, show=false) throws {
-  if !isDir(MASON_HOME + '/git/') {
-    mkdir(MASON_HOME + '/git/', parents=true);
+  if !isDir(MASON_HOME + "/git/") {
+    mkdir(MASON_HOME + "/git/", parents=true);
   }
 
   var gitDepsWithRevision: list((string, string, string, string));
@@ -574,7 +574,7 @@ private proc pullGitDeps(gitDeps, show=false) throws {
     var branch = if origBranch == "" then "HEAD" else origBranch;
     const nameVers = val + "-" + branch;
     const destination = baseDir / nameVers;
-    if !depExists(nameVers, '/git/') {
+    if !depExists(nameVers, "/git/") {
       writef("Downloading dependency: %s\n", nameVers);
       cloneSource(srcURL, destination, quiet=true);
 

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -64,9 +64,9 @@ class MasonError : Error {
 /* Creates the rest of the project structure */
 proc makeTargetFiles(binLoc: string, projectHome: string) throws {
 
-  const target = joinPath(projectHome, 'target');
+  const target = joinPath(projectHome, "target");
   const srcBin = joinPath(target, binLoc);
-  const example = joinPath(target, 'example');
+  const example = joinPath(target, "example");
 
   if !isDir(target) {
     mkdir(target);
@@ -78,7 +78,7 @@ proc makeTargetFiles(binLoc: string, projectHome: string) throws {
     mkdir(example);
   }
 
-  const actualTest = joinPath(projectHome,'test');
+  const actualTest = joinPath(projectHome,"test");
   if isDir(actualTest) {
     // temp var to work around
     // https://github.com/chapel-lang/chapel/issues/27855
@@ -90,7 +90,7 @@ proc makeTargetFiles(binLoc: string, projectHome: string) throws {
       }
     }
   }
-  const test = joinPath(target, 'test');
+  const test = joinPath(target, "test");
   if !isDir(test) {
     mkdir(test);
   }
@@ -363,7 +363,7 @@ record versionInfo {
       when 2 do
         return this.bug;
       otherwise
-        halt('Out of bounds access of versionInfo');
+        halt("Out of bounds access of versionInfo");
     }
   }
 
@@ -637,7 +637,7 @@ proc getMasonDependencies(sourceList: list(srcSource),
 
 /* Checks to see if dependency has already been
    downloaded previously */
-proc depExists(dependency: string, repo='/src/') throws {
+proc depExists(dependency: string, repo="/src/") throws {
   var repos = MASON_HOME + repo;
   var exists = false;
   if !isDir(repos) then
@@ -722,7 +722,7 @@ proc getProjectType(): string throws {
   const tomlFile = parseToml(toParse);
   if const type_ = tomlFile.get("brick.type") then
     return type_.s;
-  throw new MasonError('Type not found in TOML file; '+
+  throw new MasonError("Type not found in TOML file; "+
                        'please add a type="application" key');
 }
 
@@ -853,7 +853,7 @@ proc findLatest(packageDir: string): versionInfo throws {
     const manifestReader = openReader(joinPath(packageDir, manifest),
                                       locking=false);
     const manifestToml = parseToml(manifestReader);
-    const brick = manifestToml['brick'];
+    const brick = manifestToml["brick"];
     var (low, high) = parseChplVersion(brick);
     if chplVersion < low || chplVersion > high then continue;
 
@@ -878,12 +878,12 @@ proc parseChplVersion(
   }
 
   // Assert some expected fields are not nil
-  if brick!.get['name'] == nil || brick!.get['version'] == nil {
+  if brick!.get["name"] == nil || brick!.get["version"] == nil {
     stderr.writeln("Error: Unable to parse manifest file");
     exit(1);
   }
 
-  if brick!.get['chplVersion'] == nil {
+  if brick!.get["chplVersion"] == nil {
     const name = brick!["name"]!.s + "-" + brick!["version"]!.s;
     stderr.writeln("Brick '", name, "' missing required 'chplVersion' field");
     exit(1);

--- a/tools/mason/SpecParser.chpl
+++ b/tools/mason/SpecParser.chpl
@@ -136,13 +136,13 @@ private proc parseSpec(ref tokenList: list(string)): 4*string throws {
     var toke = tokenList.getAndRemove(0);
 
     // Package should be first token
-    if package == '' {
-      const pkgSplit = toke.split('@');
+    if package == "" {
+      const pkgSplit = toke.split("@");
       package = pkgSplit[0];
       packageVersion = pkgSplit[1];
-    } else if reCompilerVersion.match(toke).matched && compilerVersion == '' {
-      const strippedToke = toke.strip('%');
-      const compilerSplit = strippedToke.split('@');
+    } else if reCompilerVersion.match(toke).matched && compilerVersion == "" {
+      const strippedToke = toke.strip("%");
+      const compilerSplit = strippedToke.split("@");
       compiler = compilerSplit[0];
       if compilerSplit.size > 1 {
         // Note: This is currently unused

--- a/tools/mason/rules.py
+++ b/tools/mason/rules.py
@@ -21,6 +21,11 @@ def rules(driver):
         if result.node.quote_style() == '"""':
             return None
         loc = result.node.location()
-        s = result.node.value()
+        s = (
+            result.node.value()
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+        )
         fixit = Fixit.build(Edit.build(loc, '"' + s + '"'))
         return fixit

--- a/tools/mason/rules.py
+++ b/tools/mason/rules.py
@@ -1,3 +1,22 @@
+#
+# Copyright 2026-2026 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import chapel
 from rule_types import BasicRuleResult
 from fixits import Fixit, Edit

--- a/tools/mason/rules.py
+++ b/tools/mason/rules.py
@@ -2,6 +2,7 @@ import chapel
 from rule_types import BasicRuleResult
 from fixits import Fixit, Edit
 
+
 def rules(driver):
 
     @driver.basic_rule(chapel.StringLikeLiteral)

--- a/tools/mason/rules.py
+++ b/tools/mason/rules.py
@@ -1,0 +1,25 @@
+import chapel
+from rule_types import BasicRuleResult
+from fixits import Fixit, Edit
+
+def rules(driver):
+
+    @driver.basic_rule(chapel.StringLikeLiteral)
+    def OnlyDoubleQuote(_, node: chapel.StringLikeLiteral):
+        if node.quote_style() != '"' and node.quote_style() != '"""':
+            # if the string contains a double quote, its ok
+            # single quotes used to avoid escaping
+            if node.value().find('"') != -1:
+                return True
+            return BasicRuleResult(node, ignorable=False)
+        else:
+            return True
+
+    @driver.fixit(OnlyDoubleQuote)
+    def OnlyDoubleQuoteFixit(context: chapel.Context, result: BasicRuleResult):
+        if result.node.quote_style() == '"""':
+            return None
+        loc = result.node.location()
+        s = result.node.value()
+        fixit = Fixit.build(Edit.build(loc, '"' + s + '"'))
+        return fixit


### PR DESCRIPTION
This PR makes using double quotes for strings in Mason sources a requirement

This is motivated by me being frustrated that Mason inconsistently uses both `''` and `""` for strings. I picked `""` for the style for mason, and it is enforced by a custom linter rule. The changes in this PR were made using the fixit for the rule.

[Reviewed by @benharsh]