### PR TITLE
Add LLVM 22 testing and future-proof other LLVM tests

### DIFF
--- a/util/cron/test-linux64-llvm14.bash
+++ b/util/cron/test-linux64-llvm14.bash
@@ -8,9 +8,10 @@ source $UTIL_CRON_DIR/common.bash
 source /hpcdc/project/chapel/setup_llvm.bash 14
 
 clang_version=$(clang -dumpversion)
-if [ "$clang_version" != "14.0.0" ]; then
+clang_version_major=$(echo $clang_version | cut -d. -f1)
+if [ "$clang_version_major" != "14" ]; then
   echo "Wrong clang version"
-  echo "Expected Version: 14.0.0 Actual Version: $clang_version"
+  echo "Expected Version: 14 Actual Version: $clang_version"
   exit 2
 fi
 

--- a/util/cron/test-linux64-llvm14.bash
+++ b/util/cron/test-linux64-llvm14.bash
@@ -8,7 +8,7 @@ source $UTIL_CRON_DIR/common.bash
 source /hpcdc/project/chapel/setup_llvm.bash 14
 
 clang_version=$(clang -dumpversion)
-clang_version_major=$(echo $clang_version | cut -d. -f1)
+clang_version_major=$(cut -d. -f1 <<< "$clang_version")
 if [ "$clang_version_major" != "14" ]; then
   echo "Wrong clang version"
   echo "Expected Version: 14 Actual Version: $clang_version"

--- a/util/cron/test-linux64-llvm15.bash
+++ b/util/cron/test-linux64-llvm15.bash
@@ -9,7 +9,7 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 15
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+llvm_version_major=$(cut -d. -f1 <<< "$llvm_version")
 if [ "$llvm_version_major" != "15" ]; then
   echo "Wrong LLVM version"
   echo "Expected Version: 15 Actual Version: $llvm_version"

--- a/util/cron/test-linux64-llvm15.bash
+++ b/util/cron/test-linux64-llvm15.bash
@@ -9,9 +9,10 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 15
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-if [ "$llvm_version" != "15.0.7" ]; then
+llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+if [ "$llvm_version_major" != "15" ]; then
   echo "Wrong LLVM version"
-  echo "Expected Version: 15.0.7 Actual Version: $llvm_version"
+  echo "Expected Version: 15 Actual Version: $llvm_version"
   exit 2
 fi
 

--- a/util/cron/test-linux64-llvm16.bash
+++ b/util/cron/test-linux64-llvm16.bash
@@ -9,9 +9,10 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 16
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-if [ "$llvm_version" != "16.0.6" ]; then
+llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+if [ "$llvm_version_major" != "16" ]; then
   echo "Wrong LLVM version"
-  echo "Expected Version: 16.0.6 Actual Version: $llvm_version"
+  echo "Expected Version: 16 Actual Version: $llvm_version"
   exit 2
 fi
 

--- a/util/cron/test-linux64-llvm16.bash
+++ b/util/cron/test-linux64-llvm16.bash
@@ -9,7 +9,7 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 16
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+llvm_version_major=$(cut -d. -f1 <<< "$llvm_version")
 if [ "$llvm_version_major" != "16" ]; then
   echo "Wrong LLVM version"
   echo "Expected Version: 16 Actual Version: $llvm_version"

--- a/util/cron/test-linux64-llvm17.bash
+++ b/util/cron/test-linux64-llvm17.bash
@@ -9,7 +9,7 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 17
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+llvm_version_major=$(cut -d. -f1 <<< "$llvm_version")
 if [ "$llvm_version_major" != "17" ]; then
   echo "Wrong LLVM version"
   echo "Expected Version: 17 Actual Version: $llvm_version"

--- a/util/cron/test-linux64-llvm17.bash
+++ b/util/cron/test-linux64-llvm17.bash
@@ -9,12 +9,12 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 17
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-if [ "$llvm_version" != "17.0.6" ]; then
+llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+if [ "$llvm_version_major" != "17" ]; then
   echo "Wrong LLVM version"
-  echo "Expected Version: 17.0.6 Actual Version: $llvm_version"
+  echo "Expected Version: 17 Actual Version: $llvm_version"
   exit 2
 fi
-
 export CHPL_LAUNCHER=none
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm17"

--- a/util/cron/test-linux64-llvm18.bash
+++ b/util/cron/test-linux64-llvm18.bash
@@ -9,9 +9,10 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 18
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-if [ "$llvm_version" != "18.1.8" ]; then
+llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+if [ "$llvm_version_major" != "18" ]; then
   echo "Wrong LLVM version"
-  echo "Expected Version: 18.1.8 Actual Version: $llvm_version"
+  echo "Expected Version: 18 Actual Version: $llvm_version"
   exit 2
 fi
 

