### PR TITLE
Update and consolidate `README.devel` and `README.files`

### DIFF
--- a/README.devel
+++ b/README.devel
@@ -31,5 +31,8 @@ the git tree, but not exactly the same:
 
 The following files/directories are for developers only:
 
-  README.devel     : this file
-  test/            : the Chapel testing system in all its glory
+  CODE_OF_CONDUCT.md : Chapel contributor code of conduct
+  LICENSE.devel      : third-party licenses of code not appearing in release
+  Makefile.devel     : Makefile containing targets for dev use
+  README.devel       : this file
+  test/              : the Chapel testing system in all its glory

--- a/README.devel
+++ b/README.devel
@@ -2,39 +2,14 @@
 Chapel developer's file map
 ===========================
 
-The README and README.files files in this directory are intended for
-the end-user whose directory and file structure differs somewhat from
-what a developer would see in their git tree.  This file is meant to
-provide similar information as README.files for developers, and to map
-between the developer directory structure and the release directory
-structure.
+The README.files file in this directory is intended for the end user, whose
+directory and file structure differs somewhat from what a developer would see
+in their git tree. This file is meant to provide similar information for
+developers, and to map between the developer directory structure and the
+release directory structure.
 
-The following files/directories are ones that are the same and in the
-same place for developers and end users.  See README.files for a
-description:
-
-./
-  ACKNOWLEDGEMENTS.md
-  CHANGES.md
-  CONTRIBUTORS.md
-  COPYRIGHT
-  LICENSE
-  LICENSE.chapel
-  QUICKSTART.rst
-  README.files
-  README.rst
-  Makefile
-  bin/
-  compiler/
-  highlight/
-  lib/
-  make/
-  modules/
-  runtime/
-  third-party/
-  tools/
-  util/
-
+Most files/directories are the same and in the sam place for developers and end
+users. See README.files for a description of these.
 
 The following files/directories in the release are based on those in
 the git tree, but not exactly the same:
@@ -48,13 +23,11 @@ the git tree, but not exactly the same:
               from test/release/examples in the developer hierarchy
               (with outdated subdirectories pruned).
 
-  man/ :      for the developer, this directory contains the sources
+  man/      : for the developer, this directory contains the sources
               for our man page as well as for the man page itself, built
               using "make man" from the top-level directory.  For
               users, this directory only contains the resulting man
               page structure.
-
-
 
 The following files/directories are for developers only:
 

--- a/README.devel
+++ b/README.devel
@@ -8,7 +8,7 @@ in their git tree. This file is meant to provide similar information for
 developers, and to map between the developer directory structure and the
 release directory structure.
 
-Most files/directories are the same and in the sam place for developers and end
+Most files/directories are the same and in the same place for developers and end
 users. See README.files for a description of these.
 
 The following files/directories in the release are based on those in

--- a/README.files
+++ b/README.files
@@ -10,8 +10,10 @@ further information about the files and directories that they contain.
   README.rst           : top-level README
   ACKNOWLEDGEMENTS.md  : organizations who have supported this work
   CHANGES.md           : a list of changes in each release
+  CMakeLists.txt       : top-level CMake file for building things
   CONTRIBUTORS.md      : a list of contributors to the Chapel project
   COPYRIGHT            : copyright information
+  Dockerfile           : Dockerfile for the base Chapel image
   LICENSE              : license information for the Chapel release as a whole
   LICENSE.chapel       : license statement for the Chapel implementation itself
   README.files         : this file
@@ -21,6 +23,7 @@ further information about the files and directories that they contain.
   configure            : autotools-like configure script, used with make install
   doc/                 : documentation and READMEs
   examples/            : example Chapel codes
+  frontend/            : source code for the compiler frontend library
   highlight/           : syntax coloring modes for emacs, vim, source-highlight
   lib/                 : stores the runtime and launcher libraries, once built
   make/                : Makefile settings for various compilers and platforms

--- a/README.files
+++ b/README.files
@@ -7,20 +7,20 @@ structure.  Most subdirectories contain a README file to provide
 further information about the files and directories that they contain.
 
 ./
-  README.rst           : top-level README
   ACKNOWLEDGEMENTS.md  : organizations who have supported this work
   CHANGES.md           : a list of changes in each release
   CMakeLists.txt       : top-level CMake file for building things
+  configure            : autotools-like configure script, used with make install
   CONTRIBUTORS.md      : a list of contributors to the Chapel project
   COPYRIGHT            : copyright information
   Dockerfile           : Dockerfile for the base Chapel image
   LICENSE              : license information for the Chapel release as a whole
   LICENSE.chapel       : license statement for the Chapel implementation itself
-  README.files         : this file
   Makefile             : top-level Makefile for building things
+  README.files         : this file
+  README.rst           : top-level README
   bin/                 : location of the compiler (chpl) once it's been built
   compiler/            : source code for the compiler
-  configure            : autotools-like configure script, used with make install
   doc/                 : documentation and READMEs
   examples/            : example Chapel codes
   frontend/            : source code for the compiler frontend library


### PR DESCRIPTION
Make some updates and improvements to the `README.devel` and `README.files` files:
- Use alphabetical order consistently.
- Remove reference to `README` file (now `README.rst`).
- Add in files and directories that were not listed, into the respective README.

[reviewed by @bradcray , thanks!]