### PR TITLE
Retain linuxbrew and docker test containers until next run

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -100,7 +100,7 @@ update_image() {
   CONTAINER_NAME="$imageName-test"
   docker container rm --force --volumes "$CONTAINER_NAME"
   echo 'writeln("Hello, world!");' > hello.chpl
-  docker run -i --name "$CONTAINER_NAME" "$imageName"  <  "$script"
+  docker run -i --name "$CONTAINER_NAME" "$imageName" < "$script"
   CONTAINER_RUN=$?
   # Clean up scratch chpl file for testing
   rm hello.chpl

--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -97,8 +97,10 @@ update_image() {
   fi
 
   # Run test script inside container
+  CONTAINER_NAME="$imageName-test"
+  docker container rm --force --volumes "$CONTAINER_NAME"
   echo 'writeln("Hello, world!");' > hello.chpl
-  docker run --rm -i "$imageName"  <  "$script"
+  docker run -i --name "$CONTAINER_NAME" "$imageName"  <  "$script"
   CONTAINER_RUN=$?
   # Clean up scratch chpl file for testing
   rm hello.chpl

--- a/util/packaging/docker/test/homebrew_ci.bash
+++ b/util/packaging/docker/test/homebrew_ci.bash
@@ -9,7 +9,7 @@ docker image rm --force homebrew_ci
 
 # Build image
 docker build . --load --platform linux/amd64 -t homebrew_ci
-containerid= docker image ls | grep 'homebrew_ci' | awk '{print$3}'
+docker image inspect homebrew_ci
 
 # Start the container and run a script to check homebrew install inside the running container
 docker run --platform linux/amd64 --rm -i homebrew_ci /bin/bash < ${CHPL_HOME}/util/packaging/docker/test/brew_install.bash

--- a/util/packaging/docker/test/homebrew_ci.bash
+++ b/util/packaging/docker/test/homebrew_ci.bash
@@ -12,7 +12,9 @@ docker build . --load --platform linux/amd64 -t homebrew_ci
 docker image inspect homebrew_ci
 
 # Start the container and run a script to check homebrew install inside the running container
-docker run --platform linux/amd64 --rm -i homebrew_ci /bin/bash < ${CHPL_HOME}/util/packaging/docker/test/brew_install.bash
+CONTAINER_NAME=homebrew-ci-test
+docker container rm --force --volumes "$CONTAINER_NAME"
+docker run --platform linux/amd64 -i --name "$CONTAINER_NAME" homebrew_ci /bin/bash < ${CHPL_HOME}/util/packaging/docker/test/brew_install.bash
 CONTAINER_RUN=$?
 if [ $CONTAINER_RUN -ne 0 ]
 then


### PR DESCRIPTION
Instead of running these containers with `--rm`, manually remove them and their volumes by a static name (if present) before running them.

This has two benefits:
- Containers are kept around until the next run, so one can debug a failed run without having to rebuild.
- Orphaned containers and volumes (which could occur due to a Jenkins disconnect) are guaranteed to be cleaned up eventually, and can't accumulate anonymously.

[reviewer info placeholder]