### PR TITLE
Fix Python package test failures when running with TASKS=fifo

### DIFF
--- a/test/library/packages/Python/memleaks/EXECOPTS_SCRIPT
+++ b/test/library/packages/Python/memleaks/EXECOPTS_SCRIPT
@@ -33,6 +33,11 @@ else
   goodfile="$basefile.noleak.good";
 fi
 
+# Nothing seems to leak with 'fifo' which is very suspicious.
+if [ "$CHPL_TASKS" == "fifo" ]; then
+  goodfile="$basefile.noleak.good";
+fi
+
 if [[ -n "$goodfile" ]]; then
   echo "--pyMemLeaks # $goodfile"
 else


### PR DESCRIPTION
I added a fix for Python package memleak test failures, but for some reason they were still failing during the `asan` config. It turns out that the tests do not leak when `CHPL_TASKS=fifo`, regardless of the Python version. Whether or not this hints towards a deeper structural problem isn't clear to me.

Trivial and not reviewed.