### PR TITLE
dlopen: Replace uses of compiler-generated symbols in RT

### DIFF
--- a/modules/internal/ChapelProgramEntrypoints.chpl
+++ b/modules/internal/ChapelProgramEntrypoints.chpl
@@ -88,9 +88,11 @@ module ChapelProgramEntrypoints {
       return;
     }
 
+    const ptr = chpl_prepareProgramInfoHere();
+
     // NOTE: The call 'chpl_rt_init' is idempotent and nothing will happen
     // if the runtime is already initialized.
-    chpl_rt_init(chpl_programInfoHere.asPtr(), argc, argv);
+    chpl_rt_init(ptr, argc, argv);
 
     // TODO: There really needs to be a better way to do this. Is the normal
     //       casting not working because the proc-ptr is a class right now?

--- a/runtime/include/chpl-prginfo.h
+++ b/runtime/include/chpl-prginfo.h
@@ -163,6 +163,10 @@ typedef uint64_t chpl_rt_prg_id;
 #define CHPL_RT_PRGINFO_ROOT \
   (chpl_rt_prginfo_from_id_here(CHPL_RT_PRGINFO_ROOT_ID))
 
+// TODO: Eventually replace all references to this with either a program
+//       pointer or a deliberate use of 'CHPL_RT_PRGINFO_ROOT'.
+#define CHPL_RT_ROOT_PROGRAM_PLACEHOLDER CHPL_RT_PRGINFO_ROOT
+
 /** Retrieve a program's info on the current locale given an ID. */
 #define CHPL_RT_PRGINFO_FETCH(id__) (chpl_rt_prginfo_from_id_here(id__))
 

--- a/runtime/include/chpl-prginfo.h
+++ b/runtime/include/chpl-prginfo.h
@@ -65,7 +65,7 @@
   locale by writing (e.g., for a 'chpl_rt_prginfo*' named 'prg' and
   for a data named 'foo'):
 
-  CHPL_RT_PRGINFO_DATA_TEMP(prg, foo);
+  CHPL_RT_PRGINFO_DECLARE(prg, foo);
 
   This will declare a temporary in the current scope with the name 'foo' that
   has the C type for the constant.
@@ -187,7 +187,7 @@ typedef uint64_t chpl_rt_prg_id;
 #endif
 
 /** Declares a local that is a copy of a program data, with the same name. */
-#define CHPL_RT_PRGINFO_DATA_TEMP(prg__, data_name__)             \
+#define CHPL_RT_PRGINFO_DECLARE(prg__, data_name__)               \
   CHPL_RT_PRGINFO_DATA_ENTRY_TYPE(data_name__) data_name__ =      \
       CHPL_RT_PRGINFO_DATA(prg__, data_name__)
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -136,10 +136,11 @@ extern void* const chpl_global_serialize_table[];
 extern const char* const chpl_mem_descs[];
 extern const int chpl_mem_numDescs;
 
-extern const int mainHasArgs;
 extern const int mainPreserveDelimiter;
 extern const int warnUnstable;
 extern chpl_main_argument chpl_gen_main_arg;
+extern const int launcher_is_mli;
+extern const char* launcher_mli_real_name;
 
 #ifdef __cplusplus
 }

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -97,9 +97,6 @@ extern char* chpl_executionCommand;
 extern const chpl_fn_p chpl_ftable[];
 extern const chpl_fn_info chpl_finfo[];
 
-/* used for entry point: */
-extern int64_t chpl_gen_main(chpl_main_argument* const _arg);
-
 //
 // chpl_globals_registry is an array of size chpl_numGlobalsOnHeap
 // storing ptr_wide_ptr_t, that is, local addresses of wide pointers.

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -97,8 +97,6 @@ extern char* chpl_executionCommand;
 extern const chpl_fn_p chpl_ftable[];
 extern const chpl_fn_info chpl_finfo[];
 
-void chpl__init_ChapelStandard(int64_t _ln, int32_t _fn);
-
 /* used for entry point: */
 extern int64_t chpl_gen_main(chpl_main_argument* const _arg);
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -106,9 +106,6 @@ void chpl__init_ChapelStandard(int64_t _ln, int32_t _fn);
 /* used for entry point: */
 extern int64_t chpl_gen_main(chpl_main_argument* const _arg);
 
