### PR TITLE
dlopen: Move `chpl_gen_main_arg` to live in module code

### DIFF
--- a/modules/internal/ChapelProgramEntrypoints.chpl
+++ b/modules/internal/ChapelProgramEntrypoints.chpl
@@ -47,7 +47,8 @@ module ChapelProgramEntrypoints {
     chpl_error(msg, 0, 0);
   }
 
-  pragma "locale private"
+  pragma "locale private"   // TODO: May not need this, but...
+  pragma "no init"          // Don't overwite work done later.
   private var chpl_genMainArg: chpl_main_argument;
 
   // For the runtime. Get a pointer to the main argument on this locale.

--- a/modules/internal/ChapelProgramEntrypoints.chpl
+++ b/modules/internal/ChapelProgramEntrypoints.chpl
@@ -47,6 +47,14 @@ module ChapelProgramEntrypoints {
     chpl_error(msg, 0, 0);
   }
 
+  pragma "locale private"
+  private var chpl_genMainArg: chpl_main_argument;
+
+  // For the runtime. Get a pointer to the main argument on this locale.
+  export proc chpl_genMainArgPtr: c_ptr(chpl_main_argument) {
+    return c_ptrTo(chpl_genMainArg);
+  }
+
   //
   // A program using Chapel as a library might look like:
   //

--- a/runtime/include/chpl-prginfo-data-macro.h
+++ b/runtime/include/chpl-prginfo-data-macro.h
@@ -133,6 +133,11 @@ E_CALLBACK_RT(chpl__init_ChapelStandard, void, int64_t _ln, int32_t _fn)
 */
 E_CALLBACK_RT(chpl_gen_main, int64_t, chpl_main_argument* _arg)
 
+/** MODULE-CODE: ChapelProgramEntrypoints.chpl | WRITEABLE
+    Get a writeable pointer to the main argument stored on this locale.
+*/
+E_CALLBACK(chpl_genMainArgPtr, chpl_main_argument*, void)
+
 /** CODE-GENERATED
     Contains filenames, and maybe other strings besides?
 

--- a/runtime/include/chpl-prginfo.h
+++ b/runtime/include/chpl-prginfo.h
@@ -209,6 +209,9 @@ chpl_rt_prg_id chpl_rt_prginfo_id(chpl_rt_prginfo* prg);
 /** Get the load path of a program info. */
 const char* chpl_rt_prginfo_load_path(chpl_rt_prginfo* prg);
 
+/** Fetch a pointer to the main argument for a given program. */
+chpl_main_argument* chpl_rt_prginfo_main_argument(chpl_rt_prginfo* prg);
+
 // Private implementation details.
 #include "chpl-prginfo-detail.h"
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -117,7 +117,6 @@ extern void* const chpl_global_serialize_table[];
 extern const char* const chpl_mem_descs[];
 extern const int chpl_mem_numDescs;
 
-extern chpl_main_argument chpl_gen_main_arg;
 extern const int launcher_is_mli;
 extern const char* launcher_mli_real_name;
 

--- a/runtime/src/Makefile.share
+++ b/runtime/src/Makefile.share
@@ -27,6 +27,7 @@ COMMON_LAUNCHER_SRCS = \
 
 ONLY_LAUNCHER_SRCS = \
 	chpl-launcher-common.c \
+	chpl-launcher-shadow-symbols.c \
 	chpl-prginfo-launcher.c
 
 COMMON_NOGEN_SRCS = \

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -365,8 +365,13 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
   int origargc = *argc;
   int stop_parsing = 0;
   int saw_socket_conn = 0;
+  chpl_main_argument* main_arg_ptr = NULL;
 
   CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, mainHasArgs);
+
+  // Fetch the main argument pointer using a callback in program code.
+  main_arg_ptr = CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                      chpl_genMainArgPtr)();
 
   //
   // Handle the pre-parse for '-E' arguments separately.
@@ -388,8 +393,8 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
       /* update the argv structure passed to a Chapel program, but don't parse
        * the arguments
        */
-      chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = argv[i];
-      chpl_gen_main_arg.argc++;
+      main_arg_ptr->argv[main_arg_ptr->argc] = argv[i];
+      main_arg_ptr->argc++;
       continue;
     }
 
