### PR TITLE
Add retry loop in publish-docs workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,24 +70,6 @@ jobs:
       run: |
         ./util/buildRelease/smokeTest quickstart mason chpl
 
-  test_retry_failure:
-    runs-on: ubuntu-latest
-    steps:
-      - name: fail and retry
-        uses: nick-fields/retry@v4
-        with:
-          max_attempts: 15
-          timeout_seconds: 60
-          retry_wait_seconds: 1
-          command: |
-            python3 -c '
-            import sys
-            import secrets
-            a = secrets.randbelow(10)
-            print(a)
-            if a > 2:
-              sys.exit(1)'
-
   check_dyno_linters:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,6 +70,24 @@ jobs:
       run: |
         ./util/buildRelease/smokeTest quickstart mason chpl
 
+  test_retry_failure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: fail and retry
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 15
+          timeout_seconds: 60
+          retry_wait_seconds: 1
+          command: |
+            python3 -c '
+            import sys
+            import secrets
+            a = secrets.randbelow(10)
+            print(a)
+            if a > 2:
+              sys.exit(1)'
+
   check_dyno_linters:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -220,15 +220,20 @@ jobs:
           echo "${{ secrets.WEBSITE_KEY }}" > ~/.ssh/id_rsa
           echo "${{ secrets.WEBSITE_KNOWN_HOSTS}}" > ~/.ssh/known_hosts
 
-      - name: push docs
-        run: |
-          echo "extract docs"
-          tar -xvf docs.tar.gz
-          echo "Publish module docs to web server"
-          # py-modindex.html is not needed
-          rm -f py-modindex.html
-          # Remove all hidden files except .htaccess
-          find . -maxdepth 1 -type f -name ".*" ! -name ".htaccess" -exec rm -f {} +
-          rsync -avz --cvs-exclude --delete --relative . ${{ secrets.WEBSITE_USER }}@${{ secrets.WEBSITE_URL }}:${{ secrets.WEBSITE_PATH }}
-          rm ~/.ssh/id_rsa
-          rm ~/.ssh/known_hosts
+      - name: push docs (retrying)
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 3
+          timeout_seconds: 60
+          retry_wait_seconds: 30
+          command: |
+            echo "extract docs"
+            tar -xvf docs.tar.gz
+            echo "Publish module docs to web server"
+            # py-modindex.html is not needed
+            rm -f py-modindex.html
+            # Remove all hidden files except .htaccess
+            find . -maxdepth 1 -type f -name ".*" ! -name ".htaccess" -exec rm -f {} +
+            rsync -avz --cvs-exclude --delete --relative . ${{ secrets.WEBSITE_USER }}@${{ secrets.WEBSITE_URL }}:${{ secrets.WEBSITE_PATH }}
+            rm ~/.ssh/id_rsa
+            rm ~/.ssh/known_hosts


### PR DESCRIPTION
To smooth over transient network connection issues in our `publish-docs` Github Actions job, add retries after a delay with the [Retry Step](https://github.com/marketplace/actions/retry-step) action.

[reviewer info placeholder]

Testing:
- [x] retries worked as expected in test job