### PR TITLE
Implement goto-type-def for classes and enums

### DIFF
--- a/tools/chapel-py/src/method-tables/type-methods.h
+++ b/tools/chapel-py/src/method-tables/type-methods.h
@@ -50,6 +50,13 @@ CLASS_BEGIN(EnumType)
   PLAIN_GETTER(EnumType, name, "Get name of this EnumType",
                chpl::UniqueString,
                return node->name())
+  PLAIN_GETTER(EnumType, decl, "Get the chpl::uast::AstNode that declares this EnumType",
+               Nilable<const chpl::uast::AstNode*>,
+               // For completely builtin types, the ID could be empty.
+               // They don't have code-level declarations, so return 'None'.
+               auto& id = node->id();
+               if (id.isEmpty()) return nullptr;
+               return parsing::idToAst(context, id))
 CLASS_END(EnumType)
 
 CLASS_BEGIN(ClassType)

--- a/tools/chapel-py/src/method-tables/type-methods.h
+++ b/tools/chapel-py/src/method-tables/type-methods.h
@@ -63,4 +63,7 @@ CLASS_BEGIN(ClassType)
   PLAIN_GETTER(ClassType, manageable_type, "Get the type managed by this ClassType",
                Nilable<const chpl::types::ManageableType*>,
                return node->manageableType())
+  PLAIN_GETTER(ClassType, basic_class_type, "Get the basic class type for this ClassType",
+               Nilable<const chpl::types::BasicClassType*>,
+               return node->basicClassType())
 CLASS_END(ClassType)

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -610,8 +610,8 @@ class ChapelLanguageServer(LanguageServer):
         if isinstance(type_, (chapel.CompositeType, chapel.EnumType)):
             typedecl = type_.decl()
         elif isinstance(type_, chapel.ClassType):
-            if manageable := type_.manageable_type():
-                typedecl = manageable.decl()
+            if clstype := type_.basic_class_type():
+                typedecl = clstype.decl()
 
         if typedecl and isinstance(typedecl, chapel.NamedDecl):
             label.location = location_to_location(typedecl.name_location())
@@ -1170,8 +1170,8 @@ def run_lsp():
         if isinstance(type_, (chapel.CompositeType, chapel.EnumType)):
             decl = type_.decl()
         elif isinstance(type_, chapel.ClassType):
-            if manageable := type_.manageable_type():
-                decl = manageable.decl()
+            if clstype := type_.basic_class_type():
+                decl = clstype.decl()
 
         if not decl:
             return None

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -606,12 +606,17 @@ class ChapelLanguageServer(LanguageServer):
         text_edits = [TextEdit(Range(name_rng.end, name_rng.end), edit_text)]
         colon_label = InlayHintLabelPart(": ")
         label = InlayHintLabelPart(type_str)
-        if isinstance(type_, chapel.CompositeType):
+        typedecl = None
+        if isinstance(type_, (chapel.CompositeType, chapel.EnumType)):
             typedecl = type_.decl()
-            if typedecl and isinstance(typedecl, chapel.NamedDecl):
-                label.location = location_to_location(typedecl.name_location())
-            elif typedecl:
-                label.location = location_to_location(typedecl.location())
+        elif isinstance(type_, chapel.ClassType):
+            if manageable := type_.manageable_type():
+                typedecl = manageable.decl()
+
+        if typedecl and isinstance(typedecl, chapel.NamedDecl):
+            label.location = location_to_location(typedecl.name_location())
+        elif typedecl:
+            label.location = location_to_location(typedecl.location())
 
         # if the inlay hint is for a loop index type, we cannot insert the type
         # as it would be a syntax error
@@ -1156,10 +1161,16 @@ def run_lsp():
             return None
 
         _, type_, _ = qt
-        if not isinstance(type_, chapel.CompositeType):
+        if not isinstance(type_, (chapel.CompositeType, chapel.ClassType, chapel.EnumType)):
             return None
 
