### PR TITLE
Try to fix Python package memleak test failures

### DIFF
--- a/test/library/packages/Python/memleaks/EXECOPTS_SCRIPT
+++ b/test/library/packages/Python/memleaks/EXECOPTS_SCRIPT
@@ -13,19 +13,28 @@ minor_version=$(echo $version_str | cut -d' ' -f2)
 patch_version=$(echo $version_str | cut -d' ' -f3)
 
 goodfile=""
-# since python 3.14.2, we have seen extra uncleaned up memory reported
-# so with a python 3.14.2 or higher, use a different expected output file
+
+# get the basename of this file and chop off the extension
+thisfile=$(basename "$0")
+basefile="${thisfile%.*}"
+
+# since python 3.14.1, we have seen extra uncleaned up memory reported
+# so with a python 3.14.1 or higher, use a different expected output file
 if [ $major_version -gt 3 ] || \
    [ $major_version -eq 3 -a $minor_version -gt 14 ] || \
-   [ $major_version -eq 3 -a $minor_version -eq 14 -a $patch_version -ge 2 ]; then
-  # just use the default expected output file
-  goodfile="";
+   [ $major_version -eq 3 -a $minor_version -eq 14 -a $patch_version -ge 1 ]; then
+  version_suffix="$major_version.$minor_version.$patch_version";
+  goodfile="$basefile.$version_suffix.good";
+  if [ ! -f "$goodfile" ]; then
+    # A versioned '.good' does not exist, so just fall back to the '.good'.
+    goodfile=""
+  fi
 else
-  # get the basename of this file and chop off the extension
-  thisfile=$(basename "$0")
-  basefile="${thisfile%.*}"
-  goodfile=" # $basefile.noleak.good";
+  goodfile="$basefile.noleak.good";
 fi
 
-echo "--pyMemLeaks $goodfile"
-
+if [[ -n "$goodfile" ]]; then
+  echo "--pyMemLeaks # $goodfile"
+else
+  echo "--pyMemLeaks"
+fi

--- a/test/library/packages/Python/memleaks/PREDIFF
+++ b/test/library/packages/Python/memleaks/PREDIFF
@@ -3,9 +3,20 @@
 TESTNAME=$1
 OUTFILE=$2
 
-# Only process the first two lines, which report leak stats.
-cat $OUTFILE | head -n 2 > $OUTFILE.tmphead
-cat $OUTFILE | tail -n +3 > $OUTFILE.tmptail
+# TODO: This is fragile, what we should do is have the Python package
+#       output a special prefix in front of the 'show_growth()' call
+#       if it turns out there were actually leaks (that way nothing is
+#       printed if there were no deltas).
+#
+# The lines starting with these words report leak stats.
+cat $OUTFILE | grep "dict" >  $OUTFILE.tmphead
+cat $OUTFILE | grep "list" >> $OUTFILE.tmphead
+
+# cp $OUTFILE.tmphead $OUTFILE.tmphead.step1
+
+# The remaining lines (inverse grep) are just part of the test.
+cat $OUTFILE | grep -v -e "dict" -e "list" > $OUTFILE.tmptail
+# cp $OUTFILE.tmptail $OUTFILE.tmptail.step1
 
 # If the number is preceded by a '+', remove it.
 cat $OUTFILE.tmphead | sed 's/+[0-9]\{1,\}//g' > $OUTFILE.scratch
@@ -22,9 +33,13 @@ mv $OUTFILE.scratch $OUTFILE.tmphead
 cat $OUTFILE.tmphead | perl -pe 's/([0-9])([0-9]+)/$1 . "x" x length($2)/ge' > $OUTFILE.scratch
 mv $OUTFILE.scratch $OUTFILE.tmphead
 
+# Sort.
+cat $OUTFILE.tmphead | sort > $OUTFILE.scratch
+mv $OUTFILE.scratch $OUTFILE.tmphead
+
 # Stitch the files back together.
 cat $OUTFILE.tmptail >> $OUTFILE.tmphead
-mv $OUTFILE.tmphead $OUTFILE
+cp $OUTFILE.tmphead $OUTFILE
 
 # Make sure all the temp files that were used are cleaned up.
 rm -f $OUTFILE.tmphead $OUTFILE.tmptail $OUTFILE.scratch

--- a/test/library/packages/Python/memleaks/basicTypes.good
+++ b/test/library/packages/Python/memleaks/basicTypes.good
@@ -1,2 +1,2 @@
-list      6xx
 dict     2xxx
+list      7xx

--- a/test/library/packages/Python/memleaks/iterate.good
+++ b/test/library/packages/Python/memleaks/iterate.good
@@ -1,5 +1,5 @@
 dict     2xxx
-list      6xx
+list      7xx
 yielding Values from tuple
 1
 2

--- a/test/library/packages/Python/memleaks/lambdas.good
+++ b/test/library/packages/Python/memleaks/lambdas.good
@@ -1,5 +1,5 @@
-list      6xx
 dict     2xxx
+list      7xx
 [1, 1]
 [hi, hi]
 [[1, 2, 3], [1, 2, 3]]

--- a/test/library/packages/Python/memleaks/maps.good
+++ b/test/library/packages/Python/memleaks/maps.good
@@ -1,5 +1,5 @@
-list      6xx
 dict     2xxx
+list      7xx
 d size 3
 d size after deleting second 2
 d size after swap 3


### PR DESCRIPTION
These tests are failing in nightly testing because of a Python version bump. Adjust the `.good` files and also adjust the scripts to make it easier to add different `.good` files for problematic Python versions in the future.

I tested Python versions `3.14.3` `3.14.1` `3.13.5` and `3.12.3`.

Reviewed by @jabraham17. Thanks!