### PR TITLE
Allow LLVM 22 in portability testing

### DIFF
--- a/util/devel/test/portability/apptainer/current/arch/image.def
+++ b/util/devel/test/portability/apptainer/current/arch/image.def
@@ -6,7 +6,7 @@ From: archlinux:base-devel
 
 %post
     /provision-scripts/pacman-deps.sh
-    /provision-scripts/pacman-llvm21.sh
+    /provision-scripts/pacman-llvm22.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/portability/apptainer/current/centos-stream-10/image.def
+++ b/util/devel/test/portability/apptainer/current/centos-stream-10/image.def
@@ -8,7 +8,7 @@ From: quay.io/centos/centos:stream10
     /provision-scripts/dnf-upgrade.sh
     /provision-scripts/dnf-epel.sh
     /provision-scripts/dnf-deps.sh
-    /provision-scripts/dnf-llvm20.sh
+    /provision-scripts/dnf-llvm.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/portability/apptainer/current/centos-stream-9/image.def
+++ b/util/devel/test/portability/apptainer/current/centos-stream-9/image.def
@@ -8,7 +8,7 @@ From: quay.io/centos/centos:stream9
     /provision-scripts/dnf-upgrade.sh
     /provision-scripts/dnf-epel.sh
     /provision-scripts/dnf-deps.sh
-    /provision-scripts/dnf-llvm19.sh
+    /provision-scripts/dnf-llvm.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/portability/provision-scripts/dnf-llvm19.sh
+++ b/util/devel/test/portability/provision-scripts/dnf-llvm19.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-dnf -y install llvm19-devel clang19 clang19-devel

--- a/util/devel/test/portability/provision-scripts/pacman-llvm21.sh
+++ b/util/devel/test/portability/provision-scripts/pacman-llvm21.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-pacman --noconfirm -S llvm21 clang21

--- a/util/devel/test/portability/provision-scripts/pacman-llvm22.sh
+++ b/util/devel/test/portability/provision-scripts/pacman-llvm22.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pacman --noconfirm -S llvm22 clang22

--- a/util/packaging/homebrew/chapel-main.rb
+++ b/util/packaging/homebrew/chapel-main.rb
@@ -20,7 +20,7 @@ class Chapel < Formula
   depends_on "gmp"
   depends_on "hwloc"
   depends_on "jemalloc"
-  depends_on "llvm@21"
+  depends_on "llvm"
   depends_on "pkgconf"
   depends_on "python@3.14"
 


### PR DESCRIPTION
This PR allows the usage of LLVM 22 in CentOS, Archlinux, and homebrew testing.