### PR TITLE
Add initial support for cuda 13

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -5043,6 +5043,8 @@ static void makeBinaryLLVMForCUDA(const std::string& artifactFilename,
                          " " + artifactFilename.c_str();
     mysystem(ptxCmd.c_str(), "PTX to object file");
 
+    profiles += std::string(" --image3=kind=ptx,sm=") + sm +
+                  ",file=" + artifactFilename;
     profiles += std::string(" --image3=kind=elf,sm=") + sm +
                   ",file=" + gpuObject;
   }

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -5029,10 +5029,10 @@ static void makeBinaryLLVMForCUDA(const std::string& artifactFilename,
   std::string profiles;
   for (auto& gpuArch : gpuArches) {
     // Figure out the corresponding compute capability and object name
-    if (strncmp(gpuArch.c_str(), "sm_", 3) != 0 || gpuArch.size() != 5) {
+    if (strncmp(gpuArch.c_str(), "sm_", 3) != 0 || gpuArch.size() < 4) {
       USR_FATAL("Unrecognized CUDA arch");
     }
-    std::string computeCap = std::string("compute_") + gpuArch[3] + gpuArch[4];
+    std::string sm = gpuArch.substr(3);
     std::string gpuObject = gpuObjectFilenamePrefix + "_" + gpuArch + ".o";
 
     // Execute the assembler for this architecture
@@ -5043,11 +5043,8 @@ static void makeBinaryLLVMForCUDA(const std::string& artifactFilename,
                          " " + artifactFilename.c_str();
     mysystem(ptxCmd.c_str(), "PTX to object file");
 
-    // Track the new object we created and the CC we enabled.
-    profiles += std::string(" --image=profile=") + computeCap +
-                ",file=" + artifactFilename;
-    profiles += std::string(" --image=profile=") + gpuArch +
-                ",file=" + gpuObject;
+    profiles += std::string(" --image3=kind=elf,sm=") + sm +
+                  ",file=" + gpuObject;
   }
 
   std::string fatbinaryCmd = std::string("fatbinary -64 ") +

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -150,14 +150,13 @@ The following are further requirements for GPU support:
 
 * Specifically for targeting NVIDIA GPUs:
 
-  * CUDA toolkit version 11.7+ or 12.x must be installed.
-
-    * While CUDA 12.9 may work, it is untested and may generate deprecation
-      warnings.
+  * CUDA toolkit version 11.7+, 12.x, or 13.x must be installed.
 
   * We test with LLVM 22. Older versions may work.
 
     * Note that LLVM versions older than 16 do not support CUDA 12.
+
+    * Note that LLVM versions older than 22 do not support CUDA 13.
 
   * If using ``CHPL_LLVM=system``, it must have been built with support for
     NVPTX target. You can check supported targets of your LLVM installation by
@@ -202,10 +201,11 @@ These variables include:
   Portability`_ section.
 
 * ``CHPL_GPU_ARCH`` --- specifies GPU architecture to generate kernel code for.
-  This must be set while targeting AMD GPUs.  If unset and targeting NVIDIA
-  GPUs, will default to ``sm_60``. This may also be set by passing the ``chpl``
-  compiler ``--gpu-arch=<architecture>``. For more information, see the `Vendor
-  Portability`_ section.
+  This must be set while targeting AMD GPUs. If unset and targeting NVIDIA
+  GPUs, will default to ``sm_80`` for CUDA 13+ and ``sm_60`` otherwise.
+  This may also be set by passing the ``chpl``  compiler
+  ``--gpu-arch=<architecture>``. For more information, see the
+  `Vendor Portability`_ section.
 
 * ``CHPL_CUDA_PATH`` --- specifies path to CUDA toolkit.  If unset, Chapel tries
   to automatically determine this path based on the location of ``nvcc``. This
@@ -271,14 +271,15 @@ automatically detect the path to the relevant runtime. If it is not
 automatically detected (or you would like to use a different installation) you
 may set ``CHPL_CUDA_PATH`` and/or ``CHPL_ROCM_PATH`` explicitly.
 
-The ``CHPL_GPU_ARCH`` environment variable can be set to control the desired GPU
-architecture to compile for. The default value is ``sm_60`` for
-``CHPL_GPU=nvidia``. You may also use the ``--gpu-arch`` compiler flag to
-set GPU architecture.  If using AMD, this variable must be set. `This table in
-the ROCm documentation
-<https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html>`_
-has possible architecture values (see the "LLVM target name" column). For NVIDIA, see
-the `CUDA Compute Capability <https://developer.nvidia.com/cuda-gpus>`_ table.
+The ``CHPL_GPU_ARCH`` environment variable can be set to control the desired
+GPU architecture to compile for. The default value is ``sm_80`` for CUDA 13+
+and ``sm_60`` otherwise for ``CHPL_GPU=nvidia``. You may also use the
+``--gpu-arch`` compiler flag to set GPU architecture.  If using AMD, this
+variable must be set. `This table in the ROCm documentation
+<https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html>`_ has
+possible architecture values (see the "LLVM target name" column). For NVIDIA,
+see the `CUDA Compute Capability <https://developer.nvidia.com/cuda-gpus>`_
+table.
 
 For NVIDIA, the ``CHPL_GPU_ARCH`` variable can also be set to a comma-separated
 list. This causes the Chapel compiler to generate device code for each of the
@@ -707,7 +708,7 @@ marked with * are covered in our nightly testing configurations.
 
   * Hardware: RTX A2000, P100*, V100*, A100*, H100, GH200
 
-  * Software: CUDA 11.7, 11.8, 12.0, 12.2, 12.4, 12.8*, 12.9
+  * Software: CUDA 11.7, 11.8, 12.0, 12.2, 12.4, 12.8*, 12.9, 13.0
 
 * AMD
 

--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -202,7 +202,7 @@ These variables include:
 
 * ``CHPL_GPU_ARCH`` --- specifies GPU architecture to generate kernel code for.
   This must be set while targeting AMD GPUs. If unset and targeting NVIDIA
-  GPUs, will default to ``sm_80`` for CUDA 13+ and ``sm_60`` otherwise.
+  GPUs, will default to ``sm_75`` for CUDA 13+ and ``sm_60`` otherwise.
   This may also be set by passing the ``chpl``  compiler
   ``--gpu-arch=<architecture>``. For more information, see the
   `Vendor Portability`_ section.
@@ -272,7 +272,7 @@ automatically detected (or you would like to use a different installation) you
 may set ``CHPL_CUDA_PATH`` and/or ``CHPL_ROCM_PATH`` explicitly.
 
 The ``CHPL_GPU_ARCH`` environment variable can be set to control the desired
-GPU architecture to compile for. The default value is ``sm_80`` for CUDA 13+
+GPU architecture to compile for. The default value is ``sm_75`` for CUDA 13+
 and ``sm_60`` otherwise for ``CHPL_GPU=nvidia``. You may also use the
 ``--gpu-arch`` compiler flag to set GPU architecture.  If using AMD, this
 variable must be set. `This table in the ROCm documentation

--- a/runtime/src/gpu/nvidia/Makefile.share
+++ b/runtime/src/gpu/nvidia/Makefile.share
@@ -48,4 +48,4 @@ endif
 
 $(RUNTIME_OBJ_DIR)/gpu-nvidia-cub.o: gpu-nvidia-cub.cc \
                                          $(RUNTIME_OBJ_DIR_STAMP)
-	$(CXX) -c $(CXX11_STD) $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -o $@ $<
+	$(CXX) -c $(RUNTIME_CXXFLAGS) $(RUNTIME_INCLS) -std=c++17 -o $@ $<

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -103,6 +103,14 @@ def find_cuda_libdevice_path(compiler: str):
     return libdevices[0] if len(libdevices) > 0 else None
 
 
+def _cuda_default_arch():
+    # if using cuda <13, default to sm_60. Otherwise default to sm_75
+    cuda_version_major = get_sdk_version().split('.')[0]
+    if cuda_version_major and int(cuda_version_major) < 13:
+        return "sm_60"
+    else:
+        return "sm_75"
+
 def find_llvm_amd_bin_path(compiler: str):
     out = gpu_compiler_basic_compile(compiler, "hip")
     if not out:
@@ -173,54 +181,46 @@ def _find_rocm_version(compiler: str):
 
 
 GPU_TYPES = {
-    "nvidia": gpu_type(
-        sdk_path_env="CHPL_CUDA_PATH",
-        compiler="nvcc",
-        default_arch="sm_60",
-        llvm_target="NVPTX",
-        runtime_impl="cuda",
-        find_sdk_path=_find_cuda_sdk_path,
-        find_version=_find_cuda_version,
-        version_validator=_validate_cuda_version,
-        llvm_validator=_validate_cuda_llvm_version,
-        real_gpu=True,
-    ),
-    "amd": gpu_type(
-        sdk_path_env="CHPL_ROCM_PATH",
-        compiler="hipcc",
-        default_arch="",
-        llvm_target="AMDGPU",
-        runtime_impl="rocm",
-        find_sdk_path=_find_hip_sdk_path,
-        find_version=_find_rocm_version,
-        version_validator=_validate_rocm_version,
-        llvm_validator=_validate_rocm_llvm_version,
-        real_gpu=True,
-    ),
-    "cpu": gpu_type(
-        sdk_path_env="",
-        compiler="",
-        default_arch="",
-        llvm_target="",
-        runtime_impl="cpu",
-        find_sdk_path=lambda compiler: None,
-        find_version=lambda compiler: None,
-        version_validator=lambda: None,
-        llvm_validator=lambda: None,
-        real_gpu=False,
-    ),
-    "none": gpu_type(
-        sdk_path_env="",
-        compiler="",
-        default_arch="",
-        llvm_target="",
-        runtime_impl="",
-        find_sdk_path=lambda compiler: None,
-        find_version=lambda compiler: None,
-        version_validator=lambda: None,
-        llvm_validator=lambda: None,
-        real_gpu=False,
-    ),
+    "nvidia": gpu_type(sdk_path_env="CHPL_CUDA_PATH",
+                       compiler="nvcc",
+                       default_arch=_cuda_default_arch,
+                       llvm_target="NVPTX",
+                       runtime_impl="cuda",
+                       find_sdk_path=_find_cuda_sdk_path,
+                       find_version=_find_cuda_version,
+                       version_validator=_validate_cuda_version,
+                       llvm_validator=_validate_cuda_llvm_version,
+                       real_gpu=True),
+    "amd": gpu_type(sdk_path_env="CHPL_ROCM_PATH",
+                    compiler="hipcc",
+                    default_arch=lambda: "",
+                    llvm_target="AMDGPU",
+                    runtime_impl="rocm",
+                    find_sdk_path=_find_hip_sdk_path,
+                    find_version=_find_rocm_version,
+                    version_validator=_validate_rocm_version,
+                    llvm_validator=_validate_rocm_llvm_version,
+                    real_gpu=True),
+    "cpu": gpu_type(sdk_path_env="",
+                    compiler="",
+                    default_arch=lambda: "",
+                    llvm_target="",
+                    runtime_impl="cpu",
+                    find_sdk_path=lambda compiler: None,
+                    find_version=lambda compiler: None,
+                    version_validator=lambda: None,
+                    llvm_validator=lambda: None,
+                    real_gpu=False),
+    "none": gpu_type(sdk_path_env="",
+                     compiler="",
+                     default_arch=lambda: "",
+                     llvm_target="",
+                     runtime_impl="",
+                     find_sdk_path=lambda compiler: None,
+                     find_version=lambda compiler: None,
+                     version_validator=lambda: None,
+                     llvm_validator=lambda: None,
+                     real_gpu=False)
 }
 
 
@@ -306,7 +306,7 @@ def get_arch():
         return arch
 
     # Return vendor-specific default architecture
-    arch = GPU_TYPES[gpu_type].default_arch
+    arch = GPU_TYPES[gpu_type].default_arch()
     if arch != "":
         return arch
     else:

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -107,12 +107,12 @@ def find_cuda_libdevice_path(compiler: str):
 
 
 def _cuda_default_arch():
-    # if using cuda <13, default to sm_60. Otherwise default to sm_80
+    # if using cuda <13, default to sm_60. Otherwise default to sm_75
     cuda_version_major = get_sdk_version().split(".")[0]
     if cuda_version_major and int(cuda_version_major) < 13:
         return "sm_60"
     else:
-        return "sm_80"
+        return "sm_75"
 
 
 def find_llvm_amd_bin_path(compiler: str):

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -589,11 +589,10 @@ def _validate_cuda_version_impl():
         return False
 
     if not is_ver_in_range(cuda_version, MIN_REQ_VERSION, MAX_REQ_VERSION):
-        _reportMissingGpuReq(
+        warning(
             "Chapel requires a CUDA version between %s and %s, "
-            "detected version %s on system."
-            % (MIN_REQ_VERSION, MAX_REQ_VERSION, cuda_version)
-        )
+            "detected version %s on system." %
+            (MIN_REQ_VERSION, MAX_REQ_VERSION, cuda_version))
         return False
 
     # CUDA 12 requires the bundled LLVM or the major LLVM version must be >15
@@ -614,6 +613,19 @@ def _validate_cuda_version_impl():
                     allowExempt=False,
                 )
                 return False
+
+    # CUDA 13 requires LLVM 21+
+    if is_ver_in_range(cuda_version, "13", "14"):
+        llvm_ver_str = int(chpl_llvm.get_llvm_version())
+        if llvm_ver_str < 21:
+            _reportMissingGpuReq(
+                "LLVM versions before 21 do not support CUDA 13. "
+                "Your LLVM version is {}".format(llvm_ver_str),
+                suggestNone=False,
+                allowExempt=False,
+            )
+            return False
+
 
     return True
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -426,10 +426,10 @@ def get_runtime_compile_args():
         gpu = GPU_TYPES[gpu_type]
         includes = _find_cuda_variable(gpu.compiler, "INCLUDES")
         if includes:
-            system.append(shlex.split(includes))
+            system.extend(shlex.split(includes))
         system_includes = _find_cuda_variable(gpu.compiler, "SYSTEM_INCLUDES")
         if system_includes:
-            system.append(shlex.split(system_includes))
+            system.extend(shlex.split(system_includes))
 
         major_version, minor_version = get_sdk_version().split(".")[:2]
         bundled.append("-DCHPL_CUDA_VERSION_MAJOR=" + major_version)

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -633,12 +633,12 @@ def _validate_cuda_version_impl():
                 )
                 return False
 
-    # CUDA 13 requires LLVM 21+
+    # CUDA 13 requires LLVM 22+
     if is_ver_in_range(cuda_version, "13", "14"):
         llvm_ver_str = int(chpl_llvm.get_llvm_version())
-        if llvm_ver_str < 21:
+        if chpl_llvm.get() == "system" and llvm_ver_str < 21:
             _reportMissingGpuReq(
-                "LLVM versions before 21 do not support CUDA 13. "
+                "LLVM versions before 22 do not support CUDA 13. "
                 "Your LLVM version is {}".format(llvm_ver_str),
                 suggestNone=False,
                 allowExempt=False,

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -107,12 +107,12 @@ def find_cuda_libdevice_path(compiler: str):
 
 
 def _cuda_default_arch():
-    # if using cuda <13, default to sm_60. Otherwise default to sm_75
+    # if using cuda <13, default to sm_60. Otherwise default to sm_80
     cuda_version_major = get_sdk_version().split(".")[0]
     if cuda_version_major and int(cuda_version_major) < 13:
         return "sm_60"
     else:
-        return "sm_75"
+        return "sm_80"
 
 
 def find_llvm_amd_bin_path(compiler: str):

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -80,6 +80,7 @@ def gpu_compiler_basic_compile(compiler: str, lang: str):
     # all we care about is the output
     return stdout
 
+
 def _find_cuda_variable(compiler: str, variable_name: str):
     out = gpu_compiler_basic_compile(compiler, "cu")
     if not out:
@@ -88,8 +89,10 @@ def _find_cuda_variable(compiler: str, variable_name: str):
     match = re.search(regex, out, re.MULTILINE)
     return match.group(1) if match else None
 
+
 def _find_cuda_sdk_path(compiler: str):
     return _find_cuda_variable(compiler, "TOP")
+
 
 def find_cuda_libdevice_path(compiler: str):
     libdevice_path = _find_cuda_variable(compiler, "NVVMIR_LIBRARY_DIR")
@@ -105,11 +108,12 @@ def find_cuda_libdevice_path(compiler: str):
 
 def _cuda_default_arch():
     # if using cuda <13, default to sm_60. Otherwise default to sm_75
-    cuda_version_major = get_sdk_version().split('.')[0]
+    cuda_version_major = get_sdk_version().split(".")[0]
     if cuda_version_major and int(cuda_version_major) < 13:
         return "sm_60"
     else:
         return "sm_75"
+
 
 def find_llvm_amd_bin_path(compiler: str):
     out = gpu_compiler_basic_compile(compiler, "hip")
@@ -181,46 +185,54 @@ def _find_rocm_version(compiler: str):
 
 
 GPU_TYPES = {
-    "nvidia": gpu_type(sdk_path_env="CHPL_CUDA_PATH",
-                       compiler="nvcc",
-                       default_arch=_cuda_default_arch,
-                       llvm_target="NVPTX",
-                       runtime_impl="cuda",
-                       find_sdk_path=_find_cuda_sdk_path,
-                       find_version=_find_cuda_version,
-                       version_validator=_validate_cuda_version,
-                       llvm_validator=_validate_cuda_llvm_version,
-                       real_gpu=True),
-    "amd": gpu_type(sdk_path_env="CHPL_ROCM_PATH",
-                    compiler="hipcc",
-                    default_arch=lambda: "",
-                    llvm_target="AMDGPU",
-                    runtime_impl="rocm",
-                    find_sdk_path=_find_hip_sdk_path,
-                    find_version=_find_rocm_version,
-                    version_validator=_validate_rocm_version,
-                    llvm_validator=_validate_rocm_llvm_version,
-                    real_gpu=True),
-    "cpu": gpu_type(sdk_path_env="",
-                    compiler="",
-                    default_arch=lambda: "",
-                    llvm_target="",
-                    runtime_impl="cpu",
-                    find_sdk_path=lambda compiler: None,
-                    find_version=lambda compiler: None,
-                    version_validator=lambda: None,
-                    llvm_validator=lambda: None,
-                    real_gpu=False),
-    "none": gpu_type(sdk_path_env="",
-                     compiler="",
-                     default_arch=lambda: "",
-                     llvm_target="",
-                     runtime_impl="",
-                     find_sdk_path=lambda compiler: None,
-                     find_version=lambda compiler: None,
-                     version_validator=lambda: None,
-                     llvm_validator=lambda: None,
-                     real_gpu=False)
+    "nvidia": gpu_type(
+        sdk_path_env="CHPL_CUDA_PATH",
+        compiler="nvcc",
+        default_arch=_cuda_default_arch,
+        llvm_target="NVPTX",
+        runtime_impl="cuda",
+        find_sdk_path=_find_cuda_sdk_path,
+        find_version=_find_cuda_version,
+        version_validator=_validate_cuda_version,
+        llvm_validator=_validate_cuda_llvm_version,
+        real_gpu=True,
+    ),
+    "amd": gpu_type(
+        sdk_path_env="CHPL_ROCM_PATH",
+        compiler="hipcc",
+        default_arch=lambda: "",
+        llvm_target="AMDGPU",
+        runtime_impl="rocm",
+        find_sdk_path=_find_hip_sdk_path,
+        find_version=_find_rocm_version,
+        version_validator=_validate_rocm_version,
+        llvm_validator=_validate_rocm_llvm_version,
+        real_gpu=True,
+    ),
+    "cpu": gpu_type(
+        sdk_path_env="",
+        compiler="",
+        default_arch=lambda: "",
+        llvm_target="",
+        runtime_impl="cpu",
+        find_sdk_path=lambda compiler: None,
+        find_version=lambda compiler: None,
+        version_validator=lambda: None,
+        llvm_validator=lambda: None,
+        real_gpu=False,
+    ),
+    "none": gpu_type(
+        sdk_path_env="",
+        compiler="",
+        default_arch=lambda: "",
+        llvm_target="",
+        runtime_impl="",
+        find_sdk_path=lambda compiler: None,
+        find_version=lambda compiler: None,
+        version_validator=lambda: None,
+        llvm_validator=lambda: None,
+        real_gpu=False,
+    ),
 }
 
 
@@ -586,7 +598,7 @@ def _validate_cuda_version_impl():
     """Check that the installed CUDA version is >= MIN_REQ_VERSION and <
     MAX_REQ_VERSION"""
     MIN_REQ_VERSION = "11.7"
-    MAX_REQ_VERSION = "14" # upper bound non-inclusive
+    MAX_REQ_VERSION = "14"  # upper bound non-inclusive
 
     cuda_version = get_sdk_version()
 
@@ -597,8 +609,9 @@ def _validate_cuda_version_impl():
     if not is_ver_in_range(cuda_version, MIN_REQ_VERSION, MAX_REQ_VERSION):
         warning(
             "Chapel requires a CUDA version between %s and %s, "
-            "detected version %s on system." %
-            (MIN_REQ_VERSION, MAX_REQ_VERSION, cuda_version))
+            "detected version %s on system."
+            % (MIN_REQ_VERSION, MAX_REQ_VERSION, cuda_version)
+        )
         return False
 
     # CUDA 12 requires the bundled LLVM or the major LLVM version must be >15
@@ -631,7 +644,6 @@ def _validate_cuda_version_impl():
                 allowExempt=False,
             )
             return False
-
 
     return True
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -636,7 +636,7 @@ def _validate_cuda_version_impl():
     # CUDA 13 requires LLVM 22+
     if is_ver_in_range(cuda_version, "13", "14"):
         llvm_ver_str = int(chpl_llvm.get_llvm_version())
-        if chpl_llvm.get() == "system" and llvm_ver_str < 21:
+        if chpl_llvm.get() == "system" and llvm_ver_str < 22:
             _reportMissingGpuReq(
                 "LLVM versions before 22 do not support CUDA 13. "
                 "Your LLVM version is {}".format(llvm_ver_str),

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -580,7 +580,7 @@ def _validate_cuda_version_impl():
     """Check that the installed CUDA version is >= MIN_REQ_VERSION and <
     MAX_REQ_VERSION"""
     MIN_REQ_VERSION = "11.7"
-    MAX_REQ_VERSION = "13"
+    MAX_REQ_VERSION = "14" # upper bound non-inclusive
 
     cuda_version = get_sdk_version()
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import shlex
 import chpl_locale_model
 import chpl_platform
 import chpl_llvm
@@ -79,25 +80,21 @@ def gpu_compiler_basic_compile(compiler: str, lang: str):
     # all we care about is the output
     return stdout
 
-
-def _find_cuda_sdk_path(compiler: str):
+def _find_cuda_variable(compiler: str, variable_name: str):
     out = gpu_compiler_basic_compile(compiler, "cu")
     if not out:
         return None
-    regex = r"^#\$ TOP=(.+)$"
+    regex = r"^#\$ {}=(.+)$".format(variable_name)
     match = re.search(regex, out, re.MULTILINE)
     return match.group(1) if match else None
 
+def _find_cuda_sdk_path(compiler: str):
+    return _find_cuda_variable(compiler, "TOP")
 
 def find_cuda_libdevice_path(compiler: str):
-    out = gpu_compiler_basic_compile(compiler, "cu")
-    if not out:
+    libdevice_path = _find_cuda_variable(compiler, "NVVMIR_LIBRARY_DIR")
+    if not libdevice_path:
         return None
-    regex = r"^#\$ NVVMIR_LIBRARY_DIR=(.+)$"
-    match = re.search(regex, out, re.MULTILINE)
-    if not match:
-        return None
-    libdevice_path = match.group(1)
     # there can be multiple libdevices for multiple compute architectures. Not
     # sure how realistic that is, nor I see multiple instances in the systems I
     # have access to. They are always named `libdevice.10.bc`, but I just want
@@ -424,6 +421,15 @@ def get_runtime_compile_args():
 
         # workaround an issue with __float128 not being supported by clang in device code
         system.append("-D__STRICT_ANSI__=1")
+
+        # add includes and system includes from nvcc
+        gpu = GPU_TYPES[gpu_type]
+        includes = _find_cuda_variable(gpu.compiler, "INCLUDES")
+        if includes:
+            system.append(shlex.split(includes))
+        system_includes = _find_cuda_variable(gpu.compiler, "SYSTEM_INCLUDES")
+        if system_includes:
+            system.append(shlex.split(system_includes))
 
         major_version, minor_version = get_sdk_version().split(".")[:2]
         bundled.append("-DCHPL_CUDA_VERSION_MAJOR=" + major_version)


### PR DESCRIPTION
Adds initial support for cuda 13 with LLVM 22+

Notable changes
* the default CHPL_GPU_ARCH is set to sm_75 with cuda 13
  * this is the lowest value available to cuda 13
* the Chapel runtime for cuda is now built with C++17 

Resolves https://github.com/chapel-lang/chapel/issues/28387

- [x] `make check` with CUDA 13 works

[Reviewed by @arifthpe]