### PR TITLE
Add a dummy 'from' address for commit emails

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -73,8 +73,8 @@ jobs:
            subject: "[Chapel Merge] ${{github.event.pull_request.title}}"
            # Required recipients' addresses:
            to: chapel+commits@discoursemail.com
-           # Required sender full name (address can be skipped):
-           from:  ${{env.AUTHOR}}
+           # Required sender (supported formats: see "Supported address formats" below)
+           from:  "${{env.AUTHOR}} <chapel_commits@cray.com>"
            body: |
 
               Branch: ${{github.ref}}


### PR DESCRIPTION
Change the `from` field for our commit emailer workflow from just the author's username to also include a valid email address (at a nonexistent mailbox).

The new `from` address is like `arifthpe <chapel_commits@cray.com>`, chosen as I can be reasonably sure no such mailbox exists, and for tradition :)

This is needed for https://github.com/chapel-lang/chapel/pull/28815.

[trivial, not reviewed]