### PR TITLE
Prefix computed GPU version macros

### DIFF
--- a/runtime/include/gpu/nvidia/chpl-gpu-dev-reduce.h
+++ b/runtime/include/gpu/nvidia/chpl-gpu-dev-reduce.h
@@ -78,7 +78,7 @@ chpl_gpu_dev_##chpl_kind##_breduce_##data_type##_##block_size(data_type thread_v
   } \
 }
 
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 129
+#if defined(CHPL_CUDA_VERSION) && CHPL_CUDA_VERSION >= 129
 GPU_DEV_REDUCE(DEF_ONE_DEV_REDUCE_RET_VAL, cuda::minimum, min);
 GPU_DEV_REDUCE(DEF_ONE_DEV_REDUCE_RET_VAL, cuda::maximum, max);
 #else

--- a/runtime/src/gpu/amd/gpu-amd.c
+++ b/runtime/src/gpu/amd/gpu-amd.c
@@ -176,7 +176,7 @@ void chpl_gpu_impl_begin_init(int* num_all_devices) {
 }
 
 static hipDevice_t ith_device(int i) {
-#if ROCM_VERSION_MAJOR >= 6
+#if CHPL_ROCM_VERSION_MAJOR >= 6
   return i;
 #else
   hipDevice_t device;
@@ -232,7 +232,7 @@ void chpl_gpu_impl_setup_with_device_count(int num_my_devices) {
 
 void chpl_gpu_impl_setup_device(int my_index, int global_index) {
   hipDevice_t device = ith_device(global_index);
-#if ROCM_VERSION_MAJOR >= 6
+#if CHPL_ROCM_VERSION_MAJOR >= 6
   ROCM_CALL(hipSetDevice(device));
   ROCM_CALL(hipSetDeviceFlags(hipDeviceScheduleBlockingSync))
 #else
@@ -270,7 +270,7 @@ bool chpl_gpu_impl_is_device_ptr(const void* ptr) {
     }
   }
 
-#if ROCM_VERSION_MAJOR >= 6
+#if CHPL_ROCM_VERSION_MAJOR >= 6
   // TODO: is this right?
   return res.type != hipMemoryTypeUnregistered;
 #else
@@ -294,7 +294,7 @@ bool chpl_gpu_impl_is_host_ptr(const void* ptr) {
     }
   }
   else {
-#if ROCM_VERSION_MAJOR >= 6
+#if CHPL_ROCM_VERSION_MAJOR >= 6
     return res.type == hipMemoryTypeHost || res.type == hipMemoryTypeUnregistered;
 #else
     return res.memoryType == hipMemoryTypeHost;

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -436,7 +436,7 @@ def get_runtime_compile_args():
         system.append("-isystem" + os.path.join(sdk_path, "hip", "include"))
 
         major_version = get_sdk_version().split(".")[0]
-        bundled.append("-DROCM_VERSION_MAJOR=" + major_version)
+        bundled.append("-DCHPL_ROCM_VERSION_MAJOR=" + major_version)
 
     return bundled, system
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -426,9 +426,9 @@ def get_runtime_compile_args():
         system.append("-D__STRICT_ANSI__=1")
 
         major_version, minor_version = get_sdk_version().split(".")[:2]
-        bundled.append("-DCUDA_VERSION_MAJOR=" + major_version)
-        bundled.append("-DCUDA_VERSION_MINOR=" + minor_version)
-        bundled.append("-DCUDA_VERSION=" + major_version + minor_version)
+        bundled.append("-DCHPL_CUDA_VERSION_MAJOR=" + major_version)
+        bundled.append("-DCHPL_CUDA_VERSION_MINOR=" + minor_version)
+        bundled.append("-DCHPL_CUDA_VERSION=" + major_version + minor_version)
 
     elif gpu_type == "amd":
         # -isystem instead of -I silences warnings from inside these includes.


### PR DESCRIPTION
Adds a `CHPL_` prefix to computed GPU sdk version variables, to avoid conflicting with the ones predefined by the library

Another solution would be to just use the builtin version variables, but this is more consistent with what we have to do for ROCM (which doesn't have builtin version variables like CUDA does)

Followup to https://github.com/chapel-lang/chapel/pull/28795

[Reviewed by @arifthpe]