-/* used for config vars: */
-extern void CreateConfigVarTable(void);
-
 //
 // Shared interface (implemented in the compiler generated code)
 //

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -136,7 +136,6 @@ extern void* const chpl_global_serialize_table[];
 extern const char* const chpl_mem_descs[];
 extern const int chpl_mem_numDescs;
 
-extern const int warnUnstable;
 extern chpl_main_argument chpl_gen_main_arg;
 extern const int launcher_is_mli;
 extern const char* launcher_mli_real_name;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -107,11 +107,6 @@ void chpl__init_ChapelStandard(int64_t _ln, int32_t _fn);
 extern int64_t chpl_gen_main(chpl_main_argument* const _arg);
 
 //
-// Shared interface (implemented in the compiler generated code)
-//
-extern void chpl__heapAllocateGlobals(void);
-
-//
 // chpl_globals_registry is an array of size chpl_numGlobalsOnHeap
 // storing ptr_wide_ptr_t, that is, local addresses of wide pointers.
 // It is filled in and used by chpl_comm_register_global_var() and

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -97,7 +97,6 @@ extern char* chpl_executionCommand;
 extern const chpl_fn_p chpl_ftable[];
 extern const chpl_fn_info chpl_finfo[];
 
-void chpl__init_preInit(int64_t _ln, int32_t _fn);
 void chpl__init_PrintModuleInitOrder(int64_t _ln, int32_t _fn);
 void chpl__init_ChapelStandard(int64_t _ln, int32_t _fn);
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -136,6 +136,11 @@ extern void* const chpl_global_serialize_table[];
 extern const char* const chpl_mem_descs[];
 extern const int chpl_mem_numDescs;
 
+extern const int mainHasArgs;
+extern const int mainPreserveDelimiter;
+extern const int warnUnstable;
+extern chpl_main_argument chpl_gen_main_arg;
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -97,7 +97,6 @@ extern char* chpl_executionCommand;
 extern const chpl_fn_p chpl_ftable[];
 extern const chpl_fn_info chpl_finfo[];
 
-void chpl__init_PrintModuleInitOrder(int64_t _ln, int32_t _fn);
 void chpl__init_ChapelStandard(int64_t _ln, int32_t _fn);
 
 /* used for entry point: */

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -136,7 +136,6 @@ extern void* const chpl_global_serialize_table[];
 extern const char* const chpl_mem_descs[];
 extern const int chpl_mem_numDescs;
 
-extern const int mainPreserveDelimiter;
 extern const int warnUnstable;
 extern chpl_main_argument chpl_gen_main_arg;
 extern const int launcher_is_mli;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -97,8 +97,6 @@ extern char* chpl_executionCommand;
 extern const chpl_fn_p chpl_ftable[];
 extern const chpl_fn_info chpl_finfo[];
 
-extern void chpl__initStringLiterals(void);
-
 void chpl__init_preInit(int64_t _ln, int32_t _fn);
 void chpl__init_PrintModuleInitOrder(int64_t _ln, int32_t _fn);
 void chpl__init_ChapelStandard(int64_t _ln, int32_t _fn);

--- a/runtime/include/config.h
+++ b/runtime/include/config.h
@@ -22,6 +22,7 @@
 #define _config_H_
 
 #include "chpltypes.h"
+#include "chplcgfns.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,11 +46,6 @@ void parseConfigFile(const char* configFilename,
 
 chpl_bool chpl_config_has_value(c_string v, c_string m);
 c_string chpl_config_get_value(c_string v, c_string m);
-
-extern const int mainHasArgs;
-extern const int mainPreserveDelimiter;
-extern const int warnUnstable;
-extern chpl_main_argument chpl_gen_main_arg;
 
 #ifdef __cplusplus
 }

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -27,6 +27,7 @@
 #include "chplexit.h"
 #include "chplio.h"
 #include "chpl-mem.h"
+#include "chpl-prginfo.h"
 #include "chplmemtrack.h"
 #include "chpl-tasks.h"
 #include "chpl-linefile-support.h"