@@ -403,8 +408,8 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
       // may use it as a passthrough delimiter
       if (CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                                mainPreserveDelimiter)) {
-        chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = currentArg;
-        chpl_gen_main_arg.argc++;
+        main_arg_ptr->argv[main_arg_ptr->argc] = currentArg;
+        main_arg_ptr->argc++;
       }
       continue;
     }
@@ -434,8 +439,8 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
 
           if (strcmp(flag, "help") == 0) {
             printHelp = 1;
-            chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = "--help";
-            chpl_gen_main_arg.argc++;
+            main_arg_ptr->argv[main_arg_ptr->argc] = "--help";
+            main_arg_ptr->argc++;
             break;
           }
           if (strcmp(flag, "about") == 0) {
@@ -470,9 +475,9 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
             saw_socket_conn = 1;
             // We reached information about the socket in a multilocale library
             // run.  Save it.
-            chpl_gen_main_arg.argv[chpl_gen_main_arg.argc++] =
+            main_arg_ptr->argv[main_arg_ptr->argc++] =
               "--chpl-mli-socket-loc";
-            chpl_gen_main_arg.argv[chpl_gen_main_arg.argc++] = currentArg;
+            main_arg_ptr->argv[main_arg_ptr->argc++] = currentArg;
             break;
           }
           if (argLength < 3) {
@@ -522,8 +527,8 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
       case 'h':
         if (currentArg[2] == '\0') {
           printHelp = 1;
-          chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = "-h";
-          chpl_gen_main_arg.argc++;
+          main_arg_ptr->argv[main_arg_ptr->argc] = "-h";
+          main_arg_ptr->argc++;
         } else {
           i += handleNonstandardArg(argc, argv, i, lineno, filename);
         }

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -365,13 +365,10 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
   int origargc = *argc;
   int stop_parsing = 0;
   int saw_socket_conn = 0;
-  chpl_main_argument* main_arg_ptr = NULL;
+  chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
+  chpl_main_argument* main_arg_ptr = chpl_rt_prginfo_main_argument(prg);
 
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, mainHasArgs);
-
-  // Fetch the main argument pointer using a callback in program code.
-  main_arg_ptr = CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                                      chpl_genMainArgPtr)();
+  CHPL_RT_PRGINFO_DECLARE(prg, mainHasArgs);
 
   //
   // Handle the pre-parse for '-E' arguments separately.

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -64,11 +64,9 @@ void deallocate_string_literals_buf(void) {
 
 int handleNonstandardArg(int* argc, char* argv[], int argNum,
                          int32_t lineno, int32_t filename) {
-  if (CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, mainHasArgs)) {
-    chpl_main_argument* main_arg_ptr = NULL;
-
-    main_arg_ptr = CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                                        chpl_genMainArgPtr)();
+  chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
+  if (CHPL_RT_PRGINFO_DATA(prg, mainHasArgs)) {
+    chpl_main_argument* main_arg_ptr = chpl_rt_prginfo_main_argument(prg);
 
     main_arg_ptr->argv[main_arg_ptr->argc] = argv[argNum];
     main_arg_ptr->argc++;
@@ -280,12 +278,9 @@ void chpl_rt_init(chpl_rt_prginfo* root_prg, int argc, char** argv) {
   chpl_comm_barrier("about to leave comm init code");
 
   // Call a callback from the program data to initialize the config table.
-  CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                       CreateConfigVarTable)();
+  CHPL_RT_PRGINFO_DATA(root_prg, CreateConfigVarTable)();
 
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                          chpl_genMainArgPtr);
-  chpl_main_argument* main_arg_ptr = chpl_genMainArgPtr();
+  chpl_main_argument* main_arg_ptr = chpl_rt_prginfo_main_argument(root_prg);
 
   main_arg_ptr->argv = chpl_malloc(argc * sizeof(char*));
   main_arg_ptr->argv[0] = argv[0];
@@ -410,8 +405,7 @@ void chpl_executable_init(void) {
     chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
 
     // Get the main argument.
-    chpl_main_argument* main_arg_ptr = NULL;
-    main_arg_ptr = CHPL_RT_PRGINFO_DATA(prg, chpl_genMainArgPtr)();
+    chpl_main_argument* main_arg_ptr = chpl_rt_prginfo_main_argument(prg);
 
     // Fetch 'chpl_gen_main' from the root program's data.
     CHPL_RT_PRGINFO_DECLARE(prg, chpl_gen_main);

--- a/runtime/src/chpl-init.c
+++ b/runtime/src/chpl-init.c
@@ -48,8 +48,6 @@
 
 static const int32_t myFilename = CHPL_FILE_IDX_INTERNAL;
 
-chpl_main_argument chpl_gen_main_arg;
-
 void* chpl_string_literals_buffer;
 
 const char* allocate_string_literals_buf(int64_t s) {
@@ -67,8 +65,13 @@ void deallocate_string_literals_buf(void) {
 int handleNonstandardArg(int* argc, char* argv[], int argNum,
                          int32_t lineno, int32_t filename) {
   if (CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, mainHasArgs)) {
-    chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = argv[argNum];
-    chpl_gen_main_arg.argc++;
+    chpl_main_argument* main_arg_ptr = NULL;
+
+    main_arg_ptr = CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                        chpl_genMainArgPtr)();
+
+    main_arg_ptr->argv[main_arg_ptr->argc] = argv[argNum];
+    main_arg_ptr->argc++;
   } else {
     char* message = chpl_glom_strings(3, "Unexpected flag:  \"", argv[argNum], "\"");
     chpl_error(message, lineno, filename);
@@ -280,10 +283,14 @@ void chpl_rt_init(chpl_rt_prginfo* root_prg, int argc, char** argv) {
   CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                        CreateConfigVarTable)();
 
-  chpl_gen_main_arg.argv = chpl_malloc(argc * sizeof(char*));
-  chpl_gen_main_arg.argv[0] = argv[0];
-  chpl_gen_main_arg.argc = 1;
-  chpl_gen_main_arg.return_value = 0;
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_genMainArgPtr);
+  chpl_main_argument* main_arg_ptr = chpl_genMainArgPtr();
+
+  main_arg_ptr->argv = chpl_malloc(argc * sizeof(char*));
+  main_arg_ptr->argv[0] = argv[0];
+  main_arg_ptr->argc = 1;
+  main_arg_ptr->return_value = 0;
 
   parseArgs(false, parse_normally, &argc, argv);
 
@@ -400,14 +407,19 @@ void chpl_executable_init(void) {
   chpl_std_module_init();
 
   if (chpl_nodeID == 0) {
+    chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
+
+    // Get the main argument.
+    chpl_main_argument* main_arg_ptr = NULL;
+    main_arg_ptr = CHPL_RT_PRGINFO_DATA(prg, chpl_genMainArgPtr)();
+
     // Fetch 'chpl_gen_main' from the root program's data.
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_gen_main);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_gen_main);
 
     //
     // Call the compiler-generated main() routine
     //
-    chpl_gen_main_arg.return_value = chpl_gen_main(&chpl_gen_main_arg);
+    main_arg_ptr->return_value = chpl_gen_main(main_arg_ptr);
   }
 
 }

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -42,10 +42,6 @@
 // used in get_enviro_keys
 extern char** environ;
 
-// This global variable stores the arguments to main
-// that should be handled by the program.
-chpl_main_argument chpl_gen_main_arg;
-
 //
 // Are we doing a dry run, printing the system launcher command but
 // not running it?
@@ -642,8 +638,12 @@ int handleNonstandardArg(int* argc, char* argv[], int argNum,
   if (numHandled == 0) {
     if (CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                              mainHasArgs)) {
-      chpl_gen_main_arg.argv[chpl_gen_main_arg.argc] = argv[argNum];
-      chpl_gen_main_arg.argc++;
+      chpl_main_argument* main_arg_ptr = NULL;
+      main_arg_ptr = CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                          chpl_genMainArgPtr)();
+
+      main_arg_ptr->argv[main_arg_ptr->argc] = argv[argNum];
+      main_arg_ptr->argc++;
     } else {
       char* message;
       message = chpl_glom_strings(3,"Unexpected flag:  \"",argv[argNum],"\"");
@@ -807,13 +807,17 @@ int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales,
   int32_t execNumLocales;
   int32_t execNumLocalesPerNode;
   int argc = *c_argc;
+  chpl_main_argument* main_arg_ptr = NULL;
+
+  main_arg_ptr = CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                      chpl_genMainArgPtr)();
 
   // Set up main argument parsing.
-  chpl_gen_main_arg.argv = chpl_mem_allocMany(argc, sizeof(char*),
-                                      CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
-  chpl_gen_main_arg.argv[0] = argv[0];
-  chpl_gen_main_arg.argc = 1;
-  chpl_gen_main_arg.return_value = 0;
+  main_arg_ptr->argv = chpl_mem_allocMany(argc, sizeof(char*),
+                                          CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
+  main_arg_ptr->argv[0] = argv[0];
+  main_arg_ptr->argc = 1;
+  main_arg_ptr->return_value = 0;
 
   // Call a callback to create the table which stores config vars.
   CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -636,11 +636,10 @@ int handleNonstandardArg(int* argc, char* argv[], int argNum,
   }
 
   if (numHandled == 0) {
-    if (CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                             mainHasArgs)) {
-      chpl_main_argument* main_arg_ptr = NULL;
-      main_arg_ptr = CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                                          chpl_genMainArgPtr)();
+    chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
+
+    if (CHPL_RT_PRGINFO_DATA(prg, mainHasArgs)) {
+      chpl_main_argument* main_arg_ptr = chpl_rt_prginfo_main_argument(prg);
 
       main_arg_ptr->argv[main_arg_ptr->argc] = argv[argNum];
       main_arg_ptr->argc++;
@@ -807,10 +806,8 @@ int chpl_launch_prep(int* c_argc, char* argv[], int32_t* c_execNumLocales,
   int32_t execNumLocales;
   int32_t execNumLocalesPerNode;
   int argc = *c_argc;
-  chpl_main_argument* main_arg_ptr = NULL;
-
-  main_arg_ptr = CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                                      chpl_genMainArgPtr)();
+  chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
+  chpl_main_argument* main_arg_ptr = chpl_rt_prginfo_main_argument(prg);
 
   // Set up main argument parsing.
   main_arg_ptr->argv = chpl_mem_allocMany(argc, sizeof(char*),

--- a/runtime/src/chpl-launcher-shadow-symbols.c
+++ b/runtime/src/chpl-launcher-shadow-symbols.c
@@ -18,15 +18,7 @@
  * limitations under the License.
  */
 
-#include "chplcgfns.h"
-#include "chpl-prginfo.h"
-#include "chpl-comm-launch.h"
-#include "chpl-comm-locales.h"
-#include "chplexit.h"
-#include "chpllaunch.h"
-#include "chpl-mem.h"
 #include "chpltypes.h"
-#include "chpl-error.h"
 
 //
 // Symbols declared in this source are launcher-only copies of symbols that
@@ -37,7 +29,6 @@
 
 // This mimics a function that is defined in module code.
 chpl_main_argument* chpl_genMainArgPtr(void);
-
 chpl_main_argument* chpl_genMainArgPtr(void) {
   static chpl_main_argument main_argument;
   return &main_argument;

--- a/runtime/src/chpl-launcher-shadow-symbols.c
+++ b/runtime/src/chpl-launcher-shadow-symbols.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "chplcgfns.h"
+#include "chpl-prginfo.h"
+#include "chpl-comm-launch.h"
+#include "chpl-comm-locales.h"
+#include "chplexit.h"
+#include "chpllaunch.h"
+#include "chpl-mem.h"
+#include "chpltypes.h"
+#include "chpl-error.h"
+
+//
+// Symbols declared in this source are launcher-only copies of symbols that
+// are normally used by the runtime and declared by the program. Many of
+// these "shadow" symbols are declared in "chpl_compilation_config.c" during
+// code generation, but not all of them.
+//
+
+// This mimics a function that is defined in module code.
+chpl_main_argument* chpl_genMainArgPtr(void);
+
+chpl_main_argument* chpl_genMainArgPtr(void) {
+  static chpl_main_argument main_argument;
+  return &main_argument;
+}

--- a/runtime/src/chpl-prginfo.c
+++ b/runtime/src/chpl-prginfo.c
@@ -237,3 +237,9 @@ void chpl_rt_prginfo_dump_data_entries(chpl_rt_prginfo* prg,
 
   #include "chpl-prginfo-data-macro-adapter.h"
 }
+
+chpl_main_argument* chpl_rt_prginfo_main_argument(chpl_rt_prginfo* prg) {
+  CHPL_RT_PRGINFO_DECLARE(prg, chpl_genMainArgPtr);
+  chpl_main_argument* ret = chpl_genMainArgPtr();
+  return ret;
+}

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -30,21 +30,21 @@ extern chpl_rt_prginfo* chpl_prepareProgramInfoHere(void);
 
 int main(int argc, char* argv[]) {
   // Run the code that initializes our program information.
-  chpl_rt_prginfo* our_root_prg = chpl_prepareProgramInfoHere();
-  chpl_rt_prginfo* got_root_prg = NULL;
+  chpl_rt_prginfo* prg = chpl_prepareProgramInfoHere();
+  chpl_rt_prginfo* got_prg = NULL;
 
   // Initialize the runtime, giving it our program info.
-  chpl_rt_init(our_root_prg, argc, argv);
+  chpl_rt_init(prg, argc, argv);
 
   // Have the runtime fetch the root program.
-  got_root_prg = CHPL_RT_PRGINFO_ROOT;
+  got_prg = CHPL_RT_PRGINFO_ROOT;
 
   // It should match what we gave 'chpl_rt_init'.
-  if (got_root_prg && our_root_prg != got_root_prg) {
+  if (got_prg && prg != got_prg) {
     chpl_internal_error("a Chapel program tried to initialize the Chapel "
                         "runtime, but the root program was already bound");
 
-  } else if (!got_root_prg) {
+  } else if (!got_prg) {
     chpl_internal_error("the Chapel runtime has not bound a root program");
   }
 
@@ -52,9 +52,7 @@ int main(int argc, char* argv[]) {
   chpl_task_callMain(chpl_executable_init);
 
   // Fetch the main argument from the program data.
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                          chpl_genMainArgPtr);
-  chpl_main_argument* main_arg_ptr = chpl_genMainArgPtr();
+  chpl_main_argument* main_arg_ptr = chpl_rt_prginfo_main_argument(prg);
 
   // have everyone exit, returning the value returned by the user written main
   // or 0 if it didn't return anything

--- a/runtime/src/main.c
+++ b/runtime/src/main.c
@@ -51,9 +51,14 @@ int main(int argc, char* argv[]) {
   // Run the main function for this node.
   chpl_task_callMain(chpl_executable_init);
 
+  // Fetch the main argument from the program data.
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_genMainArgPtr);
+  chpl_main_argument* main_arg_ptr = chpl_genMainArgPtr();
+
   // have everyone exit, returning the value returned by the user written main
   // or 0 if it didn't return anything
-  chpl_exit_all(chpl_gen_main_arg.return_value);
+  chpl_exit_all(main_arg_ptr->return_value);
 
   return 0; // should never get here
 }


### PR DESCRIPTION
This PR moves `chpl_gen_main_arg` to live in the program as a writeable value. Previously, it was declared in the runtime.

Note that I did not want to teach the code generator how to generate an export `chpl_main_argument*`, because generating a pointer of an arbitrary type does not appear to be a simple as modifying how we generate a C string.

Instead, declare the `chpl_main_argument` in module code, and fetch a pointer to it in the runtime using a new callback from the module code.

To obfuscate the extra layer of indirection here, I've added a helper function for `chpl_rt_prginfo` that fetches the main argument in one step. My intention is to add more helpers like this to `chpl_rt_prginfo` in the future, as needed for ergonomics.

Note that if we adjust the code generator, we can remove this extra indirection, but that is not a priority ATM.

TESTING

- [x] `standard`
- [x] `C backend`

Reviewed by @jabraham17. Thanks!