### PR TITLE
Add prereqs note about FreeBSD testing being outdated

### DIFF
--- a/doc/rst/usingchapel/prereqs-commands.rst
+++ b/doc/rst/usingchapel/prereqs-commands.rst
@@ -79,7 +79,7 @@
       sudo dnf install llvm-devel clang clang-devel
 
 
-  * FreeBSD 13.5, 14.3::
+  * FreeBSD 13.5, 14.3 (but see note `Outdated FreeBSD testing`_)::
 
       sudo pkg install gcc m4 perl5 python3 bash gmake gawk git pkgconf cmake libunwind
       sudo pkg install llvm

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -114,3 +114,15 @@ installing a system LLVM package using the commands shown above.
 Note that the LLVM support library is used even with ``CHPL_LLVM=none``,
 and so installing a system LLVM on these platforms is still important in
 that case.
+
+Outdated FreeBSD testing
+++++++++++++++++++++++++
+
+Our portability testing for FreeBSD relies on public Vagrant boxes. At time of
+writing (May 2026), we have been unable to find a box for FreeBSD releases
+newer than 14.3. Due to limited resources, and lacking information on how
+widely used Chapel is on FreeBSD, we have not taken on the work of making our
+own box or otherwise continuing to update this test coverage. It is still our
+intention to support FreeBSD as a best effort, so feel free to open bug reports
+for Chapel on FreeBSD versions newer than we test, and/or let us know if this
+lack of testing coverage causes you concern.

--- a/util/devel/test/portability/README-distro-timelines.txt
+++ b/util/devel/test/portability/README-distro-timelines.txt
@@ -113,9 +113,12 @@ x 14.1 EOL Mar 2025
 x 13.4 EOL Jun 2025
 x 13.5 EOL Apr 2026 (still testing as newer don't have boxes)
 x 14.2 EOL Sep 2025
-x 14.3 EOL Jun 2026
+x 14.3 EOL Jun 2026 (still testing as newer don't have boxes)
   14.4 EOL Dec 2026 (awaiting vagrant box)
   15.0 EOL Sep 2026 (awaiting vagrant box)
+** As of May 2026, we couldn't find Vagrant boxes for any production releases
+   of FreeBSD, and plan to just keep testing 13.5 and 14.3 unless newer boxes
+   appear.
 
 OpenSuse -- see https://en.opensuse.org/Lifetime
          -- and https://app.vagrantup.com/opensuse


### PR DESCRIPTION
Add explanatory note on outdated FreeBSD testing and prerequisite commands info.

Resolves https://github.com/cray/chapel-private/issues/7742.

[reviewed by @bradcray , thanks!]