### PR TITLE
Suppress AMD gpu tests that call printf from a kernel

### DIFF
--- a/test/gpu/native/basics/bug23045.suppressif
+++ b/test/gpu/native/basics/bug23045.suppressif
@@ -1,0 +1,2 @@
+# printf from a kernel results in a segfault
+CHPL_GPU==amd

--- a/test/gpu/native/gpuWritelnAndAssertOnGpu.suppressif
+++ b/test/gpu/native/gpuWritelnAndAssertOnGpu.suppressif
@@ -1,0 +1,2 @@
+# printf from a kernel results in a segfault
+CHPL_GPU==amd

--- a/test/gpu/native/intents/foreachInIntent.suppressif
+++ b/test/gpu/native/intents/foreachInIntent.suppressif
@@ -1,0 +1,2 @@
+# printf from a kernel results in a segfault
+CHPL_GPU==amd

--- a/test/gpu/native/intents/foreachInIntentCustomIter.suppressif
+++ b/test/gpu/native/intents/foreachInIntentCustomIter.suppressif
@@ -1,0 +1,2 @@
+# printf from a kernel results in a segfault
+CHPL_GPU==amd

--- a/test/gpu/native/simpleExternHello.suppressif
+++ b/test/gpu/native/simpleExternHello.suppressif
@@ -1,0 +1,2 @@
+# printf from a kernel results in a segfault
+CHPL_GPU==amd


### PR DESCRIPTION
Suppresses a few AMD gpu tests that call printf from a kernel, since they crash with unknown memory errors on ROCm 7

[Not reviewed - trivial]