### PR TITLE
Switch TomlError to properly use Error superclass

### DIFF
--- a/modules/packages/TOML.chpl
+++ b/modules/packages/TOML.chpl
@@ -105,15 +105,9 @@ module TOML {
     return tomlData;
   }
 
-
-  class TomlError : Error {
-
-    var msg:string;
-    proc init(msg:string) {
-      this.msg = msg;
-    }
-    override proc message() {
-      return msg;
+  class TomlError: Error {
+    proc init(msg: string) {
+      super.init(msg);
     }
   }
 


### PR DESCRIPTION
Switches the TomlError class to properly use the Error superclass

[Reviewed by @benharsh]