### PR TITLE
dlopen: Move `chpl_executionCommand` to be part of program data

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -255,20 +255,35 @@ genGlobalDefClassId(const char* cname, int id, bool isHeader) {
   }
 }
 static void
-genGlobalString(const char *cname, const char *value) {
+genGlobalString(const char *cname, const char *value, bool isConstant=true) {
   GenInfo* info = gGenInfo;
-  if( info->cfile ) {
-    fprintf(info->cfile, "const char* %s = \"%s\";\n", cname, value);
+  bool hasValue = value != nullptr;
+  FILE* fp = info->cfile;
+
+  if (fp) {
+    const char* constPart = isConstant ? "const " : "";
+    if (hasValue) {
+      fprintf(fp, "%schar* %s = \"%s\";\n", constPart, cname, value);
+    } else {
+      fprintf(fp, "%schar* %s = NULL;\n", constPart, cname);
+    }
   } else {
 #ifdef HAVE_LLVM
-    if(gCodegenGPU == false) {
-      llvm::GlobalVariable *globalString = llvm::cast<llvm::GlobalVariable>(
-          info->module->getOrInsertGlobal(
-            cname, getPointerType(info->module->getContext())));
-      globalString->setInitializer(llvm::cast<llvm::GlobalVariable>(
-            new_CStringSymbol(value)->codegen().val)->getInitializer());
-      globalString->setConstant(true);
-      info->lvt->addGlobalValue(cname, globalString, GEN_PTR, true, dtStringC);
+    if (!gCodegenGPU) {
+      auto llvmPtrType = getPointerType(info->module->getContext());
+      auto lookup = info->module->getOrInsertGlobal(cname, llvmPtrType);
+      auto gVar = llvm::cast<llvm::GlobalVariable>(lookup);
+
+      if (hasValue) {
+        gVar->setInitializer(llvm::cast<llvm::GlobalVariable>(
+              new_CStringSymbol(value)->codegen().val)->getInitializer());
+      } else {
+        gVar->setInitializer(llvm::Constant::getNullValue(llvmPtrType));
+      }
+
+      if (isConstant) gVar->setConstant(true);
+
+      info->lvt->addGlobalValue(cname, gVar, GEN_PTR, true, dtStringC);
     }
 #endif
   }
@@ -1370,6 +1385,8 @@ static void genConfigGlobalsAndAbout() {
   genGlobalString("chpl_compileCommand", compileCommand);
   genGlobalString("chpl_compileVersion", compileVersion);
   genGlobalString("chpl_compileDirectory", getCwd());
+  genGlobalString("chpl_executionCommand", nullptr, /**isConstant*/ false);
+
   if (!saveCDir.empty()) {
     char *actualPath = realpath(saveCDir.c_str(), NULL);
     genGlobalString("chpl_saveCDir", actualPath);

--- a/runtime/include/chpl-prginfo-data-macro.h
+++ b/runtime/include/chpl-prginfo-data-macro.h
@@ -181,6 +181,11 @@ E_CALLBACK_RT(chpl_memTracking_returnConfigVals, void,
 */
 E_CONSTANT_RT(chpl_compileCommand, const char*)
 
+/** CODE-GENERATED | WRITEABLE
+    Pointer used to store the execution command used to run this program.
+*/
+E_CONSTANT_RT(chpl_executionCommand, char*)
+
 /** CODE-GENERATED
     Directory where the compiler invocation took place.
 */

--- a/runtime/include/chpl-prginfo.h
+++ b/runtime/include/chpl-prginfo.h
@@ -139,11 +139,6 @@ typedef struct qio_channel_s qio_channel_t;
   typedef ret_type__ (*CHPL_RT_PRGINFO_DATA_ENTRY_TYPE(name__))(__VA_ARGS__);
 #include "chpl-prginfo-data-macro-adapter.h"
 
-// TODO: Where the heck does this live (i.e., launcher or us?). It was
-//       declared in 'chplcgfns.h', but clearly that's not correct as
-//       it is not code-generated (and that header is going away).
-extern char* chpl_executionCommand;
-
 /** Whether or not the runtime is compiled as a dynamic library or not. */
 extern int chpl_rt_is_dynamic_library;
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -91,8 +91,6 @@ extern const c_string chpl_funSymTable[];
 extern const int chpl_filenumSymTable[];
 extern const int32_t chpl_sizeSymTable;
 
-extern char* chpl_executionCommand;
-
 /* generated */
 extern const chpl_fn_p chpl_ftable[];
 extern const chpl_fn_info chpl_finfo[];

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -88,8 +88,8 @@ static void recordExecutionCommand(int argc, char *argv[]) {
     length += strlen(argv[i]) + 1;
   }
 
-  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_executionCommand);
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_executionCommand);
 
   chpl_executionCommand =
     (char*)chpl_mem_allocMany(length+1, sizeof(char),

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -50,8 +50,6 @@ static const int32_t myFilename = CHPL_FILE_IDX_INTERNAL;
 
 chpl_main_argument chpl_gen_main_arg;
 
-char* chpl_executionCommand;
-
 void* chpl_string_literals_buffer;
 
 const char* allocate_string_literals_buf(int64_t s) {
@@ -89,6 +87,10 @@ static void recordExecutionCommand(int argc, char *argv[]) {
   for (i = 0; i < argc; i++) {
     length += strlen(argv[i]) + 1;
   }
+
+  CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_executionCommand);
+
   chpl_executionCommand =
     (char*)chpl_mem_allocMany(length+1, sizeof(char),
                               CHPL_RT_MD_EXECUTION_COMMAND, 0, 0);

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -669,8 +669,8 @@ void chpl_reportMemInfo(void) {
   if (memLogFile && memLogFile != stdout)
     fclose(memLogFile);
   if (memLeaksLog && strcmp(memLeaksLog, "")) {
-    CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                              chpl_executionCommand);
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_executionCommand);
 
     memLogFile = fopen(memLeaksLog, "a");
     fprintf(memLogFile, "\nCompiler Command : %s\n", chpl_compileCommand);

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -30,6 +30,7 @@
 #include "chpl-comm-internal.h"
 #include "chplcgfns.h"
 #include "chpl-linefile-support.h"
+#include "chpl-prginfo.h"
 #include "config.h"
 #include "chpl-error.h"
 
@@ -668,6 +669,9 @@ void chpl_reportMemInfo(void) {
   if (memLogFile && memLogFile != stdout)
     fclose(memLogFile);
   if (memLeaksLog && strcmp(memLeaksLog, "")) {
+    CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                              chpl_executionCommand);
+
     memLogFile = fopen(memLeaksLog, "a");
     fprintf(memLogFile, "\nCompiler Command : %s\n", chpl_compileCommand);
     fprintf(memLogFile, "Execution Command: %s\n\n", chpl_executionCommand);


### PR DESCRIPTION
This PR adjusts `chpl_executionCommand` so that it no longer lives in the runtime but becomes a writeable variable that lives in data section of a `chpl_rt_prginfo`. As part of `chpl_rt_init` the runtime initializes the `chpl_executionCommand` for the root program.

TESTING

- [x] `COMM=gasnet`

Reviewed by @jabraham17. Thanks!