### PR TITLE
Fix `mason doc` with heavily nested modules

### DIFF
--- a/test/mason/cloneFallback.good
+++ b/test/mason/cloneFallback.good
@@ -1,7 +1,7 @@
-mason utils: Cloning from git@github.com:unknown/repo.git to (pathStr = dummy)
+mason utils: Cloning from git@github.com:unknown/repo.git to path(dummy)
 mason utils: runWithStatus (quiet=true, capture=true): git clone --quiet git@github.com:unknown/repo.git dummy
-mason utils: Failed to clone from git@github.com:unknown/repo.git to (pathStr = dummy)
+mason utils: Failed to clone from git@github.com:unknown/repo.git to path(dummy)
 mason utils: Retrying with https url: https://github.com/unknown/repo.git
 mason utils: runWithStatus (quiet=true, capture=true): git clone --quiet https://github.com/unknown/repo.git dummy
-mason utils: Failed to clone from https://github.com/unknown/repo.git to (pathStr = dummy)
+mason utils: Failed to clone from https://github.com/unknown/repo.git to path(dummy)
 Failed to clone from git@github.com:unknown/repo.git

--- a/test/mason/mason-doc/Pkg/src/Pkg/Included.chpl
+++ b/test/mason/mason-doc/Pkg/src/Pkg/Included.chpl
@@ -1,3 +1,5 @@
 module Included {
   writeln("Included module");
+  include module Sub;
+  public use Sub;
 }

--- a/test/mason/mason-doc/Pkg/src/Pkg/Included/Sub.chpl
+++ b/test/mason/mason-doc/Pkg/src/Pkg/Included/Sub.chpl
@@ -1,0 +1,3 @@
+module Sub {
+
+}

