### PR TITLE
Expand output of mason modules

### DIFF
--- a/test/mason/mason-modules/modules.good
+++ b/test/mason/mason-modules/modules.good
@@ -35,7 +35,12 @@ Checking out specified revision for myNewGitDep-HEAD...
 $CWD/mason_home/src/myNewDep-0.1.0/src/myNewDep.chpl $CWD/mason_home/git/myNewGitDep-HEAD/src/myNewGitDep.chpl
 mason modules --no-update --format=json
 Checking out specified revision for myNewGitDep-HEAD...
-{"modules":["$CWD/mason_home/src/myNewDep-0.1.0/src/myNewDep.chpl","$CWD/mason_home/git/myNewGitDep-HEAD/src/myNewGitDep.chpl"]}
+{
+  "tests": [], 
+  "sources": ["$CWD/myPackage/src/myPackage.chpl"], 
+  "modules": ["$CWD/mason_home/src/myNewDep-0.1.0/src/myNewDep.chpl", "$CWD/mason_home/git/myNewGitDep-HEAD/src/myNewGitDep.chpl"], 
+  "examples": []
+}
 mason modules --no-update with no lock file, should error
 Cannot skip update without an existing lock file.
 error as expected: 1
@@ -43,4 +48,9 @@ mason modules without --no-update should recreate it
 Fetching latest changes for: myNewGitDep-HEAD...
 Checking out specified revision for myNewGitDep-HEAD...
 Checking out specified revision for myNewGitDep-HEAD...
-{"modules":["$CWD/mason_home/src/myNewDep-0.1.0/src/myNewDep.chpl","$CWD/mason_home/git/myNewGitDep-HEAD/src/myNewGitDep.chpl"]}
+{
+  "tests": [], 
+  "sources": ["$CWD/myPackage/src/myPackage.chpl"], 
+  "modules": ["$CWD/mason_home/src/myNewDep-0.1.0/src/myNewDep.chpl", "$CWD/mason_home/git/myNewGitDep-HEAD/src/myNewGitDep.chpl"], 
+  "examples": []
+}

--- a/tools/mason/MasonExample.chpl
+++ b/tools/mason/MasonExample.chpl
@@ -163,7 +163,7 @@ private proc getBuildInfo(projectHome: path,
   }
 
   // get the example names from lockfile or from example directory
-  const exampleNames = getExamples(tomlFile.borrow(), projectHome:string);
+  const exampleNames = getExamples(tomlFile.borrow(), projectHome);
 
   var sourceList: list(srcSource);
   var gitList: list(gitSource);
@@ -346,9 +346,9 @@ private proc runExampleBinary(projectHome: string, exampleName: string,
   const exampleResult = runWithStatus(command.toArray(), capture=false);
 }
 
