### PR TITLE
Fix protoc gen with newer versions of protobuf

### DIFF
--- a/tools/protoc-gen-chpl/Makefile
+++ b/tools/protoc-gen-chpl/Makefile
@@ -31,8 +31,8 @@ linkFile=$(bdir)/protoc-gen-chpl
 
 SOURCES=$(wildcard *.cpp)
 HEADERS=$(wildcard *.h)
-LDFLAGS = $(shell pkg-config --libs protobuf 2>/dev/null) -lprotobuf -lprotoc
-CPPFLAGS = $(shell pkg-config --cflags protobuf 2>/dev/null) -I. -std=c++17
+LDFLAGS = $(shell pkg-config --libs protobuf 2>/dev/null) -lprotoc
+CPPFLAGS = $(shell pkg-config --cflags protobuf 2>/dev/null) -std=c++17
 
 ifeq ($(CHPL_MAKE_PLATFORM),darwin)
 	PROTOC_LIB_LOC=$(dir $(shell which protoc))../lib
@@ -50,9 +50,9 @@ protoc-gen-chpl: $(bdir)/protoc-gen-chpl FORCE
 
 install: $(bdir)/protoc-gen-chpl FORCE
 
-$(bdir)/protoc-gen-chpl:	$(SOURCES)	$(HEADERS)
+$(bdir)/protoc-gen-chpl: $(SOURCES) $(HEADERS)
 	@echo "Building protoc-gen-chpl.."
-	$(CC) $(CPPFLAGS) -o $@ $(SOURCES) $(LDFLAGS) -lstdc++
+	$(CXX) $(CPPFLAGS) -o $@ $(SOURCES) $(LDFLAGS)
 	$(UPDATE_RPATH) $@
 
 clean:

--- a/tools/protoc-gen-chpl/enum.cpp
+++ b/tools/protoc-gen-chpl/enum.cpp
@@ -18,8 +18,8 @@
  * limitations under the License.
  */
 
-#include <enum.h>
-#include <helpers.h>
+#include "enum.h"
+#include "helpers.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/enum_field.cpp
+++ b/tools/protoc-gen-chpl/enum_field.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <enum_field.h>
+#include "enum_field.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/enum_field.h
+++ b/tools/protoc-gen-chpl/enum_field.h
@@ -21,12 +21,10 @@
 #ifndef PB_ENUM_FIELD_HH
 #define PB_ENUM_FIELD_HH
 
-#include <string>
-
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/descriptor.h>
 
-#include <field_base.h>
+#include "field_base.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/field_base.cpp
+++ b/tools/protoc-gen-chpl/field_base.cpp
@@ -18,14 +18,14 @@
  * limitations under the License.
  */
 
