### PR TITLE
Replace invalid chars in Docker test container name

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -97,7 +97,7 @@ update_image() {
   fi
 
   # Run test script inside container
-  CONTAINER_NAME="$imageName-test"
+  CONTAINER_NAME="${imageName//[\/:]/_}-test"
   docker container rm --force --volumes "$CONTAINER_NAME"
   echo 'writeln("Hello, world!");' > hello.chpl
   docker run -i --name "$CONTAINER_NAME" "$imageName" < "$script"


### PR DESCRIPTION
Replace occurrences of `/` and `:` in the Docker test container's name with `_`, which occur in the image name that the container's name is generated from.

Follow up to https://github.com/chapel-lang/chapel/pull/28763, which gave these containers a set (invalid) name.

[trivial fix, not reviewed]

Testing:
- [x] local run succeeds