### PR TITLE
Fix 'gather tests' primitive for procedure pointers

### DIFF
--- a/compiler/AST/CallExpr.cpp
+++ b/compiler/AST/CallExpr.cpp
@@ -457,8 +457,9 @@ QualifiedType CallExpr::qualType(void) {
   if (primitive) {
     retval = primitive->returnInfo(this);
 
-  } else if (isResolved() || (se && isFunctionType(se->symbol()->type))) {
-    auto ft = toFunctionType(se->symbol()->type);
+  } else if (isResolved() ||
+             (se && isFunctionType(se->symbol()->getValType()) && !se->symbol()->hasFlag(FLAG_TYPE_VARIABLE))) {
+    auto ft = toFunctionType(se->symbol()->getValType());
     auto fn = resolvedFunction();
     INT_ASSERT(fn || ft);
 

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2043,6 +2043,10 @@ static void codegen_header(std::set<const char*> & cnames,
   genSubclassArray(true);
   genClassNames(types, true);
 
+  // Generate root class first to satisfy assumptions made elsewhere
+  dtObject->codegenPrototype();
+  dtObject->codegenDef();
+
   // Generate procedure pointer types first to handle circular dependencies.
   genComment("Procedure Pointer Types");
   forv_Vec(TypeSymbol, ts, types) {

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2059,6 +2059,7 @@ static void codegen_header(std::set<const char*> & cnames,
   forv_Vec(TypeSymbol, typeSymbol, types) {
     if (!typeSymbol->hasFlag(FLAG_REF) && !typeSymbol->hasFlag(FLAG_DATA_CLASS))
     {
+      if (typeSymbol->type == dtObject) continue;
       typeSymbol->codegenPrototype();
     }
   }
@@ -2100,7 +2101,9 @@ static void codegen_header(std::set<const char*> & cnames,
 
   while (current.n) {
     forv_Vec(TypeSymbol, ts, current) {
-      ts->codegenDef();
+      if (ts->type != dtObject) {
+        ts->codegenDef();
+      }
 
       if (AggregateType* at = toAggregateType(ts->type)) {
         forv_Vec(AggregateType, child, at->dispatchChildren) {

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -900,8 +900,10 @@ static Expr* preFoldPrimOp(CallExpr* call) {
               if (isSubtypeOrInstantiation(fn->getFormal(1)->type,
                                           testType,
                                           call)) {
+                auto prim = fcfs::usePointerImplementation() ? PRIM_CAPTURE_FN :
+                              PRIM_CAPTURE_FN_TO_CLASS;
                 // TODO: Replace me with a function pointer.
-                auto capture = new CallExpr(PRIM_CAPTURE_FN_TO_CLASS,
+                auto capture = new CallExpr(prim,
                                             new SymExpr(fn));
                 fn->defPoint->getStmtExpr()->insertAfter(capture);
                 Expr* val = resolveExpr(capture);


### PR DESCRIPTION
This PR allows the 'gather tests' primitive to use procedure pointers by switching to using ``PRIM_CAPTURE_FN`` when procedure pointers are enabled.

Other fixes:
- Fix ``CallExpr::qualType`` to handle calling a ref to a function
- Manually codegen ``RootClass`` so that procedure pointers can have classes as arguments

Testing:
- [x] local paratest
- [x] gasnet paratest