### PR TITLE
Add prediff for twoLocales

### DIFF
--- a/test/llvm/debugInfo/chpl-parallel-dbg/PREDIFF
+++ b/test/llvm/debugInfo/chpl-parallel-dbg/PREDIFF
@@ -16,3 +16,12 @@ mv $OUTPUT.tmp $OUTPUT
 
 grep -v 'SIGINT(2)' $OUTPUT > $OUTPUT.tmp
 mv $OUTPUT.tmp $OUTPUT
+
+# respect CHPL_TEST_VENV_DIR if it is set and not none
+if [ -n "$CHPL_TEST_VENV_DIR" ] && [ "$CHPL_TEST_VENV_DIR" != "none" ]; then
+  chpl_python=$CHPL_TEST_VENV_DIR/bin/python3
+else
+  chpl_python=$($CHPL_HOME/util/config/find-python.sh)
+fi
+CWD=$(cd $(dirname $0) ; pwd)
+$chpl_python $CWD/prediff-for-gasnet-udp $1 $OUTPUT

--- a/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
+++ b/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
@@ -9,10 +9,10 @@ with open(file, 'rb') as f:
     contents = f.read()
 
 
-out_of_order = b"""*** GASNET WARNING(Node \\d+): Detected arrival of out-of-order reply!
+out_of_order = rb"""\*\*\* GASNET WARNING\(Node \d+\): Detected arrival of out-of-order reply!
  It appears your system is delivering IP packets out-of-order between worker nodes,
- most likely due to striping over multiple adapters or links.
- This might (rarely) lead to corruption of AMUDP traffic.
+ most likely due to striping over multiple adapters or links\.
+ This might \(rarely\) lead to corruption of AMUDP traffic\.
 """
 
 output = re.sub(out_of_order, b'', contents, flags=re.MULTILINE)

--- a/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
+++ b/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+
+file=sys.argv[2]
+
+with open(file, 'rb') as f:
+    contents = f.read()
+
+
+out_of_order = b"""*** GASNET WARNING(Node \\d+): Detected arrival of out-of-order reply!
+ It appears your system is delivering IP packets out-of-order between worker nodes,
+ most likely due to striping over multiple adapters or links.
+ This might (rarely) lead to corruption of AMUDP traffic.
+"""
+
+output = re.sub(out_of_order, b'', contents, flags=re.MULTILINE)
+
+
+with open(file, 'wb') as f:
+    f.write(output)

--- a/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
+++ b/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
@@ -8,8 +8,7 @@ file=sys.argv[2]
 with open(file, 'rb') as f:
     contents = f.read()
 
-
-out_of_order = rb"""\*\*\* GASNET WARNING\(Node \d+\): Detected arrival of out-of-order reply!
+out_of_order = rb"""\*\*\* GASNET WARNING\(Node \d+\): Detected arrival of out-of-order [a-zA-Z]+!
  It appears your system is delivering IP packets out-of-order between worker nodes,
  most likely due to striping over multiple adapters or links\.
  This might \(rarely\) lead to corruption of AMUDP traffic\.


### PR DESCRIPTION
Adds a prediff for a parallel debugger test which can sometimes throw GASNet errors

[Reviewed by @dlongnecke-cray]