--- a/test/mason/mason-doc/docPkg.masontest
+++ b/test/mason/mason-doc/docPkg.masontest
@@ -14,6 +14,10 @@ checkforfiles() {
     echo "Error: expected to find $dir/Included.rst.txt but it does not exist"
     exit 1
   fi
+  if [ ! -f "$dir/Pkg/Included/Sub.rst.txt" ]; then
+    echo "Error: expected to find $dir/Included/Sub.rst.txt but it does not exist"
+    exit 1
+  fi
   if [ -f "$dir/FileSystem.rst.txt" ]; then
     echo "Error: expected not to find $dir/FileSystem.rst.txt but it exists"
     exit 1

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -86,7 +86,7 @@ proc masonDoc(args: [] string) throws {
       command.pushBack("--project-copyright-year=" + copyrightYear);
     }
     const srcFiles = [f in srcDir.findFiles(recursive=true)]
-                        if f.suffix == ".chpl" then (srcDir / f):string;
+                        if f.suffix == ".chpl" then f:string;
     command.pushBack(srcFiles);
     command.pushBack([
       "-o",

--- a/tools/mason/MasonDoc.chpl
+++ b/tools/mason/MasonDoc.chpl
@@ -29,6 +29,9 @@ use MasonUtils;
 import MasonLogger;
 use List only list;
 
+import ThirdParty.Pathlib.path;
+use ThirdParty.Pathlib.IOHelpers;
+
 private var log = MasonLogger.getLogger("mason doc");
 
 proc masonDoc(args: [] string) throws {
@@ -38,12 +41,10 @@ proc masonDoc(args: [] string) throws {
   parser.parseArgs(args);
 
   const tomlName = "Mason.toml";
-  const cwd = here.cwd();
+  const projectHome = getProjectHome(path.cwd(), tomlName);
+  const tomlPath = projectHome / tomlName;
 
-  const projectHome = getProjectHome(cwd, tomlName);
-  const tomlPath = projectHome + "/" + tomlName;
-
-  const toParse = open(projectHome + "/" + tomlName, ioMode.r);
+  const toParse = open(tomlPath, ioMode.r);
   var tomlFile = parseToml(toParse);
 
   const projectName = tomlFile["brick.name"]!.s;
@@ -67,10 +68,11 @@ proc masonDoc(args: [] string) throws {
     copyrightYear = copyrightToml.s;
   }
 
-  if isDir(projectHome + "/src/") &&
-      isFile(projectHome + "/src/" + projectFile) {
+  const srcDir = "src":path;
+  const absSrcDir = projectHome / "src";
+  if absSrcDir.isDir() && (absSrcDir / projectFile).isFile() {
     // Must use relative paths with chpldoc to prevent baking in abs paths
-    here.chdir(projectHome);
+    projectHome.chdir();
 
     var command = new list([
       "chpldoc",
@@ -83,8 +85,8 @@ proc masonDoc(args: [] string) throws {
     if copyrightYear != "" {
       command.pushBack("--project-copyright-year=" + copyrightYear);
     }
-    const srcFiles =
-      [f in listDir("src/")] if f.endsWith(".chpl") then "src/" + f;
+    const srcFiles = [f in srcDir.findFiles(recursive=true)]
+                        if f.suffix == ".chpl" then (srcDir / f):string;
     command.pushBack(srcFiles);
     command.pushBack([
       "-o",

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -483,10 +483,13 @@ proc gitC(newDir:path, command, quiet=false): string throws {
 }
 
 proc getProjectHome(cwd: string, tomlName="Mason.toml"): string throws {
-  var dir = cwd:path;
+  return getProjectHome(cwd:path, tomlName):string;
+}
+proc getProjectHome(cwd: path, tomlName="Mason.toml"): path throws {
+  var dir = cwd;
   while true {
-    if (dir/tomlName).exists() then
-      return dir:string;
+    if (dir / tomlName).exists() then
+      return dir;
     if dir:string == "/" then
       throw new MasonError("Mason could not find your " +
                            "configuration file (Mason.toml)");
@@ -494,7 +497,7 @@ proc getProjectHome(cwd: string, tomlName="Mason.toml"): string throws {
   }
   throw new MasonError("Mason could not find your " +
                        "configuration file (Mason.toml)");
-  return ""; // should never reach here
+  return new path(); // should never reach here
 }
 
 proc getLastModified(filename: string) : int {

--- a/tools/mason/ThirdParty/masonDeps.txt
+++ b/tools/mason/ThirdParty/masonDeps.txt
@@ -1,4 +1,4 @@
 TemplateString.chpl@https://raw.githubusercontent.com/jabraham17/TemplateString/refs/tags/v0.1.0/src/TemplateString.chpl@fd58c3e4a10fbc5921151ea03e343fc8bcee4e2822100562ce7145e3202f8197
-Pathlib.chpl@https://raw.githubusercontent.com/jabraham17/Pathlib/refs/tags/v0.2.0/src/Pathlib.chpl@b20eb4a4b9fb612763351cd834f1356c0aa70c188514fef1f8c88f0f004e5a7c
+Pathlib.chpl@https://raw.githubusercontent.com/jabraham17/Pathlib/refs/tags/v0.3.0/src/Pathlib.chpl@086f3d7ebbfd21b0b2d2c3ef1b23b6885ca9153204dbcaa8394303f842ce563f
 Log.chpl@https://raw.githubusercontent.com/jabraham17/Log/refs/tags/v0.1.0/src/Log.chpl@be217a0b50ce926a9e4118bebe4d61798e259ccb3e02ca4b25ef6660e1dbb0d7
 TerminalColors.chpl@https://raw.githubusercontent.com/jabraham17/TerminalColors/refs/tags/v0.1.0/src/TerminalColors.chpl@93d8d103483382459452181ae72303ce3f7faaef39b351b949447f9fdb660631


### PR DESCRIPTION
Fixes an issue where `mason doc` would not properly generate documentation for all files

- [x] paratest

[Reviewed by @arifthpe]