@@ -358,12 +359,15 @@ int32_t getArgNumLocalesPerNode(void) {
 extern void chpl_program_about(void); // The generated code provides this
 void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
                int* argc, char* argv[]) {
-  int i;
+  int i = 0;
   int printHelp = 0;
   int printAbout = 0;
   int origargc = *argc;
   int stop_parsing = 0;
   int saw_socket_conn = 0;
+
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            mainHasArgs);
 
   //
   // Handle the pre-parse for '-E' arguments separately.

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -399,6 +399,10 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
      */
     if (mainHasArgs && strcmp(currentArg, "--") == 0) {
       stop_parsing = 1;
+
+      CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                mainPreserveDelimiter);
+
       // if the ArgumentParser was also included, copy the -- through so it
       // may use it as a passthrough delimiter
       if (mainPreserveDelimiter) {

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -366,8 +366,7 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
   int stop_parsing = 0;
   int saw_socket_conn = 0;
 
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            mainHasArgs);
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, mainHasArgs);
 
   //
   // Handle the pre-parse for '-E' arguments separately.
@@ -400,12 +399,10 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
     if (mainHasArgs && strcmp(currentArg, "--") == 0) {
       stop_parsing = 1;
 
-      CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                                mainPreserveDelimiter);
-
       // if the ArgumentParser was also included, copy the -- through so it
       // may use it as a passthrough delimiter
-      if (mainPreserveDelimiter) {
+      if (CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                               mainPreserveDelimiter)) {
         chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = currentArg;
         chpl_gen_main_arg.argc++;
       }

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -352,6 +352,9 @@ void chpl_rt_init(chpl_rt_prginfo* root_prg, int argc, char** argv) {
 // each locale in order for the Chapel program to function correctly.
 //
 void chpl_std_module_init(void) {
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl__heapAllocateGlobals);
+
   // chpl__initStringLiterals runs the constructors for all string literals. We
   // need to setup the literals on every locale before any other chapel code is
   // run.

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -276,12 +276,18 @@ void chpl_rt_init(chpl_rt_prginfo* root_prg, int argc, char** argv) {
 
   chpl_comm_barrier("about to leave comm init code");
 
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            CreateConfigVarTable);
+
   CreateConfigVarTable();      // get ready to start tracking config vars
+
   chpl_gen_main_arg.argv = chpl_malloc(argc * sizeof(char*));
   chpl_gen_main_arg.argv[0] = argv[0];
   chpl_gen_main_arg.argc = 1;
   chpl_gen_main_arg.return_value = 0;
+
   parseArgs(false, parse_normally, &argc, argv);
+
   recordExecutionCommand(argc, argv);
 
   chpl_topo_post_args_init();

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -360,6 +360,8 @@ void chpl_std_module_init(void) {
                             chpl__init_preInit);
   CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                             chpl__init_PrintModuleInitOrder);
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl__init_ChapelStandard);
 
   // chpl__initStringLiterals runs the constructors for all string literals. We
   // need to setup the literals on every locale before any other chapel code is

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -406,9 +406,12 @@ void chpl_std_module_init(void) {
 // into chpl-init.c:chapel_std_module_init().
 //
 void chpl_executable_init(void) {
-
   chpl_std_module_init();
+
   if (chpl_nodeID == 0) {
+    CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                              chpl_gen_main);
+
     //
     // Call the compiler-generated main() routine
     //

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -68,7 +68,8 @@ void deallocate_string_literals_buf(void) {
 
 int handleNonstandardArg(int* argc, char* argv[], int argNum,
                          int32_t lineno, int32_t filename) {
-
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            mainHasArgs);
   if (mainHasArgs) {
     chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = argv[argNum];
     chpl_gen_main_arg.argc++;

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -353,6 +353,8 @@ void chpl_rt_init(chpl_rt_prginfo* root_prg, int argc, char** argv) {
 //
 void chpl_std_module_init(void) {
   CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl__initStringLiterals);
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                             chpl__heapAllocateGlobals);
 
   // chpl__initStringLiterals runs the constructors for all string literals. We

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -356,6 +356,8 @@ void chpl_std_module_init(void) {
                             chpl__initStringLiterals);
   CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                             chpl__heapAllocateGlobals);
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl__init_preInit);
 
   // chpl__initStringLiterals runs the constructors for all string literals. We
   // need to setup the literals on every locale before any other chapel code is

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -68,9 +68,7 @@ void deallocate_string_literals_buf(void) {
 
 int handleNonstandardArg(int* argc, char* argv[], int argNum,
                          int32_t lineno, int32_t filename) {
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            mainHasArgs);
-  if (mainHasArgs) {
+  if (CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, mainHasArgs)) {
     chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = argv[argNum];
     chpl_gen_main_arg.argc++;
   } else {
@@ -276,10 +274,9 @@ void chpl_rt_init(chpl_rt_prginfo* root_prg, int argc, char** argv) {
 
   chpl_comm_barrier("about to leave comm init code");
 
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            CreateConfigVarTable);
-
-  CreateConfigVarTable();      // get ready to start tracking config vars
+  // Call a callback from the program data to initialize the config table.
+  CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                       CreateConfigVarTable)();
 
   chpl_gen_main_arg.argv = chpl_malloc(argc * sizeof(char*));
   chpl_gen_main_arg.argv[0] = argv[0];
@@ -352,33 +349,25 @@ void chpl_rt_init(chpl_rt_prginfo* root_prg, int argc, char** argv) {
 // each locale in order for the Chapel program to function correctly.
 //
 void chpl_std_module_init(void) {
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl__initStringLiterals);
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl__heapAllocateGlobals);
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl__init_preInit);
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl__init_PrintModuleInitOrder);
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl__init_ChapelStandard);
+  chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
 
