### PR TITLE
Fix GCC 16 compiler errors with CHPL_DEVELOPER=1

### DIFF
--- a/make/compiler/Makefile.gnu
+++ b/make/compiler/Makefile.gnu
@@ -370,6 +370,16 @@ WARN_CXXFLAGS += -Wno-error=nonnull
 endif
 
 
+#
+# Avoid warnings-as-errors about unused variables in the runtime
+# this can occur in third-party libraries outside of our control included in
+# the runtime
+#
+ifeq ($(shell test $(GNU_GCC_MAJOR_VERSION) -ge 16; echo "$$?"),0)
+RUNTIME_CFLAGS += -Wno-error=unused-but-set-variable
+endif
+
+
 ifeq ($(GNU_GPP_SUPPORTS_MISSING_DECLS),1)
 WARN_CXXFLAGS += -Wmissing-declarations
 else


### PR DESCRIPTION
Fixes GCC 16 compiler errors that occur in developer mode (with `-Werror`).

The GASNet team using GCC 16 observed errors from unused variables, namely in hwloc and GASNet. Rather than worry about patching third-party code, this PR just turns the errors into warnings

Thanks to @PHHargrove for finding the issue and verifying the fix

[Reviewed by @arifthpe]