### PR TITLE
Update LLVM information for GPUs

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -155,7 +155,7 @@ The following are further requirements for GPU support:
     * While CUDA 12.9 may work, it is untested and may generate deprecation
       warnings.
 
-  * We test with LLVM 20. Older versions may work.
+  * We test with LLVM 22. Older versions may work.
 
     * Note that LLVM versions older than 16 do not support CUDA 12.
 

--- a/test/gpu/native/llvmMoved.chpl
+++ b/test/gpu/native/llvmMoved.chpl
@@ -48,7 +48,7 @@
 
 // After addressing the checklist items (or creating a GH issue to do so)
 // modify the following const so that this test no longer fails.
-const EXPECTED_LLVM_VERSION = 20;
+const EXPECTED_LLVM_VERSION = 22;
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Updates the version of LLVM primarily tests to be LLVM 22, since the bundled LLVM is now 22

[Not reviewed - trivial]