### PR TITLE
Use stop-hooks for debuggerBreakHere instead of debugger commands

### DIFF
--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -1,15 +1,23 @@
-def debuggerBreakHere_callback(frame, bp_loc, internal_dict):
-    thread = frame.GetThread()
-    thread.SetSelectedFrame(1)
+class DebuggerBreakHereStopHook:
+    def __init__(self, target, extra_args, internal_dict):
+        pass
 
-    curFrame = thread.GetSelectedFrame()
-    fn = curFrame.GetFunction()
-    if fn and fn.name.startswith("debuggerBreakHere("):
-        thread.SetSelectedFrame(2)
+    def handle_stop(self, exe_ctx, stream):
+        thread = exe_ctx.GetThread()
+        if not thread or not thread.IsValid():
+            return True
+
+        thread.SetSelectedFrame(1)
+
+        curFrame = thread.GetSelectedFrame()
+        fn = curFrame.GetFunction()
+        if fn and fn.name.startswith("debuggerBreakHere("):
+            thread.SetSelectedFrame(2)
+        return True
 
 
 def __lldb_init_module(debugger, internal_dict):
-    debugger.HandleCommand("breakpoint command delete debuggerBreakHere")
+    debugger.HandleCommand("target stop-hook delete 1")
     debugger.HandleCommand(
-        "breakpoint command add --python-function chpl_lldb_debuggerBreakHere.debuggerBreakHere_callback debuggerBreakHere"
+        "target stop-hook add --script-class chpl_lldb_debuggerBreakHere.DebuggerBreakHereStopHook"
     )

--- a/runtime/etc/debug/lldb.commands
+++ b/runtime/etc/debug/lldb.commands
@@ -1,2 +1,2 @@
 breakpoint set -n debuggerBreakHere -N debuggerBreakHere
-breakpoint command add -o 'up' debuggerBreakHere
+target stop-hook add --name debuggerBreakHere -o "up"


### PR DESCRIPTION
Use stop-hooks to implement the auto up feature of debuggerBreakHere instead of debugger commands, since in newer LLDB versions the changes made to the current state by a debugger command are not reflected to the current state of the debugger

[Reviewed by @benharsh]