-        decl = type_.decl()
+        decl = None
+        if isinstance(type_, (chapel.CompositeType, chapel.EnumType)):
+            decl = type_.decl()
+        elif isinstance(type_, chapel.ClassType):
+            if manageable := type_.manageable_type():
+                decl = manageable.decl()
+
         if not decl:
             return None
 

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1161,7 +1161,9 @@ def run_lsp():
             return None
 
         _, type_, _ = qt
-        if not isinstance(type_, (chapel.CompositeType, chapel.ClassType, chapel.EnumType)):
+        if not isinstance(
+            type_, (chapel.CompositeType, chapel.ClassType, chapel.EnumType)
+        ):
             return None
 
         decl = None

--- a/tools/chpl-language-server/test/basic_resolver.py
+++ b/tools/chpl-language-server/test/basic_resolver.py
@@ -162,13 +162,28 @@ async def test_goto_type_classes(client: LanguageClient):
         var cb = c.borrow();
         var cu = cb:unmanaged;
         """
-    init_exprs = ["C", "C?", "owned C", "owned C?", "shared C", "unmanaged C", "unmanaged C?"]
+    init_exprs = [
+        "C",
+        "C?",
+        "owned C",
+        "owned C?",
+        "shared C",
+        "unmanaged C",
+        "unmanaged C?",
+    ]
     for init_expr in init_exprs:
         file = template.format(init_expr)
         async with source_file(client, file) as doc:
-            await check_goto_type_def(client, doc, pos((2, 4)), pos((0, 6)), "class C")
-            await check_goto_type_def(client, doc, pos((3, 5)), pos((0, 6)), "class C")
-            await check_goto_type_def(client, doc, pos((4, 6)), pos((0, 6)), "class C")
+            await check_goto_type_def(
+                client, doc, pos((2, 4)), pos((0, 6)), "class C"
+            )
+            await check_goto_type_def(
+                client, doc, pos((3, 5)), pos((0, 6)), "class C"
+            )
+            await check_goto_type_def(
+                client, doc, pos((4, 6)), pos((0, 6)), "class C"
+            )
+
 
 @pytest.mark.asyncio
 async def test_goto_type_enum(client: LanguageClient):
@@ -183,8 +198,13 @@ async def test_goto_type_enum(client: LanguageClient):
            """
 
     async with source_file(client, file) as doc:
-        await check_goto_type_def(client, doc, pos((1, 4)), pos((0, 5)), "enum E")
-        await check_goto_type_def(client, doc, pos((2, 5)), pos((0, 5)), "enum E")
+        await check_goto_type_def(
+            client, doc, pos((1, 4)), pos((0, 5)), "enum E"
+        )
+        await check_goto_type_def(
+            client, doc, pos((2, 5)), pos((0, 5)), "enum E"
+        )
+
 
 @pytest.mark.asyncio
 async def test_string(client: LanguageClient):

--- a/tools/chpl-language-server/test/basic_resolver.py
+++ b/tools/chpl-language-server/test/basic_resolver.py
@@ -150,6 +150,43 @@ async def test_goto_type_def_member_field(client: LanguageClient):
 
 
 @pytest.mark.asyncio
