### PR TITLE
Extend copy elision to understand `defer` statements

### DIFF
--- a/compiler/passes/splitInit.cpp
+++ b/compiler/passes/splitInit.cpp
@@ -40,6 +40,7 @@
 #include "stmt.h"
 #include "symbol.h"
 #include "TryStmt.h"
+#include "DeferStmt.h"
 
 /************************************* | **************************************
 *                                                                             *
@@ -786,6 +787,17 @@ static ReturnInfo doFindCopyElisionPoints(Expr* start,
   if (start == NULL)
     return false;
 
+  // Process defers after we're done with 'start', in reverse order of appearence
+  llvm::SmallVector<DeferStmt*, 4> defers;
+  auto clearDefers = [&]() {
+    while (!defers.empty()) {
+      DeferStmt* defer = defers.back();
+      defers.pop_back();
+      VariablesSet newEligible;
+      doFindCopyElisionPoints(defer->body()->body.first(), map, newEligible);
+    }
+  };
+
   // Scroll forwards in the block containing start.
   for (Expr* cur = start->getStmtExpr(); cur != NULL; cur = cur->next) {
 
@@ -875,6 +887,7 @@ static ReturnInfo doFindCopyElisionPoints(Expr* start,
       }
 
       if (regularReturn || errorReturn) {
+        clearDefers();
         bool elide = !errorReturn || cannotRecover;
         if (elide) doElideCopies(map);
         return { true, elide };
@@ -894,8 +907,10 @@ static ReturnInfo doFindCopyElisionPoints(Expr* start,
         // non-loop block
         Expr* start = block->body.first();
         auto returned = doFindCopyElisionPoints(start, map, eligible);
-        if (returned.returnedUnconditionally)
+        if (returned.returnedUnconditionally) {
+          clearDefers();
           return returned; // stop traversing if it returned
+        }
       }
 
       // If we had a reason to, we could remove variables going
@@ -957,6 +972,7 @@ static ReturnInfo doFindCopyElisionPoints(Expr* start,
 
       // If both blocks return, then they have already been copy elided.
       if (ifRet.elidedCopies && elseRet.elidedCopies) {
+        clearDefers();
         return true;
 
       // Neither if nor else block unconditionally elided copies.
@@ -1025,16 +1041,21 @@ static ReturnInfo doFindCopyElisionPoints(Expr* start,
         }
       }
       if (ifRet.returnedUnconditionally && elseRet.returnedUnconditionally) {
+        clearDefers();
         return ReturnInfo { true, ifRet.elidedCopies && elseRet.elidedCopies };
       }
     } else if (isFunctionOrTypeDeclaration(cur)) {
       // OK: mentions like `proc f() { ... x ... }` don't count
+    } else if (auto defer = toDeferStmt(cur)) {
+      // Handle later; mentions aren't logically here.
+      defers.push_back(defer);
     } else {
       // Look for uses of 'x'
       noteUses(cur, map);
     }
   }
 
+  clearDefers();
   return false;
 }
 

--- a/test/statements/defer/copy-elision-branch.chpl
+++ b/test/statements/defer/copy-elision-branch.chpl
@@ -1,0 +1,28 @@
+record myRec {
+  proc init=(rhs: myRec) {
+    writeln("copy constructor");
+  }
+}
+
+proc foo() {
+  var aOrig = new myRec();
+  var aCopy = aOrig;
+  writeln("done with a");
+
+  var bOrig = new myRec();
+  var bCopy = bOrig;
+  writeln("done with b");
+
+  defer { writeln(aOrig); }
+
+  var cond: bool;
+  if cond {
+    return;
+  } else {
+    return;
+  }
+
+  defer { writeln(bOrig); }
+}
+
+foo();

--- a/test/statements/defer/copy-elision-branch.good
+++ b/test/statements/defer/copy-elision-branch.good
@@ -1,0 +1,4 @@
+copy constructor
+done with a
+done with b
+()

--- a/test/statements/defer/copy-elision-defer-local.chpl
+++ b/test/statements/defer/copy-elision-defer-local.chpl
@@ -1,0 +1,19 @@
+record myRec {
+  proc init=(rhs: myRec) {
+    writeln("copy constructor");
+  }
+}
+
+proc foo() {
+  var a = new myRec();
+  defer {
+    var b = a; // ought to copy
+    writeln("b: ", b);
+    var c = new myRec();
+    var d = c; // ought to elide
+    writeln("d: ", d);
+  }
+  return;
+}
+
+foo();

--- a/test/statements/defer/copy-elision-defer-local.good
+++ b/test/statements/defer/copy-elision-defer-local.good
@@ -1,0 +1,3 @@
+copy constructor
+b: ()
+d: ()

--- a/test/statements/defer/copy-elision.chpl
+++ b/test/statements/defer/copy-elision.chpl
@@ -1,0 +1,26 @@
+record myRec {
+  proc init=(rhs: myRec) {
+    writeln("copy constructor");
+  }
+}
+
+proc foo1() {
+  var a = new myRec();
+  defer {
+    writeln(a);
+  }
+  var b = a; // not copy elided; defer uses it.
+  return;
+}
+proc foo2() {
+  var a = new myRec();
+  defer {
+    writeln("not using a");
+  }
+  var b = a; // should be eligible for copy elision, not print 'copy constructor'
+  return;
+}
+
+foo1();
+writeln("---");
+foo2();

--- a/test/statements/defer/copy-elision.good
+++ b/test/statements/defer/copy-elision.good
@@ -1,0 +1,4 @@
+copy constructor
+()
+---
+not using a


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/28469.

As described in the linked issue, production doesn't properly handle `defer` statements. It treats them as "any old expression", and treats uses of variables in them as occurring during the time that the `defer` occurs in the code. This is simply not correct; `defer` statements are executed after all other code in the block, and in reverse order, interleaved with variable deallocation. In the program below, copy elision should not occur, since the `defer` statement uses the copied-out-of variable `a` _after_ the copy into `b`. 

```Chapel
class MyClass2 {}

proc foo() {
  var a = new shared MyClass2();
  defer {
    writeln(a);
  }
  var b = a;
  return;
}
foo();
```

This PR implements this behavior. Since variable deinitializations do not trigger copy elision (they have no mentions of other variables in scope), it's sufficient to simply keep a stack of `DeferStmt`s as they are encountered. Whenever processing of the block concludes (during an early return or when reaching its end), the encountered statements are processed in reverse order. For the time being, I do not allow copy elisions from "outer" variables into `defer`s. This may be safe, but seems tricky, and the current implementation is a strict upgrade over the current behavior. On the other hand, copy elisions of variables that are both within the `defer` now work as normal. 

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] paratest