### PR TITLE
Guard against llvm_lib_dir being None when LLVM isn't found

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -246,7 +246,7 @@ def check_llvm_packages(llvm_config):
     else:
         clang_lib_name = "libclang-cpp.so"
 
-    if os.path.isdir(llvm_lib_dir):
+    if llvm_lib_dir and os.path.isdir(llvm_lib_dir):
         clang_cpp_lib = os.path.join(llvm_lib_dir, clang_lib_name)
         clang_cpp_lib_ok = os.path.exists(clang_cpp_lib)
         if usr_include_clang_ok and not clang_cpp_lib_ok:

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -258,6 +258,8 @@ def check_llvm_packages(llvm_config):
             # use e.g. /usr/lib64/libclang-cpp.so
             clang_cpp_lib = os.path.join("/usr/lib64", clang_lib_name)
             clang_cpp_lib_ok = os.path.exists(clang_cpp_lib)
+    else:
+        llvm_include_ok = False
 
     s = ""
     if not llvm_include_ok:


### PR DESCRIPTION
Adds a guard to prevent `printchplenv` from hitting a python error when `llvm_lib_dir` is None, which can happen if we can't find a suitable LLVM to use

[Reviewed by @arifthpe]