+async def test_goto_type_classes(client: LanguageClient):
+    """
+    Ensure that goto-type-definition works on a class type.
+    """
+
+    template = """
+        class C {{ }}
+
+        var c = new {}();
+        var cb = c.borrow();
+        var cu = cb:unmanaged;
+        """
+    init_exprs = ["C", "C?", "owned C", "owned C?", "shared C", "unmanaged C", "unmanaged C?"]
+    for init_expr in init_exprs:
+        file = template.format(init_expr)
+        async with source_file(client, file) as doc:
+            await check_goto_type_def(client, doc, pos((2, 4)), pos((0, 6)), "class C")
+            await check_goto_type_def(client, doc, pos((3, 5)), pos((0, 6)), "class C")
+            await check_goto_type_def(client, doc, pos((4, 6)), pos((0, 6)), "class C")
+
+@pytest.mark.asyncio
+async def test_goto_type_enum(client: LanguageClient):
+    """
+    Ensure that goto-type-definition works on an enum type.
+    """
+
+    file = """
+           enum E { A, B, C }
+           var e = E.A;
+           var e1 = e;
+           """
+
+    async with source_file(client, file) as doc:
+        await check_goto_type_def(client, doc, pos((1, 4)), pos((0, 5)), "enum E")
+        await check_goto_type_def(client, doc, pos((2, 5)), pos((0, 5)), "enum E")
+
+@pytest.mark.asyncio
 async def test_string(client: LanguageClient):
     """
     Ensure that goto-type works on a string.

--- a/tools/chpl-language-server/test/type_inlays.py
+++ b/tools/chpl-language-server/test/type_inlays.py
@@ -369,23 +369,39 @@ async def test_type_inlays_clickable_def(client: LanguageClient):
 
     file = """
             record R { }
+            class C { }
+            enum E { A, B, C }
 
             var x = new R();
+            var y = new C();
+            var z = new shared C?();
+            var w = y.borrow();
+            var e = E.A;
            """
 
     async with source_file(client, file) as doc:
         inlays = await check_type_inlay_hints(
-            client, doc, rng((0, 0), endpos(file)), [(pos((2, 5)), "R")]
+            client, doc, rng((0, 0), endpos(file)), [(pos((4, 5)), "R"), (pos((5, 5)), "owned C"), (pos((6, 5)), "shared C?"), (pos((7, 5)), "borrowed C"), (pos((8, 5)), "E")],
         )
+        R_range = rng((0, 7), (0, 8))
+        C_range = rng((1, 6), (1, 7))
+        E_range = rng((2, 5), (2, 6))
 
-        assert len(inlays) == 1
-        # the second inlay part is the definition and should be clickable
-        assert isinstance(inlays[0].label, list) and len(inlays[0].label) == 2
+        def check_inlay(inlay, expected_range):
+            # the second inlay part is the definition and should be clickable
+            assert isinstance(inlay.label, list) and len(inlay.label) == 2
 
-        loc = inlays[0].label[1].location
-        assert loc is not None
-        assert loc.uri == doc.uri
-        assert loc.range == rng((0, 7), (0, 8))
+            loc = inlay.label[1].location
+            assert loc is not None
+            assert loc.uri == doc.uri
+            assert loc.range == expected_range
+
+        assert len(inlays) == 5
+        check_inlay(inlays[0], R_range)
+        check_inlay(inlays[1], C_range)
+        check_inlay(inlays[2], C_range)
+        check_inlay(inlays[3], C_range)
+        check_inlay(inlays[4], E_range)
 
 
 @pytest.mark.asyncio

--- a/tools/chpl-language-server/test/type_inlays.py
+++ b/tools/chpl-language-server/test/type_inlays.py
@@ -381,7 +381,16 @@ async def test_type_inlays_clickable_def(client: LanguageClient):
 
     async with source_file(client, file) as doc:
         inlays = await check_type_inlay_hints(
-            client, doc, rng((0, 0), endpos(file)), [(pos((4, 5)), "R"), (pos((5, 5)), "owned C"), (pos((6, 5)), "shared C?"), (pos((7, 5)), "borrowed C"), (pos((8, 5)), "E")],
+            client,
+            doc,
+            rng((0, 0), endpos(file)),
+            [
+                (pos((4, 5)), "R"),
+                (pos((5, 5)), "owned C"),
+                (pos((6, 5)), "shared C?"),
+                (pos((7, 5)), "borrowed C"),
+                (pos((8, 5)), "E"),
+            ],
         )
         R_range = rng((0, 7), (0, 8))
         C_range = rng((1, 6), (1, 7))


### PR DESCRIPTION
Implements goto-type-def for classes and enums, which need special handling since they are not `CompositeTypes`

[Reviewed by @DanilaFe]