-#include <field_base.h>
-#include <helpers.h>
+#include "field_base.h"
+#include "helpers.h"
 
 namespace chapel {
 
 
   void FieldGeneratorBase::SetCommonFieldVariables(
-      map<string, string>* variables) {
+      std::map<std::string, std::string>* variables) {
 
     (*variables)["type_name"] = type_name(descriptor_);
     (*variables)["proto_type_name"] = proto_type_name(descriptor_);
@@ -35,7 +35,7 @@ namespace chapel {
   }
 
   void FieldGeneratorBase::SetCommonOneofFieldVariables(
-    std::map<string, string>* variables) {
+    std::map<std::string, std::string>* variables) {
     (*variables)["oneof_name"] = oneof_name(descriptor_->containing_oneof());
     (*variables)["property_name"] = name() + "_" ;
     (*variables)["default_value"] = default_value(descriptor_);
@@ -49,15 +49,15 @@ namespace chapel {
   FieldGeneratorBase::~FieldGeneratorBase() {
   }
 
-  string FieldGeneratorBase::name() {
+  std::string FieldGeneratorBase::name() {
     return GetFieldName(descriptor_);
   }
 
-  string FieldGeneratorBase::oneof_name(const OneofDescriptor* descriptor) {
+  std::string FieldGeneratorBase::oneof_name(const OneofDescriptor* descriptor) {
     return GetOneofName(descriptor);
   }
 
-  string FieldGeneratorBase::type_name(const FieldDescriptor* descriptor) {
+  std::string FieldGeneratorBase::type_name(const FieldDescriptor* descriptor) {
     switch (descriptor->type()) {
       case FieldDescriptor::TYPE_INT64:
         return "int(64)";
@@ -99,7 +99,7 @@ namespace chapel {
     }
   }
 
-  string FieldGeneratorBase::proto_type_name(const FieldDescriptor* descriptor) {
+  std::string FieldGeneratorBase::proto_type_name(const FieldDescriptor* descriptor) {
     switch (descriptor->type()) {
       case FieldDescriptor::TYPE_INT64:
         return "int64";
@@ -144,7 +144,7 @@ namespace chapel {
     }
   }
 
-  string FieldGeneratorBase::default_value(const FieldDescriptor* descriptor) {
+  std::string FieldGeneratorBase::default_value(const FieldDescriptor* descriptor) {
     switch (descriptor->type()) {
       case FieldDescriptor::TYPE_MESSAGE:
         return ""; // we use chapel compiler generated default values for messages;
@@ -186,7 +186,7 @@ namespace chapel {
     }
   }
 
-  string FieldGeneratorBase::number() {
+  std::string FieldGeneratorBase::number() {
     return std::to_string(descriptor_->number());
   }
 

--- a/tools/protoc-gen-chpl/field_base.h
+++ b/tools/protoc-gen-chpl/field_base.h
@@ -28,8 +28,6 @@
 
 namespace chapel {
 
-  using namespace std;
-
   using namespace google::protobuf;
   using namespace google::protobuf::io;
   using namespace google::protobuf::internal;
@@ -40,21 +38,21 @@ namespace chapel {
     virtual ~FieldGeneratorBase();
 
     virtual void GenerateMembers(Printer* printer) = 0;
-    string name();
-    string type_name(const FieldDescriptor* descriptor);
-    string proto_type_name(const FieldDescriptor* descriptor);
-    string default_value(const FieldDescriptor* descriptor);
-    string number();
+    std::string name();
+    std::string type_name(const FieldDescriptor* descriptor);
+    std::string proto_type_name(const FieldDescriptor* descriptor);
+    std::string default_value(const FieldDescriptor* descriptor);
+    std::string number();
 
     const FieldDescriptor* descriptor_;
-    map<string, string> variables_;
+    std::map<std::string, std::string> variables_;
 
    protected:
-     void SetCommonOneofFieldVariables(std::map<string, string>* variables);
-     string oneof_name(const OneofDescriptor* descriptor);
+     void SetCommonOneofFieldVariables(std::map<std::string, std::string>* variables);
+     std::string oneof_name(const OneofDescriptor* descriptor);
 
    private:
-     void SetCommonFieldVariables(map<string, string>* variables);
+     void SetCommonFieldVariables(std::map<std::string, std::string>* variables);
   };
 
 }  // namespace chapel

--- a/tools/protoc-gen-chpl/generator.cpp
+++ b/tools/protoc-gen-chpl/generator.cpp
@@ -23,9 +23,9 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/io/zero_copy_stream.h>
 
-#include <generator.h>
-#include <helpers.h>
-#include <reflection_class.h>
+#include "generator.h"
+#include "helpers.h"
+#include "reflection_class.h"
 
 namespace chapel {
 
@@ -39,24 +39,24 @@ namespace chapel {
     reflectionClassGenerator.Generate(printer);
   }
 
-  bool Generator::
-  Generate(
-      const FileDescriptor *file, const string &parameter,
-      GeneratorContext *generator_context, string *error) const {
+  bool Generator::Generate(
+    const FileDescriptor* file, const std::string& parameter,
+    GeneratorContext* generator_context, std::string* error
+  ) const {
 
-        string filename_error = "";
-        string filename = GetOutputFile(file, &filename_error);
+    std::string filename_error = "";
+    std::string filename = GetOutputFile(file, filename_error);
 
-        if (filename.empty()) {
-          *error = filename_error;
-          return false;
-        }
-        unique_ptr< ZeroCopyOutputStream> output(
-            generator_context->Open(filename));
-        Printer printer(output.get(), '$');
+    if (filename.empty()) {
+      *error = filename_error;
+      return false;
+    }
+    std::unique_ptr<ZeroCopyOutputStream> output(
+        generator_context->Open(filename));
+    Printer printer(output.get(), '$');
 
-        GenerateFile(file, &printer);
+    GenerateFile(file, &printer);
 
-        return true;
+    return true;
   }
 }

--- a/tools/protoc-gen-chpl/generator.h
+++ b/tools/protoc-gen-chpl/generator.h
@@ -28,8 +28,6 @@
 
 namespace chapel {
 
-  using namespace std;
-
   using namespace google::protobuf::compiler;
   using namespace google::protobuf;
 
@@ -38,11 +36,9 @@ namespace chapel {
     Generator();
     ~Generator();
     bool Generate(
-      const FileDescriptor *file,
-      const string &parameter,
-      GeneratorContext *generator_context,
-      string *error)
-    const override;
+      const FileDescriptor* file, const std::string& parameter,
+      GeneratorContext* generator_context, std::string* error
+    ) const override;
   };
 
 } // namespace chapel

--- a/tools/protoc-gen-chpl/helpers.cpp
+++ b/tools/protoc-gen-chpl/helpers.cpp
@@ -19,28 +19,29 @@
  */
 
 #include <string>
+#include <string_view>
 
-#include <helpers.h>
-#include <primitive_field.h>
-#include <repeated_primitive_field.h>
-#include <enum_field.h>
-#include <repeated_enum_field.h>
-#include <message_field.h>
-#include <repeated_message_field.h>
-#include <map_field.h>
-#include <field_base.h>
+#include "helpers.h"
+#include "primitive_field.h"
+#include "repeated_primitive_field.h"
+#include "enum_field.h"
+#include "repeated_enum_field.h"
+#include "message_field.h"
+#include "repeated_message_field.h"
+#include "map_field.h"
+#include "field_base.h"
 
 namespace chapel {
 
-  string StripDotProto(const std::string& proto_file) {
+  std::string_view StripDotProto(std::string_view proto_file) {
     int lastindex = proto_file.find_last_of(".");
     return proto_file.substr(0, lastindex);
   }
 
-  string InvalidCharsToUnderscores(const string& input) {
-    string result;
+  std::string InvalidCharsToUnderscores(std::string_view input) {
+    std::string result;
     for (int i = 0; i < input.size(); i++) {
-      if ( isalnum(input[i]) || input[i] == '_') {
+      if (isalnum(input[i]) || input[i] == '_') {
         result += input[i];
       } else {
         result += '_';
@@ -49,15 +50,15 @@ namespace chapel {
     return result;
   }
 
-  string GetFileNameBase(const FileDescriptor* descriptor) {
-      string proto_file = descriptor->name();
+  std::string GetFileNameBase(const FileDescriptor* descriptor) {
+      auto proto_file = descriptor->name();
       int lastslash = proto_file.find_last_of("/");
-      string base = proto_file.substr(lastslash + 1);
+      auto base = proto_file.substr(lastslash + 1);
       return InvalidCharsToUnderscores(StripDotProto(base));
   }
 
   bool ValidateInputFileName(const FileDescriptor* descriptor) {
-    string proto_file = descriptor->name();
+    auto proto_file = descriptor->name();
     int lastindex = proto_file.find_last_of(".");
     if (proto_file.substr(lastindex+1) != "proto") {
       return false;
@@ -65,52 +66,52 @@ namespace chapel {
     return true;
   }
 
-  string GetPackageName(const FileDescriptor* descriptor) {
+  std::string GetPackageName(const FileDescriptor* descriptor) {
     return InvalidCharsToUnderscores(descriptor->package());
   }
 
-  string GetModuleName(const FileDescriptor* descriptor) {
-    string package_name = GetPackageName(descriptor);
+  std::string GetModuleName(const FileDescriptor* descriptor) {
+    std::string package_name = GetPackageName(descriptor);
     if (!package_name.empty()) {
       return package_name;
     }
-    string proto_filename = GetFileNameBase(descriptor);
+    std::string proto_filename = GetFileNameBase(descriptor);
     return proto_filename;
   }
 
-  string GetOutputFile(const FileDescriptor* descriptor, string* error) {
-    string file_extension = ".chpl";
+  std::string GetOutputFile(const FileDescriptor* descriptor, std::string& error) {
+    std::string file_extension = ".chpl";
 
     bool valid_input_filename = ValidateInputFileName(descriptor);
     if (!valid_input_filename) {
-      *error = "Input file should be a .proto file";
+      error = "Input file should be a .proto file";
       return "";
     }
 
-    string base_filename = GetModuleName(descriptor);
+    std::string base_filename = GetModuleName(descriptor);
     return base_filename + file_extension;
   }
 
-  string GetFieldName(const FieldDescriptor* descriptor) {
-      return descriptor->name();
+  std::string GetFieldName(const FieldDescriptor* descriptor) {
+      return std::string(descriptor->name());
   }
 
-  string GetNestedTypeName(const Descriptor* descriptor, string name) {
+  std::string GetNestedTypeName(const Descriptor* descriptor, std::string_view name) {
     if (descriptor != NULL) {
-      return descriptor->name() + "_" + name;
+      return std::string(descriptor->name()) + "_" + std::string(name);
     }
-    return name;
+    return std::string(name);
   }
 
-  string GetMessageName(const Descriptor* descriptor) {
+  std::string GetMessageName(const Descriptor* descriptor) {
     return GetNestedTypeName(descriptor->containing_type(), descriptor->name());
   }
 
-  string GetEnumName(const EnumDescriptor* descriptor) {
+  std::string GetEnumName(const EnumDescriptor* descriptor) {
     return GetNestedTypeName(descriptor->containing_type(), descriptor->name());
   }
 
-  string GetOneofName(const OneofDescriptor* descriptor) {
+  std::string GetOneofName(const OneofDescriptor* descriptor) {
     return GetNestedTypeName(descriptor->containing_type(), descriptor->name());
   }
 

--- a/tools/protoc-gen-chpl/helpers.h
+++ b/tools/protoc-gen-chpl/helpers.h
@@ -29,28 +29,26 @@
 
 namespace chapel {
 
-  using namespace std;
-
   using namespace google::protobuf;
   using namespace google::protobuf::compiler;
 
   class FieldGeneratorBase;
 
-  string GetOutputFile(const FileDescriptor* descriptor, string*error);
+  std::string GetOutputFile(const FileDescriptor* descriptor, std::string& error);
 
-  string GetFieldName(const FieldDescriptor* descriptor);
+  std::string GetFieldName(const FieldDescriptor* descriptor);
 
   FieldGeneratorBase* CreateFieldGenerator(const FieldDescriptor* descriptor);
 
-  string GetModuleName(const FileDescriptor* descriptor);
+  std::string GetModuleName(const FileDescriptor* descriptor);
 
-  string GetMessageName(const Descriptor* descriptor);
+  std::string GetMessageName(const Descriptor* descriptor);
 
-  string GetEnumName(const EnumDescriptor* descriptor);
+  std::string GetEnumName(const EnumDescriptor* descriptor);
 
-  string GetPackageName(const FileDescriptor* descriptor);
+  std::string GetPackageName(const FileDescriptor* descriptor);
 
-  string GetOneofName(const OneofDescriptor* descriptor);
+  std::string GetOneofName(const OneofDescriptor* descriptor);
 
   inline bool IsMapEntryMessage(const Descriptor* descriptor) {
     return descriptor->options().map_entry();

--- a/tools/protoc-gen-chpl/map_field.cpp
+++ b/tools/protoc-gen-chpl/map_field.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <map_field.h>
+#include "map_field.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/map_field.h
+++ b/tools/protoc-gen-chpl/map_field.h
@@ -26,7 +26,7 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/descriptor.h>
 
-#include <field_base.h>
+#include "field_base.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/message.cpp
+++ b/tools/protoc-gen-chpl/message.cpp
@@ -30,10 +30,10 @@
 #include <google/protobuf/wire_format.h>
 #include <google/protobuf/wire_format_lite.h>
 
-#include <helpers.h>
-#include <message.h>
-#include <enum.h>
-#include <field_base.h>
+#include "helpers.h"
+#include "message.h"
+#include "enum.h"
+#include "field_base.h"
 
 namespace chapel {
 
@@ -48,12 +48,12 @@ namespace chapel {
   MessageGenerator::~MessageGenerator() {
   }
 
-  string MessageGenerator::record_name() {
+  std::string MessageGenerator::record_name() {
     return GetMessageName(descriptor_);
   }
 
   void MessageGenerator::Generate(Printer* printer) {
-    map<int, map<string, string>> vars;
+    std::map<int, std::map<std::string, std::string>> vars;
 
     for (int i = 0; i < descriptor_->field_count(); i++) {
       const FieldDescriptor* fieldDescriptor = descriptor_->field(i);
@@ -101,7 +101,7 @@ namespace chapel {
       printer->Print(
         "// Field \"$field_name$\" \n",
         "field_name", fieldDescriptor->name());
-      unique_ptr<FieldGeneratorBase> generator(
+      std::unique_ptr<FieldGeneratorBase> generator(
           CreateFieldGeneratorInternal(fieldDescriptor));
       generator->GenerateMembers(printer);
       printer->Print("\n");

--- a/tools/protoc-gen-chpl/message.h
+++ b/tools/protoc-gen-chpl/message.h
@@ -22,7 +22,6 @@
 #define PB_MESSAGE_HH
 
 #include <string>
-#include <vector>
 
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/io/printer.h>
@@ -30,7 +29,6 @@
 
 namespace chapel {
 
-  using namespace std;
   using namespace google::protobuf;
   using namespace google::protobuf::compiler;
   using namespace google::protobuf::io;
@@ -50,7 +48,7 @@ namespace chapel {
     FieldGeneratorBase* CreateFieldGeneratorInternal(
     const FieldDescriptor* descriptor);
 
-    string record_name();
+    std::string record_name();
   };
 
 }  // namespace chapel

--- a/tools/protoc-gen-chpl/message_field.cpp
+++ b/tools/protoc-gen-chpl/message_field.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <message_field.h>
+#include "message_field.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/message_field.h
+++ b/tools/protoc-gen-chpl/message_field.h
@@ -24,7 +24,7 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/descriptor.h>
 
-#include <field_base.h>
+#include "field_base.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/primitive_field.cpp
+++ b/tools/protoc-gen-chpl/primitive_field.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <primitive_field.h>
+#include "primitive_field.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/primitive_field.h
+++ b/tools/protoc-gen-chpl/primitive_field.h
@@ -24,7 +24,7 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/descriptor.h>
 
-#include <field_base.h>
+#include "field_base.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/protoc-gen-chpl.cpp
+++ b/tools/protoc-gen-chpl/protoc-gen-chpl.cpp
@@ -20,7 +20,7 @@
 
 #include <google/protobuf/compiler/plugin.h>
 
-#include <generator.h>
+#include "generator.h"
 
 int main(int argc, char *argv[]) {
   chapel::Generator generator;

--- a/tools/protoc-gen-chpl/reflection_class.cpp
+++ b/tools/protoc-gen-chpl/reflection_class.cpp
@@ -18,10 +18,10 @@
  * limitations under the License.
  */
 
-#include <reflection_class.h>
-#include <message.h>
-#include <helpers.h>
-#include <enum.h>
+#include "reflection_class.h"
+#include "message.h"
+#include "helpers.h"
+#include "enum.h"
 
 namespace chapel {
 
@@ -62,7 +62,7 @@ namespace chapel {
 
       for (int i = 0; i < descriptor->real_oneof_decl_count(); i++) {
         const OneofDescriptor* oneof = descriptor->oneof_decl(i);
-        string oneof_name = GetOneofName(oneof);
+        std::string oneof_name = GetOneofName(oneof);
         printer->Print("enum $oneof_name$ {\n",
                        "oneof_name", oneof_name);
         printer->Indent();

--- a/tools/protoc-gen-chpl/reflection_class.h
+++ b/tools/protoc-gen-chpl/reflection_class.h
@@ -28,8 +28,6 @@
 
 namespace chapel {
 
-  using namespace std;
-
   using namespace google::protobuf;
   using namespace google::protobuf::io;
 
@@ -43,7 +41,7 @@ namespace chapel {
    private:
     const FileDescriptor* file_;
 
-    string module_name;
+    std::string module_name;
 
     void WriteIntroduction(Printer* printer);
     bool HasNestedGeneratedTypes(const Descriptor* descriptor);

--- a/tools/protoc-gen-chpl/repeated_enum_field.cpp
+++ b/tools/protoc-gen-chpl/repeated_enum_field.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <repeated_enum_field.h>
+#include "repeated_enum_field.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/repeated_enum_field.h
+++ b/tools/protoc-gen-chpl/repeated_enum_field.h
@@ -24,7 +24,7 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/descriptor.h>
 
-#include <field_base.h>
+#include "field_base.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/repeated_message_field.cpp
+++ b/tools/protoc-gen-chpl/repeated_message_field.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <repeated_message_field.h>
+#include "repeated_message_field.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/repeated_message_field.h
+++ b/tools/protoc-gen-chpl/repeated_message_field.h
@@ -24,7 +24,7 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/descriptor.h>
 
-#include <field_base.h>
+#include "field_base.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/repeated_primitive_field.cpp
+++ b/tools/protoc-gen-chpl/repeated_primitive_field.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <repeated_primitive_field.h>
+#include "repeated_primitive_field.h"
 
 namespace chapel {
 

--- a/tools/protoc-gen-chpl/repeated_primitive_field.h
+++ b/tools/protoc-gen-chpl/repeated_primitive_field.h
@@ -24,7 +24,7 @@
 #include <google/protobuf/io/printer.h>
 #include <google/protobuf/descriptor.h>
 
-#include <field_base.h>
+#include "field_base.h"
 
 namespace chapel {
 


### PR DESCRIPTION
Fixes the protoc-gen-chpl tool with newer versions of protobuf which use `string_view` instead of `string`

Key changes
* adjust the build to not duplicate `-lprotobuf` and remove `-I.` (switched to `""` includes for local headers)
* use `std::string_view` in some cases and careful use of `auto`. This should make it so that no matter the version of protobuf, the code compiles properly without the use of conditional macros
* stop using `using namespace std`, as thats a major anti-pattern

[Reviewed by @dlongnecke-cray]