### PR TITLE
Add regression test for fixed Map+FCF bug

### DIFF
--- a/test/library/standard/Map/issue-18736.chpl
+++ b/test/library/standard/Map/issue-18736.chpl
@@ -1,0 +1,7 @@
+use Map;
+proc myF() {
+  return 1;
+}
+var m: map(string, myF.type);
+m.add("asd", myF);
+writeln(m);

--- a/test/library/standard/Map/issue-18736.good
+++ b/test/library/standard/Map/issue-18736.good
@@ -1,0 +1,1 @@
+{asd: proc myF(): int { ... }}


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel/issues/18736.

The program in question simply does not cause errors anymore, and works as intended. So, add a regression test and close the issue.

Trivial; will not be reviewed.