-private proc getExamples(toml: Toml, projectHome: string) throws {
+proc getExamples(toml: Toml, projectHome: path) throws {
   var exampleNames: list(string);
-  const examplePath = joinPath(projectHome, "example");
+  const examplePath = projectHome / "example";
 
   if const examplesToml = toml.get("examples.examples") {
     var examples = examplesToml.toString();
@@ -358,12 +358,11 @@ private proc getExamples(toml: Toml, projectHome: string) throws {
       exampleNames.pushBack(t);
     }
     return exampleNames;
-  } else if isDir(examplePath) {
-    var examples = findFiles(startdir=examplePath,
-                             recursive=true, hidden=false);
+  } else if examplePath.isDir() {
+    var examples = examplePath.findFiles(recursive=true, hidden=false);
     for example in examples {
-      if example.endsWith(".chpl") {
-        exampleNames.pushBack(getExamplePath(example));
+      if example.suffix == ".chpl" {
+        exampleNames.pushBack(relPath(example:string, examplePath:string));
       }
     }
     return exampleNames;
@@ -371,26 +370,10 @@ private proc getExamples(toml: Toml, projectHome: string) throws {
   return exampleNames;
 }
 
-/* Gets the path of the example by following the example dir */
-proc getExamplePath(fullPath: string, examplePath = "") : string {
-  var split = splitPath(fullPath);
-  if split[1] == "example" {
-    return examplePath;
-  } else {
-    if examplePath == "" {
-      return getExamplePath(split[0], split[1]);
-    } else {
-      var appendedPath = joinPath(split[1], examplePath);
-      return getExamplePath(split[0], appendedPath);
-    }
-  }
-}
-
 // used when user calls `mason run --example` without argument
 proc printAvailableExamples() throws {
-  const cwd = here.cwd();
-  const projectHome = getProjectHome(cwd);
-  const toParse = open(projectHome + "/Mason.toml", ioMode.r);
+  const projectHome = getProjectHome(path.cwd());
+  const toParse = open(projectHome / "Mason.toml", ioMode.r);
   const toml = parseToml(toParse);
   const examples = getExamples(toml, projectHome);
   writeln("--- available examples ---");

--- a/tools/mason/MasonModules.chpl
+++ b/tools/mason/MasonModules.chpl
@@ -31,9 +31,12 @@ use MasonEnv;
 use MasonBuild;
 use Subprocess;
 use MasonUpdate;
+import MasonExample;
+import MasonTest;
 use TOML;
 import Path.joinPath;
 import ThirdParty.Pathlib.path;
+use ThirdParty.Pathlib.IOHelpers;
 
 enum OutputFormat {
   json,
@@ -55,8 +58,6 @@ proc masonModules(args: [] string) throws {
   var updateFlag = parser.addFlag(name="update", flagInversion=true);
   var formatFlag = parser.addOption(name="format", defaultValue="text");
 
-  var passArgs = parser.addPassThrough();
-
   parser.parseArgs(args);
 
   var skipUpdate = MASON_OFFLINE;
@@ -75,13 +76,11 @@ proc masonModules(args: [] string) throws {
   if !isDir(MASON_HOME) {
     mkdir(MASON_HOME, parents=true);
   }
-  const configNames = updateLock(skipUpdate, show=false);
-  const tomlName = configNames[0];
-  const lockName = configNames[1];
+  const (tomlName, lockName) = updateLock(skipUpdate, show=false);
 
-  const cwd = here.cwd():path;
-  const toParse = open((cwd / lockName):string, ioMode.r);
-  var lockFile = parseToml(toParse);
+  const projectHome = getProjectHome(path.cwd());
+  var tomlFile = parseToml(open(projectHome / tomlName, ioMode.r));
+  var lockFile = parseToml(open(projectHome / lockName, ioMode.r));
 
   // generate list of dependencies and get src code
   var (sourceList, gitList) = genSourceList(lockFile);
@@ -108,6 +107,17 @@ proc masonModules(args: [] string) throws {
     modules.pushBack(gitDepSrc);
   }
 
+  const srcPath = projectHome / "src";
+  const testPath = projectHome / "test";
+  const examplePath = projectHome / "example";
+  const sources = [f in srcPath.findFiles(recursive=true)]
+                    if f.suffix == ".chpl" then f;
+
+  const tests =
+    [f in MasonTest.getTests(lockFile, projectHome)] testPath / f;
+  const examples =
+    [f in MasonExample.getExamples(tomlFile, projectHome)] examplePath / f;
+
   select outputFormat {
     when OutputFormat.text {
       var sep = "";
@@ -118,14 +128,13 @@ proc masonModules(args: [] string) throws {
       writeln();
     }
     when OutputFormat.json {
-      var jsonModules = "{\"modules\":[";
-      var sep = "";
-      for m in modules {
-        jsonModules += sep + "\"" + m:string + "\"";
-        sep = ",";
-      }
-      jsonModules += "]}";
-      writeln(jsonModules);
+      import JSON;
+      var jsonObj = new map(string, list(string));
+      jsonObj["modules"] = new list([m in modules] m:string);
+      jsonObj["sources"] = new list([s in sources] s:string);
+      jsonObj["tests"] = new list([t in tests] t:string);
+      jsonObj["examples"] = new list([e in examples] e:string);
+      stdout.withSerializer(new JSON.jsonSerializer()).writeln(jsonObj);
     }
     otherwise {
       // this should be impossible since we check the output format above

--- a/tools/mason/MasonTest.chpl
+++ b/tools/mason/MasonTest.chpl
@@ -313,7 +313,7 @@ private proc runTests(show: bool, run: bool, parallel: bool, filter: string,
     var testsCompiled: list(string, parSafe=true);
     // get the test names from lockfile or from test directory
     if files.size == 0 && dirs.size == 0 {
-      testNames = getTests(lockFile.borrow(), projectHome);
+      testNames = getTests(lockFile.borrow(), projectHome:path);
       numTests = testNames.size;
     } else {
       try! {
@@ -479,9 +479,9 @@ private proc printTestResults(ref result, timeElapsed) {
 }
 
 
-private proc getTests(lock: borrowed Toml, projectHome: string) throws {
+proc getTests(lock: borrowed Toml, projectHome: path) throws {
   var testNames: list(string);
-  const testPath = joinPath(projectHome, "test");
+  const testPath = projectHome / "test";
 
   if const testsToml = lock.get("root.tests") {
     var tests = testsToml.toString();
@@ -490,11 +490,11 @@ private proc getTests(lock: borrowed Toml, projectHome: string) throws {
       const t = test.strip().strip('"');
       testNames.pushBack(t);
     }
-  } else if isDir(testPath) {
-    var tests = findFiles(startdir=testPath, recursive=true, hidden=false);
+  } else if testPath.isDir() {
+    var tests = testPath.findFiles(recursive=true, hidden=false);
     for test in tests {
-      if test.endsWith(".chpl") {
-        testNames.pushBack(getTestPath(test));
+      if test.suffix == ".chpl" {
+        testNames.pushBack(relPath(test:string, testPath:string));
       }
     }
   }


### PR DESCRIPTION
Expands the output of `mason modules` to include more information

- [x] paratest

Relies on https://github.com/chapel-lang/chapel/pull/28726

[Reviewed by @DanilaFe]