-  // chpl__initStringLiterals runs the constructors for all string literals. We
-  // need to setup the literals on every locale before any other chapel code is
-  // run.
-  chpl__initStringLiterals();
-  chpl__heapAllocateGlobals(); // allocate global vars on heap for multilocale
+  // Set up the string literals on every locale before other code is run.
+  // Note that this calls a function pointer from the program info's data.
+  CHPL_RT_PRGINFO_DATA(prg, chpl__initStringLiterals)();
+
+  // Allocate globals on the heap. Does nothing if not in multi-locale.
+  CHPL_RT_PRGINFO_DATA(prg, chpl__heapAllocateGlobals)();
 
   if (chpl_nodeID == 0) {
     //
     // This just sets all of the initialization predicates to false.
     // Must occur before any other call to a chpl__init_<foo> function.
     //
-    chpl__init_preInit(0, myFilename);
+    CHPL_RT_PRGINFO_DATA(prg, chpl__init_preInit)(0, myFilename);
 
     // Initialize the internal modules.
-    chpl__init_PrintModuleInitOrder(0, myFilename);
-    chpl__init_ChapelStandard(0, myFilename);
+    CHPL_RT_PRGINFO_DATA(prg, chpl__init_PrintModuleInitOrder)(0, myFilename);
+    CHPL_RT_PRGINFO_DATA(prg, chpl__init_ChapelStandard)(0, myFilename);
 
     // Note that in general, module code can contain "on" clauses
     // and should therefore not be called before the call to
@@ -409,8 +398,9 @@ void chpl_executable_init(void) {
   chpl_std_module_init();
 
   if (chpl_nodeID == 0) {
-    CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                              chpl_gen_main);
+    // Fetch 'chpl_gen_main' from the root program's data.
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_gen_main);
 
     //
     // Call the compiler-generated main() routine

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -358,6 +358,8 @@ void chpl_std_module_init(void) {
                             chpl__heapAllocateGlobals);
   CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                             chpl__init_preInit);
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl__init_PrintModuleInitOrder);
 
   // chpl__initStringLiterals runs the constructors for all string literals. We
   // need to setup the literals on every locale before any other chapel code is

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -640,10 +640,8 @@ int handleNonstandardArg(int* argc, char* argv[], int argNum,
   }
 
   if (numHandled == 0) {
-    CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                              mainHasArgs);
-
-    if (mainHasArgs) {
+    if (CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                             mainHasArgs)) {
       chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = argv[argNum];
       chpl_gen_main_arg.argc++;
     } else {
@@ -810,9 +808,6 @@ int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales,
   int32_t execNumLocalesPerNode;
   int argc = *c_argc;
 
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            CreateConfigVarTable);
-
   // Set up main argument parsing.
   chpl_gen_main_arg.argv = chpl_mem_allocMany(argc, sizeof(char*),
                                       CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
@@ -820,7 +815,10 @@ int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales,
   chpl_gen_main_arg.argc = 1;
   chpl_gen_main_arg.return_value = 0;
 
-  CreateConfigVarTable();
+  // Call a callback to create the table which stores config vars.
+  CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                       CreateConfigVarTable)();
+
   parseArgs(true, parse_normally, &argc, argv);
 
   execNumLocales = getArgNumLocales();

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <assert.h>
 #include "chplcgfns.h"
+#include "chpl-prginfo.h"
 #include "chpl-comm-launch.h"
 #include "chpl-comm-locales.h"
 #include "chplexit.h"
@@ -44,13 +45,6 @@ extern char** environ;
 // This global variable stores the arguments to main
 // that should be handled by the program.
 chpl_main_argument chpl_gen_main_arg;
