### PR TITLE
Update rules that update chpl-venv's install to blow away the dir

### DIFF
--- a/third-party/chpl-venv/Makefile
+++ b/third-party/chpl-venv/Makefile
@@ -73,6 +73,9 @@ create-virtualenv: $(CHPL_VENV_VIRTUALENV_DIR_OK)
 
 $(CHPL_VENV_CHPLDEPS_MAIN): $(CHPL_VENV_VIRTUALENV_DIR_OK) $(CHPL_VENV_TEST_REQUIREMENTS_FILE) $(CHPL_VENV_CHPLDOC_REQUIREMENTS_FILE1) $(CHPL_VENV_CHPLDOC_REQUIREMENTS_FILE2) $(CHPL_VENV_CHPLDOC_REQUIREMENTS_FILE3) $(CHPL_VENV_C2CHAPEL_REQUIREMENTS_FILE) chpldeps-main.py
 	@# Install dependencies to $(CHPL_VENV_CHPLDEPS)
+	@# Blow away the directory first to clear out old deps (apparently
+	@# --update w/ --target doesn't do this and versions accumulate)
+	rm -rf $(CHPL_VENV_CHPLDEPS)
 	@# Rely on pip to create the directory
 	export PATH="$(CHPL_VENV_VIRTUALENV_BIN):$$PATH" && \
 	export VIRTUAL_ENV=$(CHPL_VENV_VIRTUALENV_DIR) && \


### PR DESCRIPTION
Without this — as I understand it — what would happen is that when requirements were updated, the new requirements would be added to the existing directory, and things like chpldoc would use the first version found, which wouldn't necessarily be the latest.  This resulted in things like chpldoc using version 0.0.40 of the Chapel Sphinx domain when I had version 0.0.41 installed and listed in the requirements file, requiring developers to manually remove the directory to get the latest version / not get testing failures, which felt like a common annoyance.
