### PR TITLE
Skip baseline testing due to internal error

### DIFF
--- a/test/edition/preview/FileSystemIters.skipif
+++ b/test/edition/preview/FileSystemIters.skipif
@@ -1,0 +1,1 @@
+COMPOPTS <= --baseline


### PR DESCRIPTION
Skips baseline testing for a test due to internal errors

[Not reviewed - trivial]