### PR TITLE
Pin CentOS 9 to use LLVM 19

### DIFF
--- a/util/devel/test/portability/apptainer/current/centos-stream-9/image.def
+++ b/util/devel/test/portability/apptainer/current/centos-stream-9/image.def
@@ -8,7 +8,7 @@ From: quay.io/centos/centos:stream9
     /provision-scripts/dnf-upgrade.sh
     /provision-scripts/dnf-epel.sh
     /provision-scripts/dnf-deps.sh
-    /provision-scripts/dnf-llvm20.sh
+    /provision-scripts/dnf-llvm19.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"


### PR DESCRIPTION
The EPEL offerings for centos 9 and 10 have somewhat diverged, with 10 supporting clang20 but 9 only having clang19.