### PR TITLE
Fix name of LLVM package for arch

### DIFF
--- a/util/devel/test/portability/apptainer/current/arch/image.def
+++ b/util/devel/test/portability/apptainer/current/arch/image.def
@@ -6,7 +6,7 @@ From: archlinux:base-devel
 
 %post
     /provision-scripts/pacman-deps.sh
-    /provision-scripts/pacman-llvm22.sh
+    /provision-scripts/pacman-llvm.sh
 
 %runscript
     ../../provision-scripts/run.sh "$@"

--- a/util/devel/test/portability/provision-scripts/pacman-llvm.sh
+++ b/util/devel/test/portability/provision-scripts/pacman-llvm.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+pacman --noconfirm -S llvm clang


### PR DESCRIPTION
Aliases for "llvm22" and "clang22" don't exist yet since 22 is the latest version.