### PR TITLE
Fix deprecation warnings with cuda 12.9

### DIFF
--- a/runtime/include/gpu/nvidia/chpl-gpu-dev-reduce.h
+++ b/runtime/include/gpu/nvidia/chpl-gpu-dev-reduce.h
@@ -72,14 +72,19 @@ chpl_gpu_dev_##chpl_kind##_breduce_##data_type##_##block_size(data_type thread_v
 \
   typedef cub::BlockReduce<data_type, block_size> BlockReduce; \
   __shared__ typename BlockReduce::TempStorage temp_storage; \
-  data_type res = BlockReduce(temp_storage).Reduce(thread_val, cub::impl_kind()); \
+  data_type res = BlockReduce(temp_storage).Reduce(thread_val, impl_kind()); \
   if (threadIdx.x == 0) { \
     interim_res[blockIdx.x] = res; \
   } \
 }
 
-GPU_DEV_REDUCE(DEF_ONE_DEV_REDUCE_RET_VAL, Min, min);
-GPU_DEV_REDUCE(DEF_ONE_DEV_REDUCE_RET_VAL, Max, max);
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 129
+GPU_DEV_REDUCE(DEF_ONE_DEV_REDUCE_RET_VAL, cuda::minimum, min);
+GPU_DEV_REDUCE(DEF_ONE_DEV_REDUCE_RET_VAL, cuda::maximum, max);
+#else
+GPU_DEV_REDUCE(DEF_ONE_DEV_REDUCE_RET_VAL, cub::Min, min);
+GPU_DEV_REDUCE(DEF_ONE_DEV_REDUCE_RET_VAL, cub::Max, max);
+#endif
 
 #undef DEF_ONE_DEV_REDUCE_RET_VAL
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -425,6 +425,11 @@ def get_runtime_compile_args():
         # workaround an issue with __float128 not being supported by clang in device code
         system.append("-D__STRICT_ANSI__=1")
 
+        major_version, minor_version = get_sdk_version().split(".")[:2]
+        bundled.append("-DCUDA_VERSION_MAJOR=" + major_version)
+        bundled.append("-DCUDA_VERSION_MINOR=" + minor_version)
+        bundled.append("-DCUDA_VERSION=" + major_version + minor_version)
+
     elif gpu_type == "amd":
         # -isystem instead of -I silences warnings from inside these includes.
         system.append("-isystem" + os.path.join(sdk_path, "include"))


### PR DESCRIPTION
Fixes some deprecation warnings for cuda 12.9 due to a deprecation in cub.

Note: this PR gives only partial support for cuda 12.9 (enough for basic compilations to work). For full support, more steps need to be taken

Technically, cuda 12.9 is not supported with clang 21 (which is what I used to do my testing). This means there may be some instability. For example, all compilations now print "fatbinary warning : option 'image' has been deprecated". This is the same issue cuda 13 support has, see https://github.com/chapel-lang/chapel/issues/28387#issuecomment-3918070948. To fix this will require specializing for LLVM 22 (which this PR does not do)

- [x] check that basic compilations with GPUs work on cuda 12.9

[Reviewed by @arifthpe]