### PR TITLE
Fix some off-by-one errors I missed in d18ae93 when updating to 0-based indexing

### DIFF
--- a/test/exercises/duplicates/forStudents/SHA256Implementation.chpl
+++ b/test/exercises/duplicates/forStudents/SHA256Implementation.chpl
@@ -143,7 +143,7 @@ module SHA256Implementation {
   }
 
   // Set the bit numbered `bit` in `msg`.
-  // Bit numbering starts with 0. Bit numbers 0-31 are in msg(1)
+  // Bit numbering starts with 0. Bit numbers 0-31 are in msg(0)
   // and bit 0 is the most-significant.
   private
   proc set_bit(ref msg:16*uint(32), bit:uint) {
@@ -154,7 +154,7 @@ module SHA256Implementation {
   }
 
   // Clear the bits after bit `nbits` in `msg`.
-  // Bit numbering starts with 0. Bit numbers 0-31 are in msg(1)
+  // Bit numbering starts with 0. Bit numbers 0-31 are in msg(0)
   // and bit 0 is the most-significant.
   private
   proc clear_bits_after(ref msg:16*uint(32), nbits:uint) {

--- a/test/exercises/duplicates/forStudents/SHA256Implementation.chpl
+++ b/test/exercises/duplicates/forStudents/SHA256Implementation.chpl
@@ -277,12 +277,12 @@ module SHA256Implementation {
     msg = ones;
     clear_bits_after(msg, 33);
     assert(msg[0] == 0xffffffff && msg[1] == 0x80000000 &&
-           msg[3] == 0 && msg[15] == 0);
+           msg[2] == 0 && msg[15] == 0);
 
     msg = ones;
     clear_bits_after(msg, 34);
     assert(msg[0] == 0xffffffff && msg[1] == 0xc0000000 &&
-           msg[3] == 0 && msg[15] == 0);
+           msg[2] == 0 && msg[15] == 0);
 
     msg = zeros;
     set_bit(msg, 0);
@@ -302,11 +302,11 @@ module SHA256Implementation {
 
     msg = zeros;
     set_bit(msg, 32);
-    assert(msg[0] == 0 && msg[1] == 0x80000000 && msg[3] == 0);
+    assert(msg[0] == 0 && msg[1] == 0x80000000 && msg[2] == 0);
 
     msg = zeros;
     set_bit(msg, 33);
-    assert(msg[0] == 0 && msg[1] == 0x40000000 && msg[3] == 0);
+    assert(msg[0] == 0 && msg[1] == 0x40000000 && msg[2] == 0);
 
 
     var startingState:SHA256State;


### PR DESCRIPTION
Anna noticed that in updating existing test code from 1-based indexing to 0-based in d18ae93, I missed some cases in this module's assert() statements that checked for element [3] and were not updated to element [2].  Fortunately, since these are only in asserts, they didn't reflect an error in the computation itself (assuming there were no other mistakes), and presumably our testing is not sufficient to have caught them before now.  There were also a few comments I failed to update due to their use of parenthesis-based indexing rather than square brackets.
