### PR TITLE
Unset CHPL_TARGET_CPU for EX testing

### DIFF
--- a/util/cron/common-hpe-cray-ex.bash
+++ b/util/cron/common-hpe-cray-ex.bash
@@ -15,6 +15,10 @@ module load cray-pmi
 
 export CHPL_HOST_PLATFORM=hpe-cray-ex
 
+# `common.bash` sets CHPL_TARGET_CPU to 'none' but we'd prefer to test
+# the CPU defined by the environment on the EX
+unset CHPL_TARGET_CPU
+
 # Work around cxi provider bugs that limit memory registration
 export CHPL_RT_MAX_HEAP_SIZE="50%"
 export CHPL_LAUNCHER_MEM=unset


### PR DESCRIPTION
CHPL_TARGET_CPU has been set to 'none' in testing through common.bash for years now, but as of the LLVM 22 upgrade, we're seeing some linker errors on GMP routines as a result of this.  At the same time, leaving it unset is more similar to what real users will do in the field, and on EX systems, we should default it to reasonable values, so update the EX testing to unset this variable and do the testing in that mode.

[edit: It seems that I was not diagnosing something correctly, and must not have rebuilt a stale build in one of the configurations I was testing, as this did not resolve the issue.  That said, I still think it's a better practice for us to be testing with CHPL_TARGET_CPU set to an appropriate value when possible, so am leaving this as-is, and think we should consider extending it to more testing configurations]
