### PR TITLE
Add back Debian 11 portability CMake note

### DIFF
--- a/doc/rst/usingchapel/prereqs-commands.rst
+++ b/doc/rst/usingchapel/prereqs-commands.rst
@@ -57,7 +57,7 @@
       sudo dnf install llvm-devel clang clang-devel
 
 
-  * Debian 11 "Bullseye"::
+  * Debian 11 "Bullseye" (but note `Newer CMake required to build LLVM`_)::
 
       sudo apt-get update
       sudo apt-get install gcc g++ m4 perl python3 python3-dev bash make mawk git pkg-config cmake libunwind-dev


### PR DESCRIPTION
Restore reference in Debian 11 prereq commands entry to note on needing a newer CMake to build LLVM.

This seems to have been unintentionally removed in https://github.com/chapel-lang/chapel/pull/28014.

[reviewed by @jabraham17 , thanks!]