### PR TITLE
Relax check for python versions

### DIFF
--- a/util/cron/common-python.bash
+++ b/util/cron/common-python.bash
@@ -26,12 +26,15 @@ function set_and_check_python_version() {
 }
 
 # Check correct Python version loaded, exiting with error if not
+# ignores the patch version, so 3.9.21 and 3.9.0 would be considered the same version
 function check_python_version() {
   local expected_python_version=$1
+  local expected_major_minor_version=$(cut -d. -f1,2 <<< "$expected_python_version")
 
   local actual_python_version=$(python3 --version | cut -d' ' -f2)
+  local actual_major_minor_version=$(cut -d. -f1,2 <<< "$actual_python_version")
 
-  if [ "$actual_python_version" != "$expected_python_version" ]; then
+  if [ "$actual_major_minor_version" != "$expected_major_minor_version" ]; then
     echo "Wrong Python version"
     echo "Expected Version: $expected_python_version. Actual Version: $actual_python_version"
     exit 2


### PR DESCRIPTION
Relaxes the check for python versions to not care about the patch version

similar to changes made for LLVM in https://github.com/chapel-lang/chapel/pull/28828

[Reviewed by @arifthpe]