### PR TITLE
Update Nvidia GPU testing to CUDA 12.9

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -708,7 +708,7 @@ marked with * are covered in our nightly testing configurations.
 
   * Hardware: RTX A2000, P100*, V100*, A100*, H100, GH200
 
-  * Software: CUDA 11.7, 11.8, 12.0, 12.2, 12.4, 12.8*, 12.9, 13.0
+  * Software: CUDA 11.7, 11.8, 12.0, 12.2, 12.4, 12.8, 12.9*, 13.0
 
 * AMD
 

--- a/util/cron/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
+++ b/util/cron/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
@@ -1,6 +1,3 @@
 # common settings for running GPU nightly testing on the HPE Cray EX system with CUDA 12
 
-# We need 12.8 for the stream test because the CUDA driver on pinoak
-# only supports PTX for 12.8, until the driver is updated, we need to
-# stick with 12.8 instead of 12.9
-module load cuda/12.8  # default is CUDA 12.9
+module load cuda/12.9  # default is CUDA 13.0


### PR DESCRIPTION
Update our CUDA 12 test configs from 12.8 to 12.9.

Also updates comments about outdated machine drivers (no longer the case) and the default CUDA module version.

[reviewed by @jabraham17 , thanks!]