### PR TITLE
Properly handle erroneous expressions

### DIFF
--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -2767,9 +2767,19 @@ CommentsAndStmt ParserContext::
 buildForwardingDecl(YYLTYPE location,
                     owned<AttributeGroup> attributeGroup,
                     CommentsAndStmt cs) {
-  CHPL_ASSERT(cs.stmt->isVariable() || cs.stmt->isMultiDecl() || cs.stmt->isTupleDecl());
   auto decl = cs.stmt->toDecl();
-  CHPL_ASSERT(decl);
+  if (!cs.stmt->isVariable() &&
+      !cs.stmt->isMultiDecl() &&
+      !cs.stmt->isTupleDecl() &&
+      decl == nullptr) {
+    error(location, "invalid forwarding declaration, expected a variable declaration");
+    if (cs.stmt->isErroneousExpression()) {
+      return cs;
+    } else {
+      auto node = ErroneousExpression::build(builder, convertLocation(location));
+      return makeCommentsAndStmt(cs.comments, node.release());
+    }
+  }
   CHPL_ASSERT(!decl->attributeGroup());
   // TODO: pattern for composing comments should be extracted to helper
   auto commentExprs = appendList(makeList(), cs.comments);

--- a/frontend/lib/parsing/ParserContextImpl.h
+++ b/frontend/lib/parsing/ParserContextImpl.h
@@ -2767,19 +2767,13 @@ CommentsAndStmt ParserContext::
 buildForwardingDecl(YYLTYPE location,
                     owned<AttributeGroup> attributeGroup,
                     CommentsAndStmt cs) {
-  auto decl = cs.stmt->toDecl();
-  if (!cs.stmt->isVariable() &&
-      !cs.stmt->isMultiDecl() &&
-      !cs.stmt->isTupleDecl() &&
-      decl == nullptr) {
-    error(location, "invalid forwarding declaration, expected a variable declaration");
-    if (cs.stmt->isErroneousExpression()) {
-      return cs;
-    } else {
-      auto node = ErroneousExpression::build(builder, convertLocation(location));
-      return makeCommentsAndStmt(cs.comments, node.release());
-    }
+  if (cs.stmt->isErroneousExpression()) {
+    auto node = ErroneousExpression::build(builder, convertLocation(location));
+    return makeCommentsAndStmt(cs.comments, node.release());
   }
+  CHPL_ASSERT(cs.stmt->isVariable() || cs.stmt->isMultiDecl() || cs.stmt->isTupleDecl());
+  auto decl = cs.stmt->toDecl();
+  CHPL_ASSERT(decl);
   CHPL_ASSERT(!decl->attributeGroup());
   // TODO: pattern for composing comments should be extracted to helper
   auto commentExprs = appendList(makeList(), cs.comments);

--- a/test/classes/forwarding/forwardToNonVar.bad
+++ b/test/classes/forwarding/forwardToNonVar.bad
@@ -1,6 +1,0 @@
-internal error: UTI-MIS-1041 chpl version 2.1.0 pre-release (c783ceba8b)
-
-Internal errors indicate a bug in the Chapel compiler,
-and we're sorry for the hassle.  We would appreciate your reporting this bug --
-please see https://chapel-lang.org/bugs.html for instructions.
-

--- a/test/classes/forwarding/forwardToNonVar.future
+++ b/test/classes/forwarding/forwardToNonVar.future
@@ -1,3 +1,0 @@
-bug: forwarding to a badly-formed variable declaration causes internal error
-
-#25067

--- a/test/classes/forwarding/forwardToNonVar.good
+++ b/test/classes/forwarding/forwardToNonVar.good
@@ -1,2 +1,1 @@
 forwardToNonVar.chpl:4: syntax error: near '('
-forwardToNonVar.chpl:4: error: invalid forwarding declaration, expected a variable declaration

--- a/test/classes/forwarding/forwardToNonVar.good
+++ b/test/classes/forwarding/forwardToNonVar.good
@@ -1,0 +1,2 @@
+forwardToNonVar.chpl:4: syntax error: near '('
+forwardToNonVar.chpl:4: error: invalid forwarding declaration, expected a variable declaration


### PR DESCRIPTION
Avoid assertion error by handling erroneous expressions so that the user error is properly propagated

Resolves https://github.com/chapel-lang/chapel/issues/25067

- [x] paratest

[Reviewed by @DanilaFe]