### PR TITLE
Speedup `start_test`'s cleaning.

### DIFF
--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -506,11 +506,10 @@ def clean(test=False):
     date_str = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 
     # clean executables, tmps, etc. — call sub_clean directly (no subprocess)
-    sub_clean_path = os.path.join(util_dir, "test", "sub_clean.py")
     try:
         if test:  # single test
             logger.write(
-                "[Starting {0} {1} {2}]".format(sub_clean_path, test, date_str)
+                "[Starting {0} {1}]".format(test, date_str)
             )
             to_clean = [test]
         else:

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -516,10 +516,7 @@ def clean(test=False):
             to_clean = [test]
         else:
             to_clean = ["."]
-        buf = io.StringIO()
-        with contextlib.redirect_stdout(buf):
-            sub_clean.clean(to_clean)
-        logger.write(buf.getvalue())
+        logger.write(sub_clean.clean(to_clean))
     except:
         logger.write("[Error: sub_clean error]")
 

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -10,6 +10,7 @@ import contextlib
 import fnmatch
 import getpass
 import glob
+import io
 import logging
 import os
 import platform
@@ -43,6 +44,7 @@ from chplenv import *
 import py3_compat
 import re2_supports_valgrind
 import check_perf_graphs
+import sub_clean
 
 import argparse
 
@@ -504,17 +506,20 @@ def summarize():
 def clean(test=False):
     date_str = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 
-    # clean executables, tmps, etc.
-    sub_clean = os.path.join(util_dir, "test", "sub_clean")
+    # clean executables, tmps, etc. — call sub_clean directly (no subprocess)
+    sub_clean_path = os.path.join(util_dir, "test", "sub_clean.py")
     try:
         if test:  # single test
             logger.write(
-                "[Starting {0} {1} {2}]".format(sub_clean, test, date_str)
+                "[Starting {0} {1} {2}]".format(sub_clean_path, test, date_str)
             )
-            out = run_command([sub_clean, test])
+            to_clean = [test]
         else:
-            out = run_command([sub_clean])
-        logger.write(out)
+            to_clean = ["."]
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            sub_clean.clean(to_clean)
+        logger.write(buf.getvalue())
     except:
         logger.write("[Error: sub_clean error]")
 

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -508,9 +508,7 @@ def clean(test=False):
     # clean executables, tmps, etc. — call sub_clean directly (no subprocess)
     try:
         if test:  # single test
-            logger.write(
-                "[Starting {0} {1}]".format(test, date_str)
-            )
+            logger.write("[Starting {0} {1}]".format(test, date_str))
             to_clean = [test]
         else:
             to_clean = ["."]

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -505,10 +505,10 @@ def summarize():
 def clean(test=False):
     date_str = time.strftime("%a %b %d %H:%M:%S %Z %Y")
 
-    # clean executables, tmps, etc. — call sub_clean directly (no subprocess)
+    # clean executables, tmps, etc.
     try:
         if test:  # single test
-            logger.write("[Starting {0} {1}]".format(test, date_str))
+            logger.write("[Starting sub_clean {0} {1}]".format(test, date_str))
             to_clean = [test]
         else:
             to_clean = ["."]

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -10,7 +10,6 @@ import contextlib
 import fnmatch
 import getpass
 import glob
-import io
 import logging
 import os
 import platform

--- a/util/test/sub_clean.py
+++ b/util/test/sub_clean.py
@@ -5,37 +5,55 @@
 
 import os, sys, time, glob, shutil
 
+
 # return True if f has .chpl or test.c extension
 def getExecname(f):
