### PR TITLE
Add overrideable variables for Docker test script params

### DIFF
--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -26,6 +26,10 @@ set -exuo pipefail
 # simultaneously, and each build will use this many threads.
 export DOCKER_BUILD_MAKE_THREADS=${DOCKER_BUILD_MAKE_THREADS:-2}
 
+# Comma-separated list of Docker platforms to build multi-arch image for.
+# This will be passed as the argument to --platform.
+export DOCKER_BUILD_PLATFORMS="linux/amd64,linux/arm64"
+
 # BEGIN FUNCTIONS
 
 # Patch the Dockerfile to build FROM the nightly image instead of latest.
@@ -77,7 +81,7 @@ update_image() {
   # image before erroring out; it's important that release pushes come after
   # all nightly pushes so we can't push a broken release image.
   # Anna, 2024-10-07
-  docker_build_cmd="docker buildx build --build-arg MAKE_THREADS=$DOCKER_BUILD_MAKE_THREADS --platform=linux/amd64,linux/arm64 --push . -t $imageName"
+  docker_build_cmd="docker buildx build --build-arg MAKE_THREADS=$DOCKER_BUILD_MAKE_THREADS --platform=$DOCKER_BUILD_PLATFORMS --push . -t $imageName"
   if [ -n "$release_tag" ]
   then
     # Also push as 'latest' tag if this is a release build.

--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -28,7 +28,7 @@ export DOCKER_BUILD_MAKE_THREADS=${DOCKER_BUILD_MAKE_THREADS:-2}
 
 # Comma-separated list of Docker platforms to build multi-arch image for.
 # This will be passed as the argument to --platform.
-export DOCKER_BUILD_PLATFORMS="linux/amd64,linux/arm64"
+export DOCKER_BUILD_PLATFORMS="${DOCKER_BUILD_PLATFORMS:-linux/amd64,linux/arm64}"
 
 # BEGIN FUNCTIONS
 

--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -24,7 +24,7 @@ set -exuo pipefail
 # Use this many `make` threads in parallel within the Docker image build.
 # Note that for multi-arch builds, the build for each arch occurs
 # simultaneously, and each build will use this many threads.
-export DOCKER_BUILD_MAKE_THREADS=2
+export DOCKER_BUILD_MAKE_THREADS=${DOCKER_BUILD_MAKE_THREADS:-2}
 
 # BEGIN FUNCTIONS
 

--- a/util/cron/test-docker.bash
+++ b/util/cron/test-docker.bash
@@ -30,6 +30,10 @@ export DOCKER_BUILD_MAKE_THREADS=${DOCKER_BUILD_MAKE_THREADS:-2}
 # This will be passed as the argument to --platform.
 export DOCKER_BUILD_PLATFORMS="${DOCKER_BUILD_PLATFORMS:-linux/amd64,linux/arm64}"
 
+# Namespace (account) to name and push Docker images to. This is the part of
+# the name before the /, like "chapel" in "chapel/chapel-gasnet".
+export DOCKER_IMAGE_NAMESPACE="${DOCKER_IMAGE_NAMESPACE:-chapel}"
+
 # BEGIN FUNCTIONS
 
 # Patch the Dockerfile to build FROM the nightly image instead of latest.
@@ -42,7 +46,7 @@ dockerfile_nightly_patch() {
 1c1
 < FROM chapel/chapel:latest
 ---
-> FROM chapel/chapel:nightly
+> FROM $DOCKER_IMAGE_NAMESPACE/chapel:nightly
 "
 
   patch $patch_args ./Dockerfile << EOF
@@ -127,17 +131,17 @@ update_all_images() {
   local release_tag="$1"
 
   cd "$CHPL_HOME"
-  update_image chapel/chapel "${CHPL_HOME}/util/cron/docker-chapel.bash" "$release_tag"
+  update_image $DOCKER_IMAGE_NAMESPACE/chapel "${CHPL_HOME}/util/cron/docker-chapel.bash" "$release_tag"
 
   cd "$CHPL_HOME/util/packaging/docker/gasnet"
   dockerfile_nightly_patch
-  update_image chapel/chapel-gasnet "${CHPL_HOME}/util/cron/docker-gasnet.bash" "$release_tag"
+  update_image $DOCKER_IMAGE_NAMESPACE/chapel-gasnet "${CHPL_HOME}/util/cron/docker-gasnet.bash" "$release_tag"
   # Clean up after patch changes
   dockerfile_nightly_patch -R
 
   cd "$CHPL_HOME/util/packaging/docker/gasnet-smp"
   dockerfile_nightly_patch
-  update_image chapel/chapel-gasnet-smp "${CHPL_HOME}/util/cron/docker-gasnet.bash" "$release_tag"
+  update_image $DOCKER_IMAGE_NAMESPACE/chapel-gasnet-smp "${CHPL_HOME}/util/cron/docker-gasnet.bash" "$release_tag"
   # Clean up after patch changes
   dockerfile_nightly_patch -R
 }


### PR DESCRIPTION
Add several variables in `util/cron/test-docker.bash` for controlling build parameters, which may be set before running the script to override defaults.

Variables:
- `DOCKER_BUILD_MAKE_THREADS` (default `2`) (already existed, made overrideable)
- `DOCKER_BUILD_PLATFORMS` (default `linux/amd64,linux/arm64`)
- `DOCKER_IMAGE_NAMESPACE` (default `chapel`)

These are not currently used in our scripting, but I found them useful for quick local testing, e.g.:
```bash
# Use all cores
export DOCKER_BUILD_MAKE_THREADS=8
# Only build my machine's native arch
export DOCKER_BUILD_PLATFORMS=linux/arm64
# Place these test images in a different namespace (and Dockerhub repo) than the official one.
export DOCKER_IMAGE_NAMESPACE=arifthpe
```

[trivial, not reviewed]

Testing:
- [x] local run succeeds