### PR TITLE
Fix constness issues for codegen-time arrays

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1612,7 +1612,7 @@ static void genGlobalSerializeTable(GenInfo* info) {
   }
 
   if( hdrfile ) {
-    fprintf(hdrfile, "\nconst void* chpl_global_serialize_table[] = {");
+    fprintf(hdrfile, "\nvoid* const chpl_global_serialize_table[] = {");
     if (serializeCalls.size() == 0) {
       // Quiet PGI warning about empty initializer
       fprintf(hdrfile, "\nNULL,");
@@ -1632,7 +1632,7 @@ static void genGlobalSerializeTable(GenInfo* info) {
 #ifdef HAVE_LLVM
     auto name = "chpl_global_serialize_table";
     auto eltType = getPointerType(info->module->getContext());
-    bool isConstant = false;
+    bool isConstant = true;
 
     // Build up the table entries.
     std::vector<llvm::Constant*> entries;
@@ -1695,7 +1695,7 @@ static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*
     #endif
   }
   if( hdrfile ) {
-    fprintf(hdrfile, "\nconst char* chpl_mem_descs[] = {\n");
+    fprintf(hdrfile, "\nconst char* const chpl_mem_descs[] = {\n");
     bool first = true;
     if (memDescsVec.n == 0) {
       // Quiet PGI warning about empty initializer
@@ -1717,7 +1717,7 @@ static void codegen_defn(std::set<const char*> & cnames, std::vector<TypeSymbol*
   // add table of private-broadcast constants
   //
   if( hdrfile ) {
-    fprintf(hdrfile, "\nconst void* chpl_private_broadcast_table[] = {\n");
+    fprintf(hdrfile, "\nvoid* const chpl_private_broadcast_table[] = {\n");
     int i = 0;
     forv_Vec(CallExpr, call, gCallExprs) {
       if (call->isPrimitive(PRIM_PRIVATE_BROADCAST)) {
@@ -2189,7 +2189,7 @@ static void codegen_header(std::set<const char*> & cnames,
 #endif
   }
   if( hdrfile ) {
-      fprintf(hdrfile, "\nextern const char* chpl_mem_descs[];\n");
+      fprintf(hdrfile, "\nextern const char* const chpl_mem_descs[];\n");
     } else {
 #ifdef HAVE_LLVM
     // Build up the values of the array.
@@ -2212,12 +2212,12 @@ static void codegen_header(std::set<const char*> & cnames,
   // add table of private-broadcast constants
   //
   if( hdrfile ) {
-    fprintf(hdrfile, "\nextern const void* chpl_private_broadcast_table[];\n");
+    fprintf(hdrfile, "\nextern void* const chpl_private_broadcast_table[];\n");
   } else if(!gCodegenGPU) {
 #ifdef HAVE_LLVM
     auto eltType = getPointerType(info->module->getContext());
     auto name = "chpl_private_broadcast_table";
-    bool isConstant = false;
+    bool isConstant = true;
 
     // Build up the table entries.
     std::vector<llvm::Constant*> entries;

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -573,7 +573,7 @@ void chpl_comm_task_end(void) {
 }
 
 
-const void* chpl_get_global_serialize_table(int64_t idx);
+void* chpl_get_global_serialize_table(int64_t idx);
 
 // Used to park and wake up the main process
 void chpl_signal_shutdown(void);

--- a/runtime/include/chpl-mem-desc.h
+++ b/runtime/include/chpl-mem-desc.h
@@ -22,6 +22,7 @@
 #define _chpl_mem_desc_H_
 
 #include "chpltypes.h"
+#include "chplcgfns.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -115,18 +116,6 @@ typedef enum {
 } chpl_mem_rtMemDesc_t;
 
 #undef CHPL_MEMDESC_MACRO
-
-
-//
-// The compiler generates a separate array of descriptions for the
-// allocation types it defines.  Indices into that compiler-generated
-// array conceptually start after the CHPL_RT_MD_NUM enum value in
-// chpl-mem.h).  This is that compiler-generated array, and how many
-// entries it has (also defined in the generated code).
-//
-extern const char* chpl_mem_descs[];
-extern const int chpl_mem_numDescs;
-
 
 typedef int16_t chpl_mem_descInt_t;
 

--- a/runtime/include/chpl-prginfo-data-macro.h
+++ b/runtime/include/chpl-prginfo-data-macro.h
@@ -53,7 +53,7 @@ E_CALLBACK_RT(chpl_task_setCommDiagsTemporarilyDisabled, void, chpl_bool)
 /** CODE-GENERATED
     Table of private broadcast constants.
 */
-E_CONSTANT_RT(chpl_private_broadcast_table, const void**)
+E_CONSTANT_RT(chpl_private_broadcast_table, void* const*)
 
 /** CODE-GENERATED
     Length of table of private broadcast constants.
@@ -63,7 +63,7 @@ E_CONSTANT_RT(chpl_private_broadcast_table_len, int)
 /** CODE-GENERATED
     TODO: Not exactly sure what this thing is. Table of serializers for RVF?
 */
-E_CONSTANT_RT(chpl_global_serialize_table, const void**)
+E_CONSTANT_RT(chpl_global_serialize_table, void* const*)
 
 /** CODE-GENERATED | WRITEABLE
     A table of local addresses of wide pointers containing global vars.
@@ -154,7 +154,7 @@ E_CONSTANT(chpl_filenameTableSize, int32_t)
     chpl-mem.h).  This is that compiler-generated array, and how many
     entries it has (also defined in the generated code).
 */
-E_CONSTANT_RT(chpl_mem_descs, const char**)
+E_CONSTANT_RT(chpl_mem_descs, const char* const*)
 
 /** CODE-GENERATED
     Length of the memory description table.

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -122,9 +122,19 @@ extern void chpl__heapAllocateGlobals(void);
 //
 extern const int chpl_numGlobalsOnHeap;
 extern ptr_wide_ptr_t chpl_globals_registry[];
-extern const void* chpl_private_broadcast_table[];
-extern int const chpl_private_broadcast_table_len;
-extern const void* chpl_global_serialize_table[];
+extern void* const chpl_private_broadcast_table[];
+extern const int chpl_private_broadcast_table_len;
+extern void* const chpl_global_serialize_table[];
+
+//
+// The compiler generates a separate array of descriptions for the
+// allocation types it defines.  Indices into that compiler-generated
+// array conceptually start after the CHPL_RT_MD_NUM enum value in
+// chpl-mem.h).  This is that compiler-generated array, and how many
+// entries it has (also defined in the generated code).
+//
+extern const char* const chpl_mem_descs[];
+extern const int chpl_mem_numDescs;
 
 #ifdef __cplusplus
 }

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -222,7 +222,7 @@ void chpl_comm_regMemHeapTouch(void* start, uintptr_t size) {
   }
 }
 
-const void* chpl_get_global_serialize_table(int64_t idx) {
+void* chpl_get_global_serialize_table(int64_t idx) {
   return chpl_global_serialize_table[idx];
 }
 

--- a/test/dynamic-loading/CodegenTimeArrays.chpl
+++ b/test/dynamic-loading/CodegenTimeArrays.chpl
@@ -15,15 +15,15 @@ extern {
   // Pass in the values materialized from the addresses through Chapel.
   void getter_chpl_global_serialize_table(void* const x[]);
   void getter_chpl_globals_registry(ptr_wide_ptr_t x[]);
-  void getter_chpl_mem_descs(const char* x[]);
+  void getter_chpl_mem_descs(const char* const x[]);
   void getter_chpl_private_broadcast_table(void* const x[]);
   void get_from_holder(holder* x);
 
   // Realize the addresses in C.
-  extern const void* chpl_global_serialize_table[];
+  extern void* const chpl_global_serialize_table[];
   extern ptr_wide_ptr_t chpl_globals_registry[];
-  extern const char* chpl_mem_descs[];
-  extern const void* chpl_private_broadcast_table[];
+  extern const char* const chpl_mem_descs[];
+  extern void* const chpl_private_broadcast_table[];
 
   #define PRINTER(in__, name__) do {                        \
     void* ptr1 = ((void*) in__);                            \
@@ -41,7 +41,7 @@ extern {
     PRINTER(x, chpl_globals_registry);
   }
 
-  void getter_chpl_mem_descs(const char* x[]) {
+  void getter_chpl_mem_descs(const char* const x[]) {
     PRINTER(x, chpl_mem_descs);
   }
 


### PR DESCRIPTION
In a previous PR I tried to adjust the types of several codegen-time arrays in order to simplify them, but that caused problems. Revert my changes, and mark several arrays that can be constant as constant under LLVM.

In my ideal world, within the runtime, the types of these arrays wouldn't have any `const` decorators at all, because `const` usually just causes grief within C code. However, in the generated Chapel program code, they _do_ need to be marked as `const` in some capacity because we need to ensure that they are correctly placed in _read-only_ memory by the C compiler.

In the future when `chplcgfns.h` is removed we can decouple the types a bit more, but for now, we need to make sure that things still strongly match w.r.t. constness.

TESTING

- [x] `standard`
- [x] `LLVM=none`, `TARGET_COMPILER=gnu`
- [x] `COMM=gasnet`

Reviewed by @benharsh. Thanks!