### PR TITLE
Update links for new GASNet repo

### DIFF
--- a/doc/rst/platforms/comm-layers/gasnet.rst
+++ b/doc/rst/platforms/comm-layers/gasnet.rst
@@ -200,7 +200,7 @@ run Chapel programs using the MPI library for communication between locales.
 
 For best practices about how to configure/use GASNet to avoid such conflicts
 with MPI, please see the
-`GASNet docs for the MPI Conduit <https://bitbucket.org/berkeleylab/gasnet/src/master/mpi-conduit/README>`_
+`GASNet docs for the MPI Conduit <https://github.com/BerkeleyLab/gasnet/tree/main/mpi-conduit/README>`_
 (also available at
 ``$CHPL_HOME/third-party/gasnet/gasnet-src/mpi-conduit/README``).
 

--- a/doc/rst/platforms/networks/infiniband.rst
+++ b/doc/rst/platforms/networks/infiniband.rst
@@ -128,7 +128,7 @@ values are:
   more information about this option, including how to configure job
   launch via ``PMIRUN_CMD``, see the `GASNet README for the PMI-based
   spawner
-  <https://bitbucket.org/berkeleylab/gasnet/src/master/other/pmi-spawner/README>`_
+  <https://github.com/BerkeleyLab/gasnet/tree/main/other/pmi-spawner/README>`_
   (also available at
   ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/pmi-spawner/README``).
 
@@ -180,7 +180,7 @@ For further information about environment variables that can be used
 to control how `ssh` is used to launch your Chapel program, see the
 descriptions of ``GASNET_SSH_CMD`` and ``GASNET_SSH_OPTIONS`` in the
 `GASNet README for the ssh spawner
-<https://bitbucket.org/berkeleylab/gasnet/src/master/other/ssh-spawner/README>`_
+<https://github.com/BerkeleyLab/gasnet/tree/main/other/ssh-spawner/README>`_
 (also available at
 ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/ssh-spawner/README``).
 
@@ -216,7 +216,7 @@ preferred for InfiniBand):
 For tips and best practices about how to configure/use GASNet to avoid
 such conflicts with MPI, please refer to the section "Build-time
 Configuration" in the `GASNet README for the MPI spawner
-<https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README>`_
+<https://github.com/BerkeleyLab/gasnet/tree/main/other/mpi-spawner/README>`_
 (also available at
 ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/mpi-spawner/README``).
 Within this README, see also the description of the ``MPIRUN_CMD``

--- a/doc/rst/platforms/networks/omnipath.rst
+++ b/doc/rst/platforms/networks/omnipath.rst
@@ -74,7 +74,7 @@ values are:
   more information about this option, including how to configure job
   launch via ``PMIRUN_CMD``, see the `GASNet README for the PMI-based
   spawner
-  <https://bitbucket.org/berkeleylab/gasnet/src/master/other/pmi-spawner/README>`_
+  <https://github.com/BerkeleyLab/gasnet/tree/main/other/pmi-spawner/README>`_
   (also available at
   ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/pmi-spawner/README``).
 
@@ -125,7 +125,7 @@ For further information about environment variables that can be used
 to control how `ssh` is used to launch your Chapel program, see the
 descriptions of ``GASNET_SSH_CMD`` and ``GASNET_SSH_OPTIONS`` in the
 `GASNet README for the ssh spawner
-<https://bitbucket.org/berkeleylab/gasnet/src/master/other/ssh-spawner/README>`_
+<https://github.com/BerkeleyLab/gasnet/tree/main/other/ssh-spawner/README>`_
 (also available at
 ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/ssh-spawner/README``).
 
@@ -158,7 +158,7 @@ one in which MPI is preventing GASNet from accessing what it needs:
 For tips and best practices about how to configure/use GASNet to avoid
 such conflicts with MPI, please refer to the section "Build-time
 Configuration" in the `GASNet README for the MPI spawner
-<https://bitbucket.org/berkeleylab/gasnet/src/master/other/mpi-spawner/README>`_
+<https://github.com/BerkeleyLab/gasnet/tree/main/other/mpi-spawner/README>`_
 (also available at
 ``$CHPL_HOME/third-party/gasnet/gasnet-src/other/mpi-spawner/README``).
 Within this README, see also the description of the ``MPIRUN_CMD``

--- a/third-party/gasnet/README
+++ b/third-party/gasnet/README
@@ -17,7 +17,7 @@ The directory $CHPL_HOME/third-party/gasnet/gasnet-src/ contains the
 un-tarballed GASNet package contents.  Version updates should be done as
 follows, assuming the CWD is $CHPL_HOME/third-party/gasnet/:
 
-1. Download the new package from https://bitbucket.org/berkeleylab/gasnet/downloads/GASNet-2025.8.0.tar.gz
+1. Download the new package from https://github.com/BerkeleyLab/gasnet/releases/download/gex-2025.8.0/GASNet-2025.8.0.tar.gz
 2. un-tarball the new package version into the directory it specifies,
    for example GASNet-2025.8.0
 3. git rm -r gasnet-src


### PR DESCRIPTION
GASNet has moved from bitbucket to github.

This means in the future we will get tarballs from the new github and any docs we have linking to their repo have to be updated.

[Reviewed by @benharsh]