### PR TITLE
Replace Mason's custom versionInfo record

### DIFF
--- a/test/mason/chplVersion/tomls/format/badFormatNum.good
+++ b/test/mason/chplVersion/tomls/format/badFormatNum.good
@@ -1,9 +1,1 @@
-Invalid chplVersion in package 'badFormatNum-0.1.0': 1.x.x
-Details: Invalid Chapel version format: 1.x.x
-
-chplVersion format must be '<version>..<version>' or '<version>'
-A <version> must be in one of the following formats:
-  x.x.x
-  x.x
-where 'x' is a positive integer.
-
+Invalid chplVersion of '1.x.x' in package 'badFormatNum-0.1.0': Invalid Chapel version format '1.x.x', must be either 'major.minor.update' or 'major.minor'

--- a/test/mason/chplVersion/tomls/format/badRangeFormat.good
+++ b/test/mason/chplVersion/tomls/format/badRangeFormat.good
@@ -1,9 +1,1 @@
-Invalid chplVersion in package 'badRangeFormat-0.1.0': 1.1..1.2..1.3
-Details: Expecting 1 or 2 versions in chplVersion range.
-
-chplVersion format must be '<version>..<version>' or '<version>'
-A <version> must be in one of the following formats:
-  x.x.x
-  x.x
-where 'x' is a positive integer.
-
+Invalid chplVersion of '1.1..1.2..1.3' in package 'badRangeFormat-0.1.0': 'chplVersion' must be '<version>..<version>' or '<version>'

--- a/test/mason/chplVersion/tomls/format/badRangeOrder.good
+++ b/test/mason/chplVersion/tomls/format/badRangeOrder.good
@@ -1,2 +1,1 @@
-Invalid chplVersion in package 'badRangeOrder-0.1.0': 1.10..1.1
-Details: Lower bound of chplVersion must be <= upper bound: 1.10.0 > 1.1.0
+Invalid chplVersion of '1.10..1.1' in package 'badRangeOrder-0.1.0': Lower bound of chplVersion must be <= upper bound: 1.10.0 > 1.1.0

--- a/test/mason/chplVersion/tomls/format/badVersion.good
+++ b/test/mason/chplVersion/tomls/format/badVersion.good
@@ -1,9 +1,1 @@
-Invalid chplVersion in package 'badVersion-0.1.0': 1.2.3.4.5
-Details: Invalid Chapel version format: 1.2.3.4.5
-
-chplVersion format must be '<version>..<version>' or '<version>'
-A <version> must be in one of the following formats:
-  x.x.x
-  x.x
-where 'x' is a positive integer.
-
+Invalid chplVersion of '1.2.3.4.5' in package 'badVersion-0.1.0': Invalid Chapel version format '1.2.3.4.5', must be either 'major.minor.update' or 'major.minor'

--- a/test/mason/chplVersion/tomls/format/unboundedLower.good
+++ b/test/mason/chplVersion/tomls/format/unboundedLower.good
@@ -1,9 +1,1 @@
-Invalid chplVersion in package 'unboundedLower-0.1.0': ..1.99
-Details: Unbounded chplVersion ranges are not allowed.
-
-chplVersion format must be '<version>..<version>' or '<version>'
-A <version> must be in one of the following formats:
-  x.x.x
-  x.x
-where 'x' is a positive integer.
-
+Invalid chplVersion of '..1.99' in package 'unboundedLower-0.1.0': Unbounded chplVersion ranges are not allowed. 'chplVersion' must be '<version>..<version>' or '<version>'

--- a/test/mason/chplVersion/tomls/format/unboundedUpper.good
+++ b/test/mason/chplVersion/tomls/format/unboundedUpper.good
@@ -1,9 +1,1 @@
-Invalid chplVersion in package 'unboundedUpper-0.1.0': 1.0..
-Details: Unbounded chplVersion ranges are not allowed.
-
-chplVersion format must be '<version>..<version>' or '<version>'
-A <version> must be in one of the following formats:
-  x.x.x
-  x.x
-where 'x' is a positive integer.
-
+Invalid chplVersion of '1.0..' in package 'unboundedUpper-0.1.0': Unbounded chplVersion ranges are not allowed. 'chplVersion' must be '<version>..<version>' or '<version>'

