### PR TITLE
Fix a malformed date in the script that runs chapcs playground

### DIFF
--- a/util/cron/test-perf.chapcs.playground.bash
+++ b/util/cron/test-perf.chapcs.playground.bash
@@ -37,7 +37,7 @@ export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.chapcs.playground"
 GITHUB_USER=chapel-lang
 GITHUB_BRANCH=main
 SHORT_NAME=unset
-START_DATE=4/23/2026
+START_DATE=4/23/26
 
 set -e
 checkout_branch $GITHUB_USER $GITHUB_BRANCH


### PR DESCRIPTION
We weren't actively using this playground, but this config has been going yellow for a week because I put a malformed date into the script. Fix that.