### PR TITLE
Revert "Bump dawidd6/action-send-mail from 3 to 17"

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -58,7 +58,7 @@ jobs:
               echo 'EOF' >> $GITHUB_ENV
 
       - name: Send mail
-        uses: dawidd6/action-send-mail@v17
+        uses: dawidd6/action-send-mail@v3
         with:
            # Required mail server address if not connection_url:
            server_address: ${{ secrets.SMTP_PROVIDER}}


### PR DESCRIPTION
Reverts chapel-lang/chapel#28812

Broke because `from` now needs to be a valid email address (currently is just github username), will fix in a bit.