### PR TITLE
Add test for code that previously resulted in an internal error

### DIFF
--- a/test/errors/issue-21289.chpl
+++ b/test/errors/issue-21289.chpl
@@ -1,0 +1,11 @@
+module foo {
+    record bar_t{
+        var a: int;
+    }
+    proc bar(x: int){
+        return x;
+    }
+}
+
+foo.bar.t;
+foo.bar_t;

--- a/test/errors/issue-21289.good
+++ b/test/errors/issue-21289.good
@@ -1,0 +1,2 @@
+issue-21289.chpl:10: error: unresolved call 'proc(x: int): int.t'
+issue-21289.chpl:10: note: because no functions named t found in scope


### PR DESCRIPTION
Adds the reproducer for https://github.com/chapel-lang/chapel/issues/21289, which now gets a nice error

Resolves https://github.com/chapel-lang/chapel/issues/21289

[Not reviewed - trivial]