--- a/test/mason/mason-external/githubConnectivityCheck
+++ b/test/mason/mason-external/githubConnectivityCheck
@@ -2,7 +2,7 @@
 
 # Skip this test if we cannot connect to github, which is required to
 # run the test
-ping -c 1 github.com &> /dev/null
+curl -I https://github.com &> /dev/null
 status=$?
 if ! [ $status -eq 0 ]; then
   echo "True"

--- a/test/mason/mason-external/versionInfoCompare.chpl
+++ b/test/mason/mason-external/versionInfoCompare.chpl
@@ -1,12 +1,12 @@
-use MasonExternal;
 use MasonUtils;
+import Version;
 
-var v1 = new versionInfo("0.15.0");
-var v2 = new versionInfo("0.16.0");
-var v3 = new versionInfo("0.15.1");
-var v4 = new versionInfo("1.15.0");
-var v5 = new versionInfo("1.0.0");
-var v6 = new versionInfo("0.0.9");
+var v1 = Version.version.fromString("0.15.0");
+var v2 = Version.version.fromString("0.16.0");
+var v3 = Version.version.fromString("0.15.1");
+var v4 = Version.version.fromString("1.15.0");
+var v5 = Version.version.fromString("1.0.0");
+var v6 = Version.version.fromString("0.0.9");
 
 // same major, lower minor, same patch
 // should output true

--- a/test/mason/mason-test-exit/exitCodeTest.skipif
+++ b/test/mason/mason-test-exit/exitCodeTest.skipif
@@ -2,7 +2,7 @@
 
 # Skip this test if we cannot connect to github, which is required to
 # run the test
-ping -c 1 github.com &> /dev/null
+curl -I https://github.com &> /dev/null
 status=$?
 if ! [ $status -eq 0 ]; then
   echo "True"

