### PR TITLE
Fix bug when accessing a class field by name using Reflection

### DIFF
--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -158,7 +158,7 @@ proc getField(const ref obj:?t, param name: string) type
 pragma "unsafe"
 pragma "suppress generic actual warning"
 inline proc getField(const ref obj:?t, param name:string) const ref {
-  param i = __primitive("field name to num", t, name);
+  param i = __primitive("field name to num", checkQueryT(t), name);
   if i == -1 then
     compilerError("field ", name, " not found in ", t:string);
   return __primitive("field by num", obj, i);
@@ -250,8 +250,7 @@ inline proc getFieldRef(x: borrowed, param i:int) ref {
 pragma "unsafe"
 @unstable(reason="'getFieldRef' is unstable")
 proc getFieldRef(ref x:?t, param s:string) ref {
-  checkValidQueryT(t);
-  param i = __primitive("field name to num", t, s);
+  param i = __primitive("field name to num", checkQueryT(t), s);
   if i == -1 then
     compilerError("field ", s, " not found in ", t:string);
   if isType(__primitive("field by num", x, i)) then

--- a/test/library/standard/Reflection/getField-managed.chpl
+++ b/test/library/standard/Reflection/getField-managed.chpl
@@ -4,7 +4,9 @@ proc test(in obj) {
   writeln("  getNumFields    ", getNumFields(obj.type)         :string);
   writeln("  getFieldName    ", getFieldName(obj.type, 5)             );
   writeln("  getField        ", getField(obj, 5)               :string);
-  writeln("  getFieldRef     ", getFieldRef(obj, 5)             :string);
+  writeln("  getField        ", getField(obj, "f6")            :string);
+  writeln("  getFieldRef     ", getFieldRef(obj, 5)            :string);
+  writeln("  getFieldRef     ", getFieldRef(obj, "f6")         :string);
   writeln("  hasField        ", hasField(obj.type, "f6")       :string);
   writeln("  getFieldIndex   ", getFieldIndex(obj.type, "f6")  :string);
   writeln("  isFieldBound 5  ", isFieldBound(obj.type, 5)      :string);

--- a/test/library/standard/Reflection/getField-managed.good
+++ b/test/library/standard/Reflection/getField-managed.good
@@ -2,6 +2,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5
@@ -11,6 +13,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5
@@ -20,6 +24,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5
@@ -29,6 +35,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5
@@ -38,6 +46,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5
@@ -47,6 +57,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5
@@ -56,6 +68,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5
@@ -65,6 +79,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5
@@ -74,6 +90,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5
@@ -83,6 +101,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5
@@ -92,6 +112,8 @@
   getNumFields    6
   getFieldName    f6
   getField        17
+  getField        17
+  getFieldRef     17
   getFieldRef     17
   hasField        true
   getFieldIndex   5


### PR DESCRIPTION
Fixes a bug when accessing a class field by name using Reflection, due to a missing check

- [x] paratest

[Reviewed by @dlongnecke-cray]