### PR TITLE
Unpin Github CI Dockerfile dep versions, build periodically

### DIFF
--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -24,9 +24,9 @@ on:
       - .github/workflows/build-CI-container.yml
   # Adds a "manual run" option in the GH UI
   workflow_dispatch:
-  # Also rebuild nightly
+  # Also rebuild weekly
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 0'
 
 
 jobs:

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -24,6 +24,9 @@ on:
       - .github/workflows/build-CI-container.yml
   # Adds a "manual run" option in the GH UI
   workflow_dispatch:
+  # Also rebuild nightly
+  schedule:
+    - cron: '0 0 * * *'
 
 
 jobs:
@@ -48,7 +51,7 @@ jobs:
           # example: ghcr.io/chapel-lang/chapel-github-ci:latest
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
       - name: Push Docker Image if on main
-        if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+        if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push') || (github.event_name == 'schedule'))
         uses: docker/build-push-action@v2.9.0
         with:
           file: ${{ env.DOCKERFILE }}

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -51,7 +51,7 @@ jobs:
           # example: ghcr.io/chapel-lang/chapel-github-ci:latest
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
       - name: Push Docker Image if on main
-        if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push') || (github.event_name == 'schedule'))
+        if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule'))
         uses: docker/build-push-action@v2.9.0
         with:
           file: ${{ env.DOCKERFILE }}

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
   # Also rebuild weekly
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 0 * * 2'
 
 
 jobs:

--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -2,25 +2,25 @@
 # tzdata is necessary for util/test/check_annotations.py to function properly (get the right dates)
 # locales is necessary for util/buildRelease/smokeTest docs
 
-FROM ubuntu:24.04
+FROM ubuntu:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     bash \
-    clang-19 \
+    clang \
     cmake \
     cscope \
     doxygen \
     g++ \
     gcc \
     git \
-    libclang-19-dev \
-    libclang-cpp19-dev \
+    libclang-dev \
+    libclang-dev \
     libedit-dev \
-    llvm-19 \
-    llvm-19-dev \
-    llvm-19-tools \
+    llvm \
+    llvm-dev \
+    llvm-tools \
     locales \
     m4 \
     make \


### PR DESCRIPTION
In the Dockerfile used to build the container our Github Actions workflows run in, use the `:latest` (LTS) version of the `ubuntu` base image and the default version of chpl dependencies from its repos.

Also includes:
- Add a `schedule` trigger to rebuild the image weekly, so we're always close to up to date.
- Change the condition on the push part of the job to allow pushing from the `workflow_dispatch` trigger. Previously, a manually-triggered run of this job would not push the newly-built image, a likely unintended result of https://github.com/chapel-lang/chapel/pull/20760.

Similarly to https://github.com/chapel-lang/chapel/pull/26713, this makes it so we don't have to worry about manually updating this image (like in https://github.com/chapel-lang/chapel/pull/27463). This should pretty much always give us a "reasonable" version of the OS and our dependencies, and I think it's unlikely that latest LTS Ubuntu will outrun what we support -- if it did, we'd have to update to accommodate it anyways.

Has the nice side effect of reducing the image size from 549MB to 491MB (in my local build).

[reviewer info placeholder]