### PR TITLE
Make `third-party/llvm/update-bundled.sh` less redundant

### DIFF
--- a/third-party/llvm/update-bundled.sh
+++ b/third-party/llvm/update-bundled.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e # error out on any failed command
+set -ex
 
 LLVM_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 LLVM_VERSION=$1
@@ -11,32 +11,34 @@ fi
 
 BASE_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VERSION
 
+cd $LLVM_DIR
+
 # download sources if not already present
-(set -x && cd $LLVM_DIR && test -f llvm-project-$LLVM_VERSION.src.tar.xz || wget $BASE_URL/llvm-project-$LLVM_VERSION.src.tar.xz)
-(set -x && cd $LLVM_DIR && test -f llvm-project-$LLVM_VERSION.src.tar.xz.sig || wget $BASE_URL/llvm-project-$LLVM_VERSION.src.tar.xz.sig)
+test -f llvm-project-$LLVM_VERSION.src.tar.xz || wget $BASE_URL/llvm-project-$LLVM_VERSION.src.tar.xz
+test -f llvm-project-$LLVM_VERSION.src.tar.xz.sig || wget $BASE_URL/llvm-project-$LLVM_VERSION.src.tar.xz.sig
 
 # verify signatures
-(set -x && cd $LLVM_DIR && gpg --verify llvm-project-$LLVM_VERSION.src.tar.xz.sig)
+gpg --verify llvm-project-$LLVM_VERSION.src.tar.xz.sig
 
 # clean tree
-(set -x && cd $LLVM_DIR && git rm -r llvm-src cmake third-party)
+git rm -r llvm-src cmake third-party
 
 # extract sources
-(set -x && cd $LLVM_DIR && tar xfv llvm-project-$LLVM_VERSION.src.tar.xz)
+tar xfv llvm-project-$LLVM_VERSION.src.tar.xz
 
 # rename directories
-(set -x && cd $LLVM_DIR && mv llvm-project-$LLVM_VERSION.src/llvm llvm-src)
-(set -x && cd $LLVM_DIR && mv llvm-project-$LLVM_VERSION.src/clang llvm-src/tools/clang)
-(set -x && cd $LLVM_DIR && mv llvm-project-$LLVM_VERSION.src/cmake cmake)
-(set -x && cd $LLVM_DIR && mv llvm-project-$LLVM_VERSION.src/third-party third-party)
+mv llvm-project-$LLVM_VERSION.src/llvm llvm-src
+mv llvm-project-$LLVM_VERSION.src/clang llvm-src/tools/clang
+mv llvm-project-$LLVM_VERSION.src/cmake cmake
+mv llvm-project-$LLVM_VERSION.src/third-party third-party
 
 # remove unused folders
-(set -x && cd $LLVM_DIR && rm -rf llvm-src/test llvm-src/unittests llvm-src/examples llvm-src/benchmarks llvm-src/docs)
-(set -x && cd $LLVM_DIR && rm -rf llvm-src/tools/clang/test llvm-src/tools/clang/unittests llvm-src/tools/clang/examples llvm-src/tools/clang/docs)
+rm -rf llvm-src/test llvm-src/unittests llvm-src/examples llvm-src/benchmarks llvm-src/docs
+rm -rf llvm-src/tools/clang/test llvm-src/tools/clang/unittests llvm-src/tools/clang/examples llvm-src/tools/clang/docs
 
 # git add and commit
-(set -x && cd $LLVM_DIR && git add --force llvm-src cmake third-party)
-(set -x && cd $LLVM_DIR && git commit -sm "Update bundled LLVM to version $LLVM_VERSION")
+git add --force llvm-src cmake third-party
+git commit -sm "Update bundled LLVM to version $LLVM_VERSION"
 
 # cleanup
-(set -x && cd $LLVM_DIR && rm -r llvm-project-$LLVM_VERSION.src.tar.xz llvm-project-$LLVM_VERSION.src.tar.xz.sig llvm-project-$LLVM_VERSION.src)
+rm -r llvm-project-$LLVM_VERSION.src.tar.xz llvm-project-$LLVM_VERSION.src.tar.xz.sig llvm-project-$LLVM_VERSION.src

--- a/third-party/llvm/update-bundled.sh
+++ b/third-party/llvm/update-bundled.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -exuo pipefail
 
 LLVM_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 LLVM_VERSION=$1


### PR DESCRIPTION
Add `set -x` and `cd $LLVM_DIR` at the top of `third-party/llvm/update-bundled.sh` rather than repeating those steps on each line.

While here, also set the rest of `set -exuo pipefail` as a good practice.

[reviewer info placeholder]

Testing:
- [x] test run of script worked