### PR TITLE
Fix debug test failures due to new LLVM/LLDB

### DIFF
--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -1,3 +1,4 @@
+import lldb
 class DebuggerBreakHereStopHook:
     def __init__(self, target, extra_args, internal_dict):
         pass
@@ -5,6 +6,28 @@ class DebuggerBreakHereStopHook:
     def handle_stop(self, exe_ctx, stream):
         thread = exe_ctx.GetThread()
         if not thread or not thread.IsValid():
+            return True
+
+        # only do something if we hit the debuggerBreakHere breakpoint
+        stopReason = thread.GetStopReason()
+        if stopReason != lldb.eStopReasonBreakpoint:
+            return True
+        count = thread.GetStopReasonDataCount()
+        if count < 2:
+            return True
+        brkId = thread.GetStopReasonDataAtIndex(0)
+        breakpointInfo = thread.GetProcess().GetTarget().FindBreakpointByID(brkId)
+        isNamedDebuggerBreakHere = breakpointInfo and breakpointInfo.IsValid() and breakpointInfo.MatchesName("debuggerBreakHere")
+        numLocations = breakpointInfo.GetNumLocations()
+        if numLocations < 1:
+            return True
+        location = breakpointInfo.GetLocationAtIndex(0)
+        if not location or not location.IsValid():
+            return True
+        breakFunc = location.GetAddress().GetFunction()
+        isBreakOnDebuggerBreakHere = breakFunc and breakFunc.IsValid() and breakFunc.GetName().startswith("debuggerBreakHere(")
+
+        if not (isNamedDebuggerBreakHere or isBreakOnDebuggerBreakHere):
             return True
 
         thread.SetSelectedFrame(1)

--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -1,4 +1,6 @@
 import lldb
+
+
 class DebuggerBreakHereStopHook:
     def __init__(self, target, extra_args, internal_dict):
         pass
@@ -16,8 +18,14 @@ class DebuggerBreakHereStopHook:
         if count < 2:
             return True
         brkId = thread.GetStopReasonDataAtIndex(0)
-        breakpointInfo = thread.GetProcess().GetTarget().FindBreakpointByID(brkId)
-        isNamedDebuggerBreakHere = breakpointInfo and breakpointInfo.IsValid() and breakpointInfo.MatchesName("debuggerBreakHere")
+        breakpointInfo = (
+            thread.GetProcess().GetTarget().FindBreakpointByID(brkId)
+        )
+        isNamedDebuggerBreakHere = (
+            breakpointInfo
+            and breakpointInfo.IsValid()
+            and breakpointInfo.MatchesName("debuggerBreakHere")
+        )
         numLocations = breakpointInfo.GetNumLocations()
         if numLocations < 1:
             return True
@@ -25,7 +33,11 @@ class DebuggerBreakHereStopHook:
         if not location or not location.IsValid():
             return True
         breakFunc = location.GetAddress().GetFunction()
-        isBreakOnDebuggerBreakHere = breakFunc and breakFunc.IsValid() and breakFunc.GetName().startswith("debuggerBreakHere(")
+        isBreakOnDebuggerBreakHere = (
+            breakFunc
+            and breakFunc.IsValid()
+            and breakFunc.GetName().startswith("debuggerBreakHere(")
+        )
 
         if not (isNamedDebuggerBreakHere or isBreakOnDebuggerBreakHere):
             return True

--- a/test/execflags/lldbddash/declint.prediff
+++ b/test/execflags/lldbddash/declint.prediff
@@ -15,6 +15,8 @@ grep -v "Breakpoint 1: where" $tmpfile | \
   grep -v 'breakpoint set -n debuggerBreakHere -N debuggerBreakHere' | \
   grep -v 'breakpoint command add' | \
   grep -v 'command script import' | \
+  grep -v 'target stop-hook add' | \
+  grep -v 'Stop hook #' | \
   grep -v 'runtime/etc/debug/lldb.commands' \
   > $outfile
 # Also filter out line about memleaks arguments to executable

--- a/test/llvm/debugInfo/lldb/basicTypesCommands.txt
+++ b/test/llvm/debugInfo/lldb/basicTypesCommands.txt
@@ -1,3 +1,4 @@
+settings set target.max-children-count 1024
 r
 p myRec
 p myRec.myField

--- a/test/llvm/debugInfo/lldb/inspectAggregatesCommands.txt
+++ b/test/llvm/debugInfo/lldb/inspectAggregatesCommands.txt
@@ -1,3 +1,4 @@
+settings set target.max-children-count 1024
 r
 
 p myIntList

--- a/test/llvm/debugInfo/lldb/locales.chpl
+++ b/test/llvm/debugInfo/lldb/locales.chpl
@@ -8,7 +8,8 @@ proc main() {
 
 
 // CHECK: p Locales
-// CHECK-LOCAL-NEXT: ([domain(1,int(64),one)] locale) [0..0] ChapelLocale::locale {
+// CHECK-LOCAL-NEXT: [domain(1,int(64),one)] locale
+// CHECK-LOCAL-SAME: [0..0] ChapelLocale::locale
 // CHECK-LOCAL-NEXT: [0] = {
 // CHECK-LOCAL-NEXT: _instance = 0x{{0*[0-9a-fA-F]+}}
 // CHECK-LOCAL-NEXT: }


### PR DESCRIPTION
Fixes a bundle of debug test failures.

Many of these were caused by a bad fix to https://github.com/chapel-lang/chapel/pull/28836, which was firing on all breakpoints. Other failures were real failures caused by changes in LLDB. I have tried to make these tests work and be LLDB version agnostic

- [x] st test/llvm/debugInfo/ test/library/standard/Debugger/breakOnHalt.chpl test/execflags/lldbddash/declint.chpl

[Reviewed by @benharsh]