-    if ((f.count('.') != 0) and (len(f) >= 6) and (len(f)-f.find('.chpl')==5)):
-        return f[:len(f)-5]
-    elif ((f.count('.') > 1) and (len(f) >= 8) and (len(f)-f.find('.test.c')==7)):
-        return f[:len(f)-7]
-    elif ((f.count('.') > 1) and (len(f) >= 11) and (len(f)-f.find('.ml-test.c')==10)):
-        return f[:len(f)-10]
+    if (
+        (f.count(".") != 0)
+        and (len(f) >= 6)
+        and (len(f) - f.find(".chpl") == 5)
+    ):
+        return f[: len(f) - 5]
+    elif (
+        (f.count(".") > 1)
+        and (len(f) >= 8)
+        and (len(f) - f.find(".test.c") == 7)
+    ):
+        return f[: len(f) - 7]
+    elif (
+        (f.count(".") > 1)
+        and (len(f) >= 11)
+        and (len(f) - f.find(".ml-test.c") == 10)
+    ):
+        return f[: len(f) - 10]
     return None
+
 
 # read a cleanfiles file (with comments)
 def ReadCleanfiles(f, ignoreLeadingSpace=True):
-    myfile = open(f, 'r')
+    myfile = open(f, "r")
     mylines = myfile.readlines()
     myfile.close()
-    mylist=list()
+    mylist = list()
     for line in mylines:
-        line=line.rstrip()
+        line = line.rstrip()
         # ignore blank lines
-        if not line.strip(): continue
+        if not line.strip():
+            continue
         # ignore comments
         if ignoreLeadingSpace:
-            if line.lstrip()[0] == '#': continue
+            if line.lstrip()[0] == "#":
+                continue
         else:
-            if line[0] == '#': continue
+            if line[0] == "#":
+                continue
         tlist = line.split()
         for t in tlist:
-            if t[0] == '#':
+            if t[0] == "#":
                 break
             mylist.append(t)
     return mylist
+
 
 def unlink(f, removeDirs=False):
     try:
@@ -46,73 +64,78 @@ def unlink(f, removeDirs=False):
     except:
         pass
 
+
 # Clean the files associated with a Chapel test program
 def _cleanChapelTest(f):
     execname = getExecname(f)
     lines = []
     if execname:
-        lines.append('Cleaning test: '+execname+'\n')
-        globfiles = glob.glob(execname+'.*.out.tmp')
+        lines.append("Cleaning test: " + execname + "\n")
+        globfiles = glob.glob(execname + ".*.out.tmp")
         for g in globfiles:
             unlink(g)
         unlink(execname)
-        unlink(execname+'_real')
-        unlink(execname+'.dSYM', removeDirs=True)
-        unlink(execname+'_real.dSYM', removeDirs=True)
-        lines.extend(_cleanCleanfiles(None, execname+'.cleanfiles', False))
+        unlink(execname + "_real")
+        unlink(execname + ".dSYM", removeDirs=True)
+        unlink(execname + "_real.dSYM", removeDirs=True)
+        lines.extend(_cleanCleanfiles(None, execname + ".cleanfiles", False))
     return lines
+
 
 # Clean files listed in the file c, in the directory d (if given)
 def _cleanCleanfiles(d, c, rmCore):
     if d:
-        cleanfile = os.path.join(d,c)
+        cleanfile = os.path.join(d, c)
     else:
         cleanfile = c
     lines = []
-    if os.access(cleanfile,os.R_OK):
+    if os.access(cleanfile, os.R_OK):
         cleanfiles = ReadCleanfiles(cleanfile)
         if rmCore:
-            cleanfiles += ['core']
+            cleanfiles += ["core"]
         for f in cleanfiles:
             if d:
-                globfiles = glob.glob(os.path.join(d,f))
+                globfiles = glob.glob(os.path.join(d, f))
             else:
                 globfiles = glob.glob(f)
             for g in globfiles:
-                lines.append('Removing '+g+'\n')
+                lines.append("Removing " + g + "\n")
                 unlink(g, removeDirs=True)
     return lines
 
 
-def clean(to_clean=['.']):
+def clean(to_clean=["."]):
     #
     # Cleaning..
     #
     lines = [
-        '[Starting sub_clean - %s]\n'%(time.strftime('%a %b %d %H:%M:%S %Z %Y', time.localtime())),
-        '[pwd: '+os.getcwd()+']\n',
+        "[Starting sub_clean - %s]\n"
+        % (time.strftime("%a %b %d %H:%M:%S %Z %Y", time.localtime())),
+        "[pwd: " + os.getcwd() + "]\n",
     ]
 
     for f in to_clean:
         if os.path.isdir(f):
