### PR TITLE
Avoid deprecated warnings due to clang bug

### DIFF
--- a/make/compiler/Makefile.clang
+++ b/make/compiler/Makefile.clang
@@ -179,12 +179,13 @@ CLANG_VER := $(shell echo __clang_major__ | $(CXX) -E -x c++ - | sed -e '/^\#/d'
 CHPL_GASNET_MORE_CFLAGS += $(shell test $(CLANG_VER) -gt 15 && echo -Wno-cast-function-type-strict)
 
 #
-# Don't warn for deprecated declarations with clang 18, 19, and 20
+# Don't warn for deprecated declarations with clang 18, 19, 20, and 22
 # https://github.com/llvm/llvm-project/issues/76515
 #
 COMP_CXXFLAGS += $(shell test $(CLANG_VER) -eq 18 && echo -Wno-deprecated-declarations)
 COMP_CXXFLAGS += $(shell test $(CLANG_VER) -eq 19 && echo -Wno-deprecated-declarations)
 COMP_CXXFLAGS += $(shell test $(CLANG_VER) -eq 20 && echo -Wno-deprecated-declarations)
+COMP_CXXFLAGS += $(shell test $(CLANG_VER) -eq 22 && echo -Wno-deprecated-declarations)
 
 endif
 


### PR DESCRIPTION
Turns off warnings for deprecated C++ library symbols due to a bug in clang

[Reviewed by @arifthpe]