### PR TITLE
Fix a bug in runtime code when building it for FreeBSD

### DIFF
--- a/runtime/include/chpl-dynamic-loading.h
+++ b/runtime/include/chpl-dynamic-loading.h
@@ -18,8 +18,18 @@
  * limitations under the License.
  */
 
-#ifndef _CHPL_DYNAMIC_LOADING_H_
-#define _CHPL_DYNAMIC_LOADING_H_
+#ifndef CHPL_RT_DYNAMIC_LOADING_H
+#define CHPL_RT_DYNAMIC_LOADING_H
+
+// Needed to access 'dladdr' and 'Dl_info'.
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+#endif
+#ifdef __FreeBSD__
+  #include <link.h>
+#endif
+
+#include <dlfcn.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/include/chpl-dynamic-loading.h
+++ b/runtime/include/chpl-dynamic-loading.h
@@ -21,16 +21,6 @@
 #ifndef CHPL_RT_DYNAMIC_LOADING_H
 #define CHPL_RT_DYNAMIC_LOADING_H
 
-// Needed to access 'dladdr' and 'Dl_info'.
-#ifndef _GNU_SOURCE
-  #define _GNU_SOURCE
-#endif
-#ifdef __FreeBSD__
-  #include <link.h>
-#endif
-
-#include <dlfcn.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/runtime/src/chpl-dynamic-loading.c
+++ b/runtime/src/chpl-dynamic-loading.c
@@ -21,7 +21,6 @@
 #include "chplrt.h"
 #include "chpl-dynamic-loading.h"
 #include "chplcgfns.h"
-#include <dlfcn.h>
 
 int CHPL_RTLD_LAZY = RTLD_LAZY;
 

--- a/runtime/src/chpl-dynamic-loading.c
+++ b/runtime/src/chpl-dynamic-loading.c
@@ -18,6 +18,15 @@
  * limitations under the License.
  */
 
+// Needed to access 'dladdr' and 'Dl_info'.
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE 1
+#endif
+#ifdef __FreeBSD__
+  #include <link.h>
+#endif
+#include <dlfcn.h>
+
 #include "chplrt.h"
 #include "chpl-dynamic-loading.h"
 #include "chplcgfns.h"

--- a/runtime/src/chpl-prginfo.c
+++ b/runtime/src/chpl-prginfo.c
@@ -18,9 +18,17 @@
  * limitations under the License.
  */
 
+// Needed to access 'dladdr' and 'Dl_info'.
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE 1
+#endif
+#ifdef __FreeBSD__
+  #include <link.h>
+#endif
+#include <dlfcn.h>
+
 #include "chplrt.h"
 #include "chpl-comm.h"
-#include "chpl-dynamic-loading.h"
 #include "chpl-prginfo.h"
 
 #include <string.h>

--- a/runtime/src/chpl-prginfo.c
+++ b/runtime/src/chpl-prginfo.c
@@ -18,17 +18,11 @@
  * limitations under the License.
  */
 
-// Must define to get access to 'dladdr'.
-#ifndef _GNU_SOURCE
-  #define _GNU_SOURCE
-#endif
-
 #include "chplrt.h"
 #include "chpl-comm.h"
 #include "chpl-dynamic-loading.h"
 #include "chpl-prginfo.h"
 
-#include <dlfcn.h>
 #include <string.h>
 
 static chpl_rt_prginfo* chpl_prg_root;

--- a/runtime/src/chpl-unwind.c
+++ b/runtime/src/chpl-unwind.c
@@ -18,12 +18,20 @@
  * limitations under the License.
  */
 
+// Needed to access 'dladdr' and 'Dl_info'.
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE 1
+#endif
+#ifdef __FreeBSD__
+  #include <link.h>
+#endif
+#include <dlfcn.h>
+
 #include "chplrt.h"
 #include "chpl-linefile-support.h"
 #include "chplcgfns.h"
 
 #include "chpl-unwind.h"
-#include "chpl-dynamic-loading.h"
 #include "chpl-env.h"
 #include "chpl-error.h"
 #include "chpl-exec.h"

--- a/runtime/src/chpl-unwind.c
+++ b/runtime/src/chpl-unwind.c
@@ -18,16 +18,12 @@
  * limitations under the License.
  */
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-// needed for dlfcn.h on linux
-
 #include "chplrt.h"
 #include "chpl-linefile-support.h"
 #include "chplcgfns.h"
 
 #include "chpl-unwind.h"
+#include "chpl-dynamic-loading.h"
 #include "chpl-env.h"
 #include "chpl-error.h"
 #include "chpl-exec.h"
@@ -57,7 +53,6 @@
 // Necessary for instruct libunwind to use only the local unwind
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
-#include <dlfcn.h>
 
 #ifdef __linux__
 // We create a pipe with addr2line and try to get a line number


### PR DESCRIPTION
This PR should hopefully fix a bug in nightly testing.

Apparently on FreeBSD it's not sufficient to just `#define _GNU_SOURCE` and then `#include <dlfcn.h>`. You also need to make sure you `#include <link.h>` before you can get access to the definition of the `Dl_info` type.

I originally had the idea to do this once in `chpl-dynamic-loading.h` and then include that header, but that doesn't seem to work. It is important that `#define _GNU_SOURCE` and `#include <dlfcn.h>` appear at the top of the source file in order to get things working correctly.

Future work could consider writing runtime wrappers around `dladdr` and `Dl_info` for extra portability (though they are standardized in POSIX 2024, if we wait long enough :D).

TESTING

- [x] `CHPL_LLVM=none`, `CHPL_TARGET_COMPILER=gnu`
- [x] `CHPL_COMM=gasnet`

Reviewed by @benharsh. Thanks much!