--- a/util/cron/test-linux64-llvm18.bash
+++ b/util/cron/test-linux64-llvm18.bash
@@ -9,7 +9,7 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 18
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+llvm_version_major=$(cut -d. -f1 <<< "$llvm_version")
 if [ "$llvm_version_major" != "18" ]; then
   echo "Wrong LLVM version"
   echo "Expected Version: 18 Actual Version: $llvm_version"

--- a/util/cron/test-linux64-llvm19.bash
+++ b/util/cron/test-linux64-llvm19.bash
@@ -10,7 +10,7 @@ export CHPL_LLVM_GCC_PREFIX='none' # spack llvm is configured with proper gcc
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+llvm_version_major=$(cut -d. -f1 <<< "$llvm_version")
 if [ "$llvm_version_major" != "19" ]; then
   echo "Wrong LLVM version"
   echo "Expected Version: 19 Actual Version: $llvm_version"

--- a/util/cron/test-linux64-llvm19.bash
+++ b/util/cron/test-linux64-llvm19.bash
@@ -10,9 +10,10 @@ export CHPL_LLVM_GCC_PREFIX='none' # spack llvm is configured with proper gcc
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-if [ "$llvm_version" != "19.1.7" ]; then
+llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+if [ "$llvm_version_major" != "19" ]; then
   echo "Wrong LLVM version"
-  echo "Expected Version: 19.1.7 Actual Version: $llvm_version"
+  echo "Expected Version: 19 Actual Version: $llvm_version"
   exit 2
 fi
 

--- a/util/cron/test-linux64-llvm20.bash
+++ b/util/cron/test-linux64-llvm20.bash
@@ -9,9 +9,10 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 20
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-if [ "$llvm_version" != "20.1.4" ]; then
+llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+if [ "$llvm_version_major" != "20" ]; then
   echo "Wrong LLVM version"
-  echo "Expected Version: 20.1.4 Actual Version: $llvm_version"
+  echo "Expected Version: 20 Actual Version: $llvm_version"
   exit 2
 fi
 

--- a/util/cron/test-linux64-llvm20.bash
+++ b/util/cron/test-linux64-llvm20.bash
@@ -9,7 +9,7 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 20
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+llvm_version_major=$(cut -d. -f1 <<< "$llvm_version")
 if [ "$llvm_version_major" != "20" ]; then
   echo "Wrong LLVM version"
   echo "Expected Version: 20 Actual Version: $llvm_version"

--- a/util/cron/test-linux64-llvm21.bash
+++ b/util/cron/test-linux64-llvm21.bash
@@ -9,9 +9,10 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 21
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-if [ "$llvm_version" != "21.1.1" ]; then
+llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+if [ "$llvm_version_major" != "21" ]; then
   echo "Wrong LLVM version"
-  echo "Expected Version: 21.1.1 Actual Version: $llvm_version"
+  echo "Expected Version: 21 Actual Version: $llvm_version"
   exit 2
 fi
 

--- a/util/cron/test-linux64-llvm21.bash
+++ b/util/cron/test-linux64-llvm21.bash
@@ -9,7 +9,7 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 21
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+llvm_version_major=$(cut -d. -f1 <<< "$llvm_version")
 if [ "$llvm_version_major" != "21" ]; then
   echo "Wrong LLVM version"
   echo "Expected Version: 21 Actual Version: $llvm_version"

--- a/util/cron/test-linux64-llvm22.bash
+++ b/util/cron/test-linux64-llvm22.bash
@@ -9,7 +9,7 @@ source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 22
 
 # Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
 llvm_version=$($CHPL_LLVM_CONFIG --version)
-llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+llvm_version_major=$(cut -d. -f1 <<< "$llvm_version")
 if [ "$llvm_version_major" != "22" ]; then
   echo "Wrong LLVM version"
   echo "Expected Version: 22 Actual Version: $llvm_version"

--- a/util/cron/test-linux64-llvm22.bash
+++ b/util/cron/test-linux64-llvm22.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Test default configuration on examples only, on linux64, with llvm 22
+
+UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $UTIL_CRON_DIR/common.bash
+
+source /hpcdc/project/chapel/chpl-deps/chapcs11/setup_llvm.bash 22
+
+# Check LLVM version via llvm-config from CHPL_LLVM_CONFIG
+llvm_version=$($CHPL_LLVM_CONFIG --version)
+llvm_version_major=$(echo $llvm_version | cut -d. -f1)
+if [ "$llvm_version_major" != "22" ]; then
+  echo "Wrong LLVM version"
+  echo "Expected Version: 22 Actual Version: $llvm_version"
+  exit 2
+fi
+
+export CHPL_LAUNCHER=none
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-llvm22"
+export CHPL_NIGHTLY_TEST_DIRS="llvm/"
+
+$UTIL_CRON_DIR/nightly -cron -examples -blog ${nightly_args}


### PR DESCRIPTION
Adds LLVM 22 testing

I also adjusted the other LLVM test configs to not be brittle to minor version changes, which should not effect the run of the tests

[Reviewed by @arifthpe]