### PR TITLE
dlopen: Program entrypoints prepare program info for runtime

### DIFF
--- a/modules/internal/ChapelProgramEntrypoints.chpl
+++ b/modules/internal/ChapelProgramEntrypoints.chpl
@@ -19,7 +19,7 @@
  */
 
 module ChapelProgramEntrypoints {
-  use ChapelBase, CTypes;
+  use ChapelBase, ChapelProgramRegistration, CTypes;
 
   // This is an opaque alias for "char" used to make sure the compiler will
   // generate the proper type instead of e.g., "int(8)" as is usually done
@@ -70,7 +70,8 @@ module ChapelProgramEntrypoints {
   //                    runtime initialization is split out from library init.
   export proc chpl_library_init(argc: chpl_opaque_c_int,
                                 argv: chpl_opaque_argv_array) {
-    extern proc chpl_rt_init(argc: chpl_opaque_c_int,
+    extern proc chpl_rt_init(root_prg: c_ptr(chpl_rt_prginfo),
+                             argc: chpl_opaque_c_int,
                              argv: chpl_opaque_argv_array): void;
     // TODO: A lie, 'chpl_main' is actually a local function pointer.
     extern proc chpl_task_callMain(chpl_main: c_ptr(void)): void;
@@ -89,7 +90,7 @@ module ChapelProgramEntrypoints {
 
     // NOTE: The call 'chpl_rt_init' is idempotent and nothing will happen
     // if the runtime is already initialized.
-    chpl_rt_init(argc, argv);
+    chpl_rt_init(chpl_programInfoHere.asPtr(), argc, argv);
 
     // TODO: There really needs to be a better way to do this. Is the normal
     //       casting not working because the proc-ptr is a class right now?

--- a/runtime/include/chpl-init.h
+++ b/runtime/include/chpl-init.h
@@ -18,12 +18,14 @@
  * limitations under the License.
  */
 
-#ifndef _CHPL_INIT_H_
-#define _CHPL_INIT_H_
+#ifndef CHPL_RT_INIT_H
+#define CHPL_RT_INIT_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include "chpl-prginfo.h"
 
 #include <stdint.h>
 
@@ -36,7 +38,7 @@ void deallocate_string_literals_buf(void);
 
 #endif // ifndef LAUNCHER
 
-void chpl_rt_init(int argc, char* argv[]);
+void chpl_rt_init(chpl_rt_prginfo* root_prg, int argc, char** argv);
 
 void chpl_executable_init(void);
 

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -210,8 +210,11 @@ void chpl_rt_init(chpl_rt_prginfo* root_prg, int argc, char** argv) {
   int runInLLDB = 0;
 
   // First thing: bind the root program so that other code can function.
-  int is_root_program_bound = chpl_rt_prginfo_register_root_here(root_prg);
-  assert(is_root_program_bound);
+  int is_root_prg_bound = chpl_rt_prginfo_register_root_here(root_prg);
+
+  // Realistically, this should never fire.
+  assert(is_root_prg_bound);
+  (void) is_root_prg_bound;
 
   // Check that we can get the page size.
   assert( sys_page_size() > 0 );

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -202,12 +202,16 @@ static int is_runtime_initialized = 0;
 //
 // Initialize the Chapel runtime.
 //
-void chpl_rt_init(int argc, char* argv[]) {
+void chpl_rt_init(chpl_rt_prginfo* root_prg, int argc, char** argv) {
   if (is_runtime_initialized) return; else is_runtime_initialized = 1;
 
-  int32_t execNumLocales;
-  int runInGDB;
-  int runInLLDB;
+  int32_t execNumLocales = 0;
+  int runInGDB = 0;
+  int runInLLDB = 0;
+
+  // First thing: bind the root program so that other code can function.
+  int is_root_program_bound = chpl_rt_prginfo_register_root_here(root_prg);
+  assert(is_root_program_bound);
 
   // Check that we can get the page size.
   assert( sys_page_size() > 0 );

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -23,11 +23,35 @@
 #include "chpl-init.h"
 #include "chplexit.h"
 #include "config.h"
+#include "chpl-prginfo.h"
+
+// Defined in our module code. We will link against it.
+extern chpl_rt_prginfo* chpl_prepareProgramInfoHere(void);
 
 int main(int argc, char* argv[]) {
+  // Run the code that initializes our program information.
+  chpl_rt_prginfo* our_root_prg = chpl_prepareProgramInfoHere();
+  chpl_rt_prginfo* got_root_prg = NULL;
 
-  // Initialize the runtime
-  chpl_rt_init(argc, argv);
+  // Initialize the runtime, giving it our program info.
+  chpl_rt_init(our_root_prg, argc, argv);
+
+  // Have the runtime fetch the root program.
+  got_root_prg = CHPL_RT_PRGINFO_ROOT;
+
+  // It should match what we gave 'chpl_rt_init'.
+  if (got_root_prg && our_root_prg != got_root_prg) {
+    fprintf(stderr, "Unexpected error: a Chapel program tried to initialize "
+                    "the Chapel runtime, but it was already initialized");
+    // Call 'exit_all' since the runtime is likely initialized (how? weird!).
+    chpl_exit_all(1);
+    return 1;
+  } else if (!got_root_prg) {
+    // In this path, we kind of have to assume the runtime is not initialized.
+    fprintf(stderr, "Unexpected error: the Chapel runtime does not "
+                    "return a root program");
+    exit(1);
+  }
 
   // Run the main function for this node.
   chpl_task_callMain(chpl_executable_init);

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -41,16 +41,11 @@ int main(int argc, char* argv[]) {
 
   // It should match what we gave 'chpl_rt_init'.
   if (got_root_prg && our_root_prg != got_root_prg) {
-    fprintf(stderr, "Unexpected error: a Chapel program tried to initialize "
-                    "the Chapel runtime, but it was already initialized");
-    // Call 'exit_all' since the runtime is likely initialized (how? weird!).
-    chpl_exit_all(1);
-    return 1;
+    chpl_internal_error("a Chapel program tried to initialize the Chapel "
+                        "runtime, but the root program was already bound");
+
   } else if (!got_root_prg) {
-    // In this path, we kind of have to assume the runtime is not initialized.
-    fprintf(stderr, "Unexpected error: the Chapel runtime does not "
-                    "return a root program");
-    exit(1);
+    chpl_internal_error("the Chapel runtime has not bound a root program");
   }
 
   // Run the main function for this node.

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -240,12 +240,12 @@ stopInitCommDiags
   from print-module-resolution.ChapelStandard.stopInitCommDiags
 ChapelDynamicLoading
   from print-module-resolution.ChapelStandard.ChapelDynamicLoading
+ChapelSetProgramInfoDataEntries
+  from print-module-resolution.ChapelStandard.ChapelProgramEntrypoints.ChapelProgramRegistration.ChapelSetProgramInfoDataEntries
+ChapelProgramRegistration
+  from print-module-resolution.ChapelStandard.ChapelProgramEntrypoints.ChapelProgramRegistration
 ChapelProgramEntrypoints
   from print-module-resolution.ChapelStandard.ChapelProgramEntrypoints
-ChapelSetProgramInfoDataEntries
-  from print-module-resolution.ChapelStandard.ChapelProgramRegistration.ChapelSetProgramInfoDataEntries
-ChapelProgramRegistration
-  from print-module-resolution.ChapelStandard.ChapelProgramRegistration
 ChapelStandard
   from print-module-resolution.ChapelStandard
 print-module-resolution

--- a/test/dynamic-loading/DumpProgramDataEntries.chpl
+++ b/test/dynamic-loading/DumpProgramDataEntries.chpl
@@ -1,8 +1,6 @@
 proc main() {
   use ChapelProgramRegistration;
   for loc in Locales do on loc {
-    // TODO: For now, prepare manually. Later, this will happen for us.
-    chpl_prepareProgramInfoHere();
     chpl_programInfoHere.dump(showAddresses=false);
   }
 }

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -65,8 +65,8 @@ Initializing Modules:
     ChapelStaticVars
     ChapelDynamicLoading
     ChapelProgramEntrypoints
-    ChapelProgramRegistration
-     ChapelSetProgramInfoDataEntries
+     ChapelProgramRegistration
+      ChapelSetProgramInfoDataEntries
     AlignedTSupport
    printModuleInitOrder
     moduleInitTest


### PR DESCRIPTION
This PR sets up program info on each locale "automagically". After this PR, the fields (callbacks, constants, tables) in a Chapel program's information may be used directly by the runtime.

This PR adjusts Chapel program entrypoints to prepare their `chpl_rt_prginfo` on each locale, and then pass it to `chpl_rt_init`. It adjusts `chpl_rt_init` to accept a new first formal of type `chpl_rt_prginfo*`. The effect after this PR is that Chapel programs appear to set up their program infos automatically.

TESTING

- [x] `standard`
- [x] `LLVM=none`, `COMPILER=gnu`
- [x] `COMM=gasnet`

Reviewed by @jabraham17. Thanks!