-            lines.append('Cleaning directory: '+f+'\n')
-            dirlist = glob.glob(f+'/*.chpl')
-            dirlist += glob.glob(f+'/*.test.c')
-            dirlist += glob.glob(f+'/*.ml-test.c')
+            lines.append("Cleaning directory: " + f + "\n")
+            dirlist = glob.glob(f + "/*.chpl")
+            dirlist += glob.glob(f + "/*.test.c")
+            dirlist += glob.glob(f + "/*.ml-test.c")
             dirlist.sort()
             for file in dirlist:
                 lines.extend(_cleanChapelTest(file))
-            lines.extend(_cleanCleanfiles(f, 'CLEANFILES', True))
+            lines.extend(_cleanCleanfiles(f, "CLEANFILES", True))
         else:
             lines.extend(_cleanChapelTest(f))
-            lines.extend(_cleanCleanfiles(os.path.dirname(f), 'CLEANFILES', True))
+            lines.extend(
+                _cleanCleanfiles(os.path.dirname(f), "CLEANFILES", True)
+            )
 
-    return ''.join(lines)
+    return "".join(lines)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     if len(sys.argv) == 1:
-        to_clean = ['.']
+        to_clean = ["."]
     else:
         to_clean = sys.argv[1:]
     sys.stdout.write(clean(to_clean))

--- a/util/test/sub_clean.py
+++ b/util/test/sub_clean.py
@@ -80,31 +80,31 @@ def cleanCleanfiles(d, c, rmCore):
                 unlink(g, removeDirs=True)
 
 
-#
-# Cleaning..
-#
-sys.stdout.write('[Starting sub_clean - %s]\n'%(time.strftime('%a %b %d %H:%M:%S %Z %Y', time.localtime())))
-sys.stdout.write('[pwd: '+os.getcwd()+']\n')
+def clean(to_clean = ['.']):
+    #
+    # Cleaning..
+    #
+    sys.stdout.write('[Starting sub_clean - %s]\n'%(time.strftime('%a %b %d %H:%M:%S %Z %Y', time.localtime())))
+    sys.stdout.write('[pwd: '+os.getcwd()+']\n')
 
-if len(sys.argv) == 1:
-    clean = ['.'];
-else:
-    clean = sys.argv[1:]
+    for f in to_clean:
+        if os.path.isdir(f):
+            print('Cleaning directory: '+f)
+            dirlist = glob.glob(f+'/*.chpl')
+            dirlist += glob.glob(f+'/*.test.c')
+            dirlist += glob.glob(f+'/*.ml-test.c')
+            dirlist.sort()
+            for file in dirlist:
+                cleanChapelTest(file)
+            cleanCleanfiles(f, 'CLEANFILES', True)
+        else:
+            cleanChapelTest(f)
+            cleanCleanfiles(os.path.dirname(f), 'CLEANFILES', True)
 
-for f in clean:
-    if os.path.isdir(f):
-        print('Cleaning directory: '+f)
-        dirlist = glob.glob(f+'/*.chpl')
-        dirlist += glob.glob(f+'/*.test.c')
-        dirlist += glob.glob(f+'/*.ml-test.c')
-        dirlist.sort()
-        for file in dirlist:
-            cleanChapelTest(file)
-        cleanCleanfiles(f, 'CLEANFILES', True)
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        to_clean = ['.']
     else:
-        cleanChapelTest(f)
-        cleanCleanfiles(os.path.dirname(f), 'CLEANFILES', True)
-
-sys.exit(0);
-
-
+        to_clean = sys.argv[1:]
+    clean(to_clean)

--- a/util/test/sub_clean.py
+++ b/util/test/sub_clean.py
@@ -47,10 +47,11 @@ def unlink(f, removeDirs=False):
         pass
 
 # Clean the files associated with a Chapel test program
