### PR TITLE
Add runtime warning when hybrid memory registration is not available

### DIFF
--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -2567,6 +2567,8 @@ void init_ofiEp(void) {
       } else {
         DBG_PRINTF(DBG_PROV, "fi_open_ops failed: %s", fi_strerror(rc));
       }
+#else
+      chpl_warning("The Chapel runtime was built without enhanced CXI support. Make sure your libfabric was built using `--enable-cxi`.", 0, 0);
 #endif
     }
     if (cxiHybridMRMode) {


### PR DESCRIPTION
Adds a runtime warning when hybrid memory registration is not available on Cray EX.

Users can get into this situation if they do the following
* Build the runtime with CHPL_LIBFABRIC=bundled on Cray EX (already warned about)
* Build the runtime with CHPL_LIBFABRIC=system, where that libfabric was not properly built to support CXI

This warning occurs when a program is run. With more work, this check could be moved to a compile time check.

[Reviewed by @arifthpe]