### PR TITLE
Use 'std::ignore' on an unused loop index variable

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -985,6 +985,8 @@ public:
     }
 
     for (auto& [cname, fns] : nameMap) {
+      std::ignore = cname;
+
       FnSymbol* lastNonExternFn = nullptr;
       FnSymbol* lastExternFn = nullptr;
       int numExportOrDefault = 0;


### PR DESCRIPTION
Fix a `-Wunused-variable` warning-as-error that was firing for an older version of `gcc`.