--- a/test/mason/masonUpdateTest.chpl
+++ b/test/mason/masonUpdateTest.chpl
@@ -14,7 +14,7 @@ proc main() throws {
   // passing anything to UpdateLock we need to replace that sentinel with the
   // actual current version.
 
-  const currentVersion = getChapelVersionStr();
+  const currentVersion = getChapelVersionInfo():string;
 
   // file.good -> file.lock
   const lf = goodLock.replace('good', 'lock');

--- a/test/mason/masonUpdateTest.skipif
+++ b/test/mason/masonUpdateTest.skipif
@@ -2,7 +2,7 @@
 
 # Skip this test if we cannot connect to github, which is required to
 # run the test
-ping -c 1 github.com &> /dev/null
+curl -I https://github.com &> /dev/null
 status=$?
 if ! [ $status -eq 0 ]; then
   echo "True"

--- a/test/mason/pkgconfig-tests/pcTest.chpl
+++ b/test/mason/pkgconfig-tests/pcTest.chpl
@@ -10,7 +10,7 @@ proc test(goodLock: string, tf: string) {
   // passing anything to updateLock we need to replace that sentinel with the
   // actual current version.
 
-  const currentVersion = getChapelVersionStr();
+  const currentVersion = getChapelVersionInfo():string;
 
   // file.good -> file.lock
   const lf = goodLock.replace('good', 'lock');

--- a/tools/mason/Manifest.chpl
+++ b/tools/mason/Manifest.chpl
@@ -59,7 +59,7 @@ proc type manifestFile.defaultNewPkg(name: string,
   var b = new manifestFile();
   b.name = name;
   b.version = "0.1.0";
-  b.chplVersion = MasonUtils.getChapelVersionStr();
+  b.chplVersion = MasonUtils.getChapelVersionInfo():string;
   b.license = "None";
   b.pkgType = pkgType;
   return b;

--- a/tools/mason/MasonBuild.chpl
+++ b/tools/mason/MasonBuild.chpl
@@ -547,7 +547,7 @@ proc computeFingerprint(
 ): string throws {
   var fingerprint = "";
   fingerprint += "MasonVersion=" + MASON_VERSION + "\n";
-  fingerprint += "ChapelVersion=" + getChapelVersionStr() + "\n";
+  fingerprint += "ChapelVersion=" + getChapelVersionInfo():string + "\n";
   fingerprint += printChplEnv();
   fingerprint += getInterestingEnvVars();
   fingerprint += "cmdline_compopts=" +

--- a/tools/mason/MasonExternal.chpl
+++ b/tools/mason/MasonExternal.chpl
@@ -25,6 +25,7 @@ use ArgumentParser;
 use FileSystem;
 use List;
 use Map;
+import Version;
 use MasonEnv;
 use MasonHelp;
 use MasonUtils;
@@ -37,7 +38,7 @@ import ThirdParty.Pathlib.path;
 private var log = MasonLogger.getLogger("mason external");
 
 // We could consider bumping this version up as needed.
-const minSpackVersion = new versionInfo(1, 0, 0);
+const minSpackVersion = new Version.version(1, 0, 0);
 const major = minSpackVersion.major:string;
 const minor = minSpackVersion.minor:string;
 const spackBranch = "releases/v" + ".".join(major, minor);
@@ -136,8 +137,8 @@ proc masonExternal(args: [] string) throws {
       if getSpackVersion() <= minSpackVersion then
         throw new MasonError("Spack update or installation failed. " +
                              "Expected v%s, got v%s".format(
-                                minSpackVersion.str(),
-                                getSpackVersion().str()));
+                                minSpackVersion:string,
+                                getSpackVersion():string));
       exit(0);
     }
     if spackInstalled() {
@@ -190,14 +191,14 @@ proc spackInstalled() throws {
   // if local spack version is lower than required version
   if getSpackVersion() < minSpackVersion && SPACK_ROOT == spackDefaultPath {
     throw new MasonError("Mason has been updated and requires a newer " +
-          "version of Spack (%s).".format(minSpackVersion.str()) +
+          "version of Spack (%s).".format(minSpackVersion:string) +
           "\nTo use mason external, call: mason external --setup");
   }
   // if local version is a major or minor version higher than required version
   if !minSpackVersion.isCompatible(getSpackVersion()) {
     log.warnf("Your version of Spack (v%s) differs from that supported by " +
               "Mason (v%s).\nThis may lead to unexpected behavior",
-              getSpackVersion().str(), minSpackVersion.str());
+              getSpackVersion():string, minSpackVersion:string);
   }
   return true;
 }
@@ -206,7 +207,7 @@ proc spackInstalled() throws {
 proc setupSpack() throws {
   writeln("Installing Spack backend ...");
   const destCLI = MASON_HOME:path / "spack";
-  const spackLatestBranch = "v" + minSpackVersion.str();
+  const spackLatestBranch = "v" + minSpackVersion:string;
   const destPackages = MASON_HOME: path / "spack-registry";
   const spackMasterBranch = "releases/latest";
   const statusCLI = cloneSpackRepository(spackLatestBranch, destCLI);
@@ -250,7 +251,7 @@ proc gitFetch(branch: string) {
 
 /* Updates the spack directory used for spack commands */
 private proc updateSpackCommandLine() {
-  const releaseTag = "v" + minSpackVersion.str();
+  const releaseTag = "v" + minSpackVersion:string;
   var tag = "refs/tags/" + releaseTag;
   tag = tag + ":" + tag;
   const statusFetch = gitFetch(tag);
@@ -288,7 +289,7 @@ private proc printSpackVersion() {
 }
 
 /* Returns spack version */
-proc getSpackVersion(): versionInfo throws {
+proc getSpackVersion(): Version.version throws {
   const command = "spack --version";
   @functionStatic
   ref tmpVersion = getSpackResult(command,true).strip();
@@ -297,7 +298,7 @@ proc getSpackVersion(): versionInfo throws {
   // partitioning the string allows us to separate the major.minor.bug
   // from the remaining values
   const version = tmpVersion.partition(" ");
-  return new versionInfo(version[0]);
+  return Version.version.fromString(version[0]);
 }
 
 /* Lists available spack packages */

--- a/tools/mason/MasonSearch.chpl
+++ b/tools/mason/MasonSearch.chpl
@@ -72,7 +72,7 @@ proc masonSearch(args: [] string): int throws {
   sort(pkgs, comparator=new pkgComparator(query));
 
   for package in pkgs {
-    writef("%s (%s)\n", package.name, package.version.str());
+    writef("%s (%s)\n", package.name, package.version:string);
   }
 
   // Handle --show flag
@@ -80,9 +80,9 @@ proc masonSearch(args: [] string): int throws {
     if pkgs.size == 1 {
       const pkg = pkgs[0];
       writeln("Displaying the latest version: " +
-              pkg.name + "@" + pkg.version.str());
+              pkg.name + "@" + pkg.version:string);
       const brickPath = joinPath(pkg.registry, "Bricks",
-                                 pkg.name, pkg.version.str() + ".toml");
+                                 pkg.name, pkg.version:string + ".toml");
       showToml(brickPath);
     } else if pkgs.size == 0 {
       throw new MasonError('"%s" returned no packages\n'.format(query) +

--- a/tools/mason/MasonUpdate.chpl
+++ b/tools/mason/MasonUpdate.chpl
@@ -24,6 +24,7 @@ module MasonUpdate {
 use FileSystem;
 use List;
 use Map;
+import Version;
 use ArgumentParser;
 use MasonEnv;
 use MasonExternal;
@@ -126,7 +127,7 @@ proc updateLock(skipUpdate: bool, tf="Mason.toml", lf="Mason.lock",
         then "The following package is"
         else "The following packages are";
       var err = "%s incompatible with your version of Chapel (%s):\n"
-                  .format(prefix, getChapelVersionStr());
+                  .format(prefix, getChapelVersionInfo():string);
       for msg in failedChapelVersion do
         err += "  " + msg + "\n";
       throw new MasonError(err.strip());
@@ -220,8 +221,7 @@ proc updateRegistry(skipUpdate: bool, show=true) throws {
 }
 
 proc verifyChapelVersion(brick:borrowed Toml) throws {
-  const tupInfo = getChapelVersionInfo();
-  const current = new versionInfo(tupInfo(0), tupInfo(1), tupInfo(2));
+  const current = getChapelVersionInfo();
 
   var (low, hi) = parseChplVersion(brick);
   var ret = low <= current && current <= hi;
@@ -231,11 +231,11 @@ proc verifyChapelVersion(brick:borrowed Toml) throws {
 
 proc prettyVersionRange(low, hi) {
   if low == hi then
-    return low.str();
+    return low:string;
   else if hi.containsMax() then
-    return low.str() + " or later";
+    return low:string + " or later";
   else
-    return low.str() + ".." + hi.str();
+    return low:string + ".." + hi:string;
 }
 
 proc chplVersionError(brick:borrowed Toml) throws {
@@ -296,7 +296,7 @@ private proc createDepTree(root: Toml) throws {
     chplVersionError(brick);
 
     // Lock in the current Chapel version
-    const curVer = getChapelVersionStr();
+    const curVer = getChapelVersionInfo():string;
     brick.set("chplVersion", curVer + ".." + curVer);
 
     if brick.pathExists("dependencies") {
@@ -416,7 +416,7 @@ private proc IVRS(A: borrowed Toml, B: borrowed Toml) throws {
   if !okA && !okB {
     stderr.writeln("Dependency resolution error: unable to find version of '",
                    name, "' compatible with your version of Chapel (",
-                   getChapelVersionStr(), "):");
+                   getChapelVersionInfo():string, "):");
     stderr.writeln("  v", version1, " expecting ",
                    prettyVersionRange(Alo, Ahi));
     stderr.writeln("  v", version2, " expecting ",

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -360,8 +360,7 @@ proc getChapelVersionInfo(): Version.version throws {
       throw new MasonError("Failed to match output of 'chpl --version':\n" +
                             output);
 
-    const split = semver.split(".");
-    chplVersionInfo = new Version.version(split[0]:int, split[1]:int, split[2]:int);
+    chplVersionInfo = Version.version.fromString(semver);
   }
 
   return chplVersionInfo;
@@ -782,7 +781,9 @@ proc parseChplVersion(
   use Regex;
 
   // Assert some expected fields are not nil
-  if brick == nil || brick!.get["name"] == nil || brick!.get["version"] == nil  then
+  if brick == nil ||
+     brick!.get["name"] == nil ||
+     brick!.get["version"] == nil then
     throw new MasonError("Unable to parse manifest file");
 
   if brick!.get["chplVersion"] == nil {
@@ -827,7 +828,8 @@ private proc parseChplVersionString(ver: string) throws {
 proc checkChplVersion(
   chplVersion: string
 ): (Version.version, Version.version) throws {
-  const formatMessage = "'chplVersion' must be '<version>..<version>' or '<version>'";
+  const formatMessage =
+    "'chplVersion' must be '<version>..<version>' or '<version>'";
   var versions = for v in chplVersion.split("..") do v.strip();
   // Expecting 1 or 2 version strings
   if versions.size > 2 || versions.size < 1 {

--- a/tools/mason/MasonUtils.chpl
+++ b/tools/mason/MasonUtils.chpl
@@ -28,6 +28,7 @@ private use CTypes;
 private use ChplConfig;
 public use FileSystem;
 import FileSystem;
+import Version;
 private use List;
 private use Map;
 public use Subprocess;
@@ -308,157 +309,62 @@ proc runSpackCommand(command, quiet=false) {
   }
 }
 
-// TODO: Can we get away with the Chapel Version object instead?
-record versionInfo {
-  var major = -1, minor = -1, bug = 0;
+/*
+  checks that a version is compatible with this version
+  versions are assumed compatible if major and minor versions match
+  and patch/update level is the same or greater
+*/
+proc (Version.version).isCompatible(other: Version.version): bool do
+  return this.major == other.major &&
+         this.minor == other.minor &&
+         this.update <= other.update;
 
-  proc init() {
-    major = -1;
-    minor = -1;
-    bug = 0;
-  }
+proc type (Version.version).zero(): Version.version do
+  return new Version.version(0, 0, 0);
+proc type (Version.version).max(): Version.version do
+  return new Version.version(Types.max(int), Types.max(int), Types.max(int));
 
-  proc init=(other: versionInfo) {
-    this.major = other.major;
-    this.minor = other.minor;
-    this.bug   = other.bug;
-  }
+proc (Version.version).containsMax() do
+  return this.major == Types.max(int) ||
+          this.minor == Types.max(int) ||
+          this.update == Types.max(int);
 
-  proc init(maj: int, min: int, bug: int) {
-    this.major = maj;
-    this.minor = min;
-    this.bug   = bug;
-  }
-
-  proc init(str: string) throws {
-    init this;
-    const s: [1..3] string = str.split(".");
-    assert(s.size == 3);
-
-    major = s[1]:int;
-    minor = s[2]:int;
-    bug   = s[3]:int;
-  }
-
-  proc str() {
-    return major:string + "." + minor:string + "." + bug:string;
-  }
-
-  proc cmp(other: versionInfo) {
-    const A = (major, minor, bug);
-    const B = (other.major, other.minor, other.bug);
-    for i in 0..2 {
-      if A(i) > B(i) then return 1;
-      else if A(i) < B(i) then return -1;
-    }
-    return 0;
-  }
-
-  proc this(i: int): int {
-    select i {
-      when 0 do
-        return this.major;
-      when 1 do
-        return this.minor;
-      when 2 do
-        return this.bug;
-      otherwise
-        halt("Out of bounds access of versionInfo");
-    }
-  }
-
-  proc containsMax() {
-    return this.major == max(int) ||
-           this.minor == max(int) ||
-           this.bug == max(int);
-  }
-
-  proc isCompatible(other: versionInfo) : bool {
-    // checks that a version is compatible with this version
-    // versions are assumed compatible if major and minor versions match
-    // and patch/bug level is the same or greater
-    return this.major == other.major
-           && this.minor == other.minor
-           && this.bug <= other.bug;
-  }
-
-  proc type zero(): versionInfo {
-    return new versionInfo(0, 0, 0);
-  }
+proc type (Version.version).fromString(ver: string) throws {
+  var split = [v in ver.split(".")] v:int;
+  if split.size != 3 then
+    throw new MasonError("Invalid version string: " + ver);
+  return new Version.version(split[0], split[1], split[2]);
 }
 
-operator versionInfo.=(ref lhs: versionInfo, const ref rhs: versionInfo) {
-  lhs.major = rhs.major;
-  lhs.minor = rhs.minor;
-  lhs.bug   = rhs.bug;
-}
-
-operator versionInfo.>=(a: versionInfo, b: versionInfo) : bool {
-  return a.cmp(b) >= 0;
-}
-operator versionInfo.<=(a: versionInfo, b: versionInfo) : bool {
-  return a.cmp(b) <= 0;
-}
-operator ==(a: versionInfo, b: versionInfo) : bool {
-  return a.cmp(b) == 0;
-}
-operator versionInfo.>(a: versionInfo, b: versionInfo) : bool {
-  return a.cmp(b) > 0;
-}
-
-operator versionInfo.<(a: versionInfo, b: versionInfo) : bool {
-  return a.cmp(b) < 0;
-}
-
-
-private var chplVersionInfo = new versionInfo(-1, -1, -1);
+private var chplVersionInfo = new Version.version(-1, -1, -1);
 /*
    Returns a tuple containing information about the `chpl --version`:
    (major, minor, bugFix, isMain)
 */
-proc getChapelVersionInfo(): versionInfo throws {
+proc getChapelVersionInfo(): Version.version throws {
   use Regex;
 
-  if chplVersionInfo(0) == -1 {
+  if chplVersionInfo.major == -1 {
 
-    var output : string;
+    var output: string;
     try {
       output = runCommand(["chpl", "--version"], quiet=true);
     } catch {
       throw new MasonError("Failed to run 'chpl --version'");
     }
 
-    const semverPattern = "(\\d+\\.\\d+\\.\\d+)";
-    var main  = new regex(semverPattern + " pre-release (\\([a-z0-9]+\\))");
+    const semverPattern = "chpl version (\\d+\\.\\d+\\.\\d+)";
     var release = new regex(semverPattern);
-
-    var semver, sha : string;
-    var isMain: bool;
-    if main.search(output, semver, sha) {
-      isMain = true;
-    } else if release.search(output, semver) {
-      isMain = false;
-    } else {
+    var semver: string;
+    if !release.search(output, semver).matched then
       throw new MasonError("Failed to match output of 'chpl --version':\n" +
                             output);
-    }
 
     const split = semver.split(".");
-    chplVersionInfo = new versionInfo(split[0]:int, split[1]:int, split[2]:int);
+    chplVersionInfo = new Version.version(split[0]:int, split[1]:int, split[2]:int);
   }
 
   return chplVersionInfo;
-}
-
-private var chplVersion = "";
-proc getChapelVersionStr() throws {
-  if chplVersion == "" {
-    const version = getChapelVersionInfo();
-    chplVersion = version(0):string + "." +
-                  version(1):string + "." +
-                  version(2):string;
-  }
-  return chplVersion;
 }
 
 // TODO: only exists because I don't want to rewrite everything to use path, yet
@@ -731,23 +637,24 @@ proc getProjectType(): string throws {
 
 record package {
   var name: string;
-  var version: versionInfo;
+  var version: Version.version;
   var registry: string;
 
   proc brickPath() {
-    const tomlName = version.str() + ".toml";
+    const tomlName = version:string + ".toml";
     return joinPath(registry, "Bricks", name, tomlName);
   }
 
-  proc type nullPackage() {
-    return new package("", versionInfo.zero(), "");
-  }
+  proc type nullPackage() do
+    return new package("", Version.version.zero(), "");
 
   operator <(a: package, b: package) : bool {
     if a.name < b.name then
       return true;
     else if a.name.toLower() == b.name.toLower() then
-      return a.version < b.version;
+      // throw can only occur with commit hashes in the version,
+      // so this should never throw
+      return try! a.version < b.version;
     else
       return false;
   }
@@ -795,9 +702,8 @@ proc searchDependencies(pattern: regex(string)): list(package) throws {
           log.debug("found hidden package: " + name);
         } else {
           const ver = findLatest(joinPath(searchDir, dir));
-          if ver != versionInfo.zero() {
+          if ver != Version.version.zero() then
             pkgs.pushBack(new package(name, ver, registry));
-          }
         }
       }
     }
@@ -815,7 +721,7 @@ proc getDepToml(depName: string, depVersion: string) throws {
 
   var foundDep = package.nullPackage();
   for pkg in pkgs {
-    if pkg.name == depName && pkg.version.str() == depVersion {
+    if pkg.name == depName && pkg.version:string == depVersion {
       foundDep = pkg;
       break;
     }
@@ -836,10 +742,10 @@ proc getDepToml(depName: string, depVersion: string) throws {
 
 /* Search TOML files within a package directory to find the latest package
    version number that is supported with current Chapel version */
-proc findLatest(packageDir: string): versionInfo throws {
+proc findLatest(packageDir: string): Version.version throws {
   use Path;
 
-  var ret = versionInfo.zero();
+  var ret = Version.version.zero();
   const suffix = ".toml";
   const packageName = basename(packageDir);
   for manifest in listDir(packageDir, files=true, dirs=false) {
@@ -862,7 +768,7 @@ proc findLatest(packageDir: string): versionInfo throws {
 
     // Check that Chapel version is supported
     const end = manifest.size - suffix.size;
-    const ver = new versionInfo(manifest[0..<end]);
+    const ver = Version.version.fromString(manifest[0..<end]);
     if ver > ret then ret = ver;
   }
   return ret;
@@ -872,94 +778,74 @@ proc findLatest(packageDir: string): versionInfo throws {
    TOML file and returns the min and max compatible versions */
 proc parseChplVersion(
   brick: borrowed Toml?
-): (versionInfo, versionInfo) throws {
+): (Version.version, Version.version) throws {
   use Regex;
 
-  if brick == nil {
-    stderr.writeln("Error: Unable to parse manifest file");
-    exit(1);
-  }
-
   // Assert some expected fields are not nil
-  if brick!.get["name"] == nil || brick!.get["version"] == nil {
-    stderr.writeln("Error: Unable to parse manifest file");
-    exit(1);
-  }
+  if brick == nil || brick!.get["name"] == nil || brick!.get["version"] == nil  then
+    throw new MasonError("Unable to parse manifest file");
 
   if brick!.get["chplVersion"] == nil {
     const name = brick!["name"]!.s + "-" + brick!["version"]!.s;
-    stderr.writeln("Brick '", name, "' missing required 'chplVersion' field");
-    exit(1);
+    throw new MasonError("Brick '%s' missing required 'chplVersion' field"
+                          .format(name));
   }
 
   const chplVersion = brick!["chplVersion"]!.s;
-  var low, high: versionInfo;
+  var low, high: Version.version;
 
   try {
     (low, high) = checkChplVersion(chplVersion);
-  } catch e : Error {
+  } catch e {
     const name = brick!["name"]!.s + "-" + brick!["version"]!.s;
-    stderr.writeln("Invalid chplVersion in package '",
-                   name, "': ", chplVersion);
-    stderr.writeln("Details: ", e.message());
-    exit(1);
+    throw new MasonError("Invalid chplVersion of '%s' in package '%s': %s"
+                          .format(chplVersion, name, e.message()));
   }
 
   return (low, high);
 }
 
+
+private proc parseChplVersionString(ver: string) throws {
+  // Finds 'x.x' or 'x.x.x' where x is a positive number
+  const pattern = new regex("^(\\d+\\.\\d+(\\.\\d+)?)$");
+  var semver: string;
+  if !pattern.match(ver, semver).matched then
+    throw new MasonError(
+      "Invalid Chapel version format '" + ver +
+      "', must be either 'major.minor.update' or 'major.minor'");
+  const nums = for s in semver.split(".") do s:int;
+  const major = nums[0],
+        minor = nums[1],
+        update = if nums.size == 3 then nums[2] else 0;
+  return new Version.version(major, minor, update);
+}
+
+
 /* Ensure that Chapel version is properly formatted. Returns
-   a tuple of the low, high supported verisons.*/
-proc checkChplVersion(chplVersion) throws {
-  use Regex;
-  var lo, hi : versionInfo;
-  const formatMessage = "\n\n" +
-    "chplVersion format must be '<version>..<version>' or '<version>'\n" +
-    "A <version> must be in one of the following formats:\n" +
-    "  x.x.x\n" +
-    "  x.x\n" +
-    "where 'x' is a positive integer.\n";
-
-  var versions = chplVersion.split("..");
-  [v in versions] v = v.strip();
-
+   a tuple of the low, high supported versions.*/
+proc checkChplVersion(
+  chplVersion: string
+): (Version.version, Version.version) throws {
+  const formatMessage = "'chplVersion' must be '<version>..<version>' or '<version>'";
+  var versions = for v in chplVersion.split("..") do v.strip();
   // Expecting 1 or 2 version strings
   if versions.size > 2 || versions.size < 1 {
-    throw new MasonError("Expecting 1 or 2 versions in chplVersion range." +
-                          formatMessage);
+    throw new MasonError(formatMessage);
   } else if versions.size == 2 && (versions[0] == "" || versions[1] == "") {
-    throw new MasonError("Unbounded chplVersion ranges are not allowed." +
+    throw new MasonError("Unbounded chplVersion ranges are not allowed. " +
                          formatMessage);
   }
 
-  proc parseString(ver:string): versionInfo throws {
-    var ret : versionInfo;
+  const lo = parseChplVersionString(versions[0]);
+  const hi =
+    if versions.size == 1
+      then Version.version.max()
+      else parseChplVersionString(versions[1]);
 
-    // Finds 'x.x' or 'x.x.x' where x is a positive number
-    const pattern = new regex("^(\\d+\\.\\d+(\\.\\d+)?)$");
-    var semver : string;
-    if !pattern.match(ver, semver).matched {
-      throw new MasonError("Invalid Chapel version format: " + ver +
-                            formatMessage);
-    }
-    const nums = for s in semver.split(".") do s:int;
-    ret.major = nums[0];
-    ret.minor = nums[1];
-    if nums.size == 3 then ret.bug = nums[2];
-
-    return ret;
-  }
-
-  lo = parseString(versions[0]);
-
-  if versions.size == 1 {
-    hi = new versionInfo(max(int), max(int), max(int));
-  } else {
-    hi = parseString(versions[1]);
-  }
   if lo > hi then
     throw new MasonError("Lower bound of chplVersion must be <= upper bound: " +
-                          lo.str() + " > " + hi.str());
+                          lo:string + " > " + hi:string);
 
   return (lo, hi);
 }


### PR DESCRIPTION
Replaces Mason's custom versionInfo record with the one defined in the standard library

While doing this, I made some editorial changes to some of the error messages

I also found some tests that would likely never run due to bad skipifs. I fixed the skipifs and the tests

- [x] paratest

[Reviewed by @benharsh]