-def cleanChapelTest(f):
+def _cleanChapelTest(f):
     execname = getExecname(f)
+    lines = []
     if execname:
-        print('Cleaning test: '+execname)
+        lines.append('Cleaning test: '+execname+'\n')
         globfiles = glob.glob(execname+'.*.out.tmp')
         for g in globfiles:
             unlink(g)
@@ -58,14 +59,16 @@ def cleanChapelTest(f):
         unlink(execname+'_real')
         unlink(execname+'.dSYM', removeDirs=True)
         unlink(execname+'_real.dSYM', removeDirs=True)
-        cleanCleanfiles(None, execname+'.cleanfiles', False)
+        lines.extend(_cleanCleanfiles(None, execname+'.cleanfiles', False))
+    return lines
 
 # Clean files listed in the file c, in the directory d (if given)
-def cleanCleanfiles(d, c, rmCore):
+def _cleanCleanfiles(d, c, rmCore):
     if d:
         cleanfile = os.path.join(d,c)
     else:
         cleanfile = c
+    lines = []
     if os.access(cleanfile,os.R_OK):
         cleanfiles = ReadCleanfiles(cleanfile)
         if rmCore:
@@ -76,30 +79,35 @@ def cleanCleanfiles(d, c, rmCore):
             else:
                 globfiles = glob.glob(f)
             for g in globfiles:
-                print('Removing '+g)
+                lines.append('Removing '+g+'\n')
                 unlink(g, removeDirs=True)
+    return lines
 
 
-def clean(to_clean = ['.']):
+def clean(to_clean=['.']):
     #
     # Cleaning..
     #
-    sys.stdout.write('[Starting sub_clean - %s]\n'%(time.strftime('%a %b %d %H:%M:%S %Z %Y', time.localtime())))
-    sys.stdout.write('[pwd: '+os.getcwd()+']\n')
+    lines = [
+        '[Starting sub_clean - %s]\n'%(time.strftime('%a %b %d %H:%M:%S %Z %Y', time.localtime())),
+        '[pwd: '+os.getcwd()+']\n',
+    ]
 
     for f in to_clean:
         if os.path.isdir(f):
-            print('Cleaning directory: '+f)
+            lines.append('Cleaning directory: '+f+'\n')
             dirlist = glob.glob(f+'/*.chpl')
             dirlist += glob.glob(f+'/*.test.c')
             dirlist += glob.glob(f+'/*.ml-test.c')
             dirlist.sort()
             for file in dirlist:
-                cleanChapelTest(file)
-            cleanCleanfiles(f, 'CLEANFILES', True)
+                lines.extend(_cleanChapelTest(file))
+            lines.extend(_cleanCleanfiles(f, 'CLEANFILES', True))
         else:
-            cleanChapelTest(f)
-            cleanCleanfiles(os.path.dirname(f), 'CLEANFILES', True)
+            lines.extend(_cleanChapelTest(f))
+            lines.extend(_cleanCleanfiles(os.path.dirname(f), 'CLEANFILES', True))
+
+    return ''.join(lines)
 
 
 if __name__ == '__main__':
@@ -107,4 +115,4 @@ if __name__ == '__main__':
         to_clean = ['.']
     else:
         to_clean = sys.argv[1:]
-    clean(to_clean)
+    sys.stdout.write(clean(to_clean))


### PR DESCRIPTION
Previously, we invoked `sub_clean` for every test directory as a subprocess. This adds a lot of overhead. Instead, since `sub_clean` is a Python script only ever used from `sub_test`, make it explicitly a Python script (add `.py`) and `import` it.

In my use case (`make www` for https://github.com/chapel-lang/chapel-blog), this is about 24 times faster, speeding up to clean step from 38 seconds to 1.6 seconds.

Probably best reviewed commit-by-commit since I had to autoformat the file to pass the CI check.

Previously, this was a subprocess invocation because both `sub_clean` and `start_test` were CSH files. They were converted into Python over time, but never integrated besides replicating the subprocess logic.

Reviewed by @jabraham17 -- thanks!