### PR TITLE
Add periodic CI container rebuild, fix manually-triggered build

### DIFF
--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -24,9 +24,9 @@ on:
       - .github/workflows/build-CI-container.yml
   # Adds a "manual run" option in the GH UI
   workflow_dispatch:
-  # Also rebuild nightly
+  # Also rebuild weekly
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 0'
 
 
 jobs:

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -24,6 +24,9 @@ on:
       - .github/workflows/build-CI-container.yml
   # Adds a "manual run" option in the GH UI
   workflow_dispatch:
+  # Also rebuild nightly
+  schedule:
+    - cron: '0 0 * * *'
 
 
 jobs:
@@ -48,7 +51,7 @@ jobs:
           # example: ghcr.io/chapel-lang/chapel-github-ci:latest
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
       - name: Push Docker Image if on main
-        if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push'))
+        if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push') || (github.event_name == 'schedule'))
         uses: docker/build-push-action@v2.9.0
         with:
           file: ${{ env.DOCKERFILE }}

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -51,7 +51,7 @@ jobs:
           # example: ghcr.io/chapel-lang/chapel-github-ci:latest
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
       - name: Push Docker Image if on main
-        if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push') || (github.event_name == 'schedule'))
+        if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule'))
         uses: docker/build-push-action@v2.9.0
         with:
           file: ${{ env.DOCKERFILE }}

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
   # Also rebuild weekly
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 0 * * 2'
 
 
 jobs:


### PR DESCRIPTION
Add a weekly scheduled run of the `build-CI-container` workflow, and fix a bug where a manually-triggered image build would not actually get pushed.

These changes are extracted from https://github.com/chapel-lang/chapel/pull/28807, with the problematic dependency updates excluded. Though there is less reason for periodic rebuilds without the unpinning, I want it anyways to 1) make use of if/when we eventually unpin, 2) make sure something doesn't break the container build without us knowing, and 3) get (security) updates that are backported to the base image tag we use.

[changes in original PR reviewed by @jabraham17 , not re-reviewed here]