### PR TITLE
dlopen: Fix issues with `--incremental` and C backend

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1468,8 +1468,6 @@ static void genFunctionTables() {
 // Only put C data objects into this file, not Chapel ones, as it may
 // also be #include'd into a launcher, and those are C/C++ code.
 //
-// New generated variables should be added to runtime/include/chplcgfns.h
-//
 static const char* sCfgFname = "chpl_compilation_config";
 
 static void codegen_header_compilation_config() {

--- a/runtime/include/chpl-prginfo-program-only-decls.h
+++ b/runtime/include/chpl-prginfo-program-only-decls.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CHPL_RT_PRGINFO_PROGRAM_ONLY_DECLS_H
+#define CHPL_RT_PRGINFO_PROGRAM_ONLY_DECLS_H
+
+#include "chpl-prginfo.h"
+
+//
+// DO NOT INCLUDE THIS HEADER WITHIN RUNTIME CODE!
+//
+
+// This header is a workaround for the fact that the compiler cannot tell
+// the types of certain global compiler-generated symbols such as
+// 'CreateConfigVarTable' or 'mainHasArgs' because it previously relied
+// on them being visible via 'chplcgfns.h'.
+//
+// We are trying to remove 'chplcgfns.h' so that the runtime cannot access
+// the symbol declarations in it (because it should not be linking against
+// those symbols at all).
+//
+// This header is a workaround, but eventually we _should remove it too_.
+// It will be easier to remove after 'chplcgfns.h' is gone.
+
+// Manually declare rather than rely on macro-expansion since the signature
+// for some callbacks can differ from machine to machine (e.g., they use
+// Chapel C types).
+//
+// Also, the declarations in 'chpl-prginfo-data-macro.h' tend to omit
+// 'const' qualifiers which makes the backend C compiler unhappy.
+
+extern void CreateConfigVarTable(void);
+extern const int mainHasArgs;
+extern const int mainPreserveDelimiter;
+extern char* chpl_executionCommand;
+extern const int warnUnstable;
+
+#endif

--- a/runtime/include/stdchpl.h
+++ b/runtime/include/stdchpl.h
@@ -71,6 +71,7 @@
 #include "chpltypes.h"
 #include "chpl-visual-debug.h"
 #include "chpl-error.h"
+#include "chpl-prginfo-program-only-decls.h"
 
 #include "chpl-comm-compiler-macros.h"
 #include "chpl-wide-ptr-fns.h"


### PR DESCRIPTION
This PR should fix failures in nightly testing, specifically those tests exercising incremental compilation.

It does so by introducing a runtime header that is only intended for use by compiled Chapel programs, and puts declarations of some code-generated symbols into that header. This is a workaround for those declarations being removed from `chplcgfns.h`, which we appear to rely upon for ensuring visibility.

- [x] `standard`
- [x] `C backend`

Reviewed by @jabraham17. Thanks!