-// This variable is normally declared in config.h
-// and comes from the generated code.
-extern const int mainHasArgs;
-extern const int mainPreserveDelimiter;
-extern const int launcher_is_mli;
-extern const char* launcher_mli_real_name;
-
 
 //
 // Are we doing a dry run, printing the system launcher command but
@@ -646,6 +640,9 @@ int handleNonstandardArg(int* argc, char* argv[], int argNum,
   }
 
   if (numHandled == 0) {
+    CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                              mainHasArgs);
+
     if (mainHasArgs) {
       chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = argv[argNum];
       chpl_gen_main_arg.argc++;

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -810,6 +810,9 @@ int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales,
   int32_t execNumLocalesPerNode;
   int argc = *c_argc;
 
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            CreateConfigVarTable);
+
   // Set up main argument parsing.
   chpl_gen_main_arg.argv = chpl_mem_allocMany(argc, sizeof(char*),
                                       CHPL_RT_MD_COMMAND_BUFFER, -1, 0);

--- a/runtime/src/chpl-prginfo.c
+++ b/runtime/src/chpl-prginfo.c
@@ -77,7 +77,8 @@ chpl_rt_prginfo_register_here_nosync(chpl_rt_prg_id id, chpl_rt_prginfo* prg) {
   chpl_bool requestingNewIdx = (id == CHPL_RT_PRGINFO_NULL_ID);
   int64_t idxToUse = requestingNewIdx ? 0 : ((int64_t) id);
 
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_PRGINFO_ROOT, chpl_mapPtrToIdxHere);
+  // Fetch and invoke callback from the root program specifically.
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_PRGINFO_ROOT, chpl_mapPtrToIdxHere);
   int64_t got = chpl_mapPtrToIdxHere(prg, idxToUse);
 
   if (!requestingNewIdx && idxToUse != got) {
@@ -119,7 +120,7 @@ chpl_rt_prginfo* chpl_rt_prginfo_from_id_here(chpl_rt_prg_id id) {
   if (id == CHPL_RT_PRGINFO_ROOT_ID) return chpl_prg_root;
 
   // Fetch pointers from the root program.
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_PRGINFO_ROOT, chpl_getPtrForIdxHere);
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_PRGINFO_ROOT, chpl_getPtrForIdxHere);
   int64_t idx = (int64_t) id;
   chpl_rt_prginfo* ret = chpl_getPtrForIdxHere(idx);
 

--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -26,6 +26,7 @@
 #include "chplexit.h"
 #include "chplio.h"
 #include "chpl-mem.h"
+#include "chpl-prginfo.h"
 #include "chpl-linefile-support.h"
 #include "config.h"
 #include "chpl-error.h"
@@ -314,6 +315,8 @@ static configVarType* lookupConfigVar(const char* moduleName,
 void initSetValue(const char* varName, const char* value,
                   const char* moduleName,
                   int32_t lineno, int32_t filename) {
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            warnUnstable);
   configVarType* configVar;
   if  (*varName == '\0') {
     const char* message = "No variable name given";

--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -315,8 +315,7 @@ static configVarType* lookupConfigVar(const char* moduleName,
 void initSetValue(const char* varName, const char* value,
                   const char* moduleName,
                   int32_t lineno, int32_t filename) {
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            warnUnstable);
+  chpl_rt_prginfo* root = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
   configVarType* configVar;
   if  (*varName == '\0') {
     const char* message = "No variable name given";
@@ -346,7 +345,8 @@ void initSetValue(const char* varName, const char* value,
       chpl_warning(configVar->deprecationMsg, lineno, filename);
     }
     #endif
-  } else if (warnUnstable && configVar->unstable) {
+  } else if (CHPL_RT_PRGINFO_DATA(root, warnUnstable) &&
+             configVar->unstable) {
     #ifndef LAUNCHER
     if (chpl_nodeID == 0) {
       chpl_warning(configVar->unstableMsg, lineno, filename);


### PR DESCRIPTION
This PR is part of a series that begins to replace all direct references to compiler-generated symbols in the runtime. As this is the first one, I've elected to replace symbols that are either used once (e.g., `chpl_gen_main`, callbacks for module initializers), or used infrequently (e.g., symbol tables for stack unwinding).

TESTING:

- [x] `standard`
- [x] `COMM=gasnet`

Reviewed by @jabraham17. Thanks!