### PR TITLE
Fix reflection for procedure pointers

### DIFF
--- a/compiler/include/resolution.h
+++ b/compiler/include/resolution.h
@@ -266,6 +266,7 @@ enum class PoiSearchMode {
 };
 
 FnSymbol* tryResolveCall(CallExpr* call, bool checkWithin=false, PoiSearchMode poiMode = PoiSearchMode::NORMAL);
+bool      resolveFunctionPointerCall(CallExpr* call, bool checkOnly, bool* resolved = nullptr);
 void      makeRefType(Type* type);
 
 // FnSymbol changes

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -2858,7 +2858,6 @@ void resolveDestructor(AggregateType* at) {
 static bool resolveTypeComparisonCall(CallExpr* call);
 static bool resolveBuiltinCastCall(CallExpr* call);
 static bool resolveClassBorrowMethod(CallExpr* call);
-static bool resolveFunctionPointerCall(CallExpr* call);
 static void resolveCoerceCopyMove(CallExpr* call);
 static void resolvePrimInit(CallExpr* call);
 static void resolveInitRef(CallExpr* call);
@@ -2938,7 +2937,7 @@ void resolveCall(CallExpr* call) {
     if (resolveClassBorrowMethod(call))
       return;
 
-    if (resolveFunctionPointerCall(call))
+    if (resolveFunctionPointerCall(call, false))
       return;
 
     if (call->isNamedAstr(astr_coerceCopy)) {
@@ -3379,7 +3378,9 @@ static bool resolveClassBorrowMethod(CallExpr* call) {
 // TODO: Ideally, we would be able to leverage the existing machinery for
 // resolving calls, but we may not be able to do that until dyno is used
 // to resolve code.
-static bool resolveFunctionPointerCall(CallExpr* call) {
+bool resolveFunctionPointerCall(CallExpr* call, bool checkOnly, bool* resolved) {
+  if (resolved) *resolved = false; // set this in case of early return
+
   auto ft = call->isIndirectCall() ? call->functionType() : nullptr;
   if (!ft) return false;
 
@@ -3387,10 +3388,12 @@ static bool resolveFunctionPointerCall(CallExpr* call) {
 
   // TODO: Support default arguments?
   if (call->numActuals() != ft->numFormals()) {
-    USR_FATAL(call, "incorrect number of arguments - expected '%d', "
-                    "but found '%d'",
-                    ft->numFormals(),
-                    call->numActuals());
+    if (!checkOnly) {
+      USR_FATAL(call, "incorrect number of arguments - expected '%d', "
+                      "but found '%d'",
+                      ft->numFormals(),
+                      call->numActuals());
+    }
     return true;
   }
 
@@ -3401,13 +3404,15 @@ static bool resolveFunctionPointerCall(CallExpr* call) {
       auto se = toSymExpr(base);
       const char* name = se ? se->symbol()->name : nullptr;
 
-      if (name) {
-        USR_FATAL_CONT(actual, "calls to function values ('%s' in this "
-                               "case) do not support named arguments yet",
-                               name);
-      } else {
-        USR_FATAL_CONT(actual, "calls to function values do not support "
-                               "named arguments yet");
+      if (!checkOnly) {
+        if (name) {
+          USR_FATAL_CONT(actual, "calls to function values ('%s' in this "
+                                 "case) do not support named arguments yet",
+                                 name);
+        } else {
+          USR_FATAL_CONT(actual, "calls to function values do not support "
+                                 "named arguments yet");
+        }
       }
     }
   }
@@ -3438,19 +3443,25 @@ static bool resolveFunctionPointerCall(CallExpr* call) {
                           ft);
     anyPromotes = anyPromotes || promotes;
     if (!ok) {
-      if (onceForErrorHeader) {
-        USR_FATAL_CONT(call, "failed to resolve call");
-        onceForErrorHeader = false;
-      }
+      if (!checkOnly) {
+        if (onceForErrorHeader) {
+          USR_FATAL_CONT(call, "failed to resolve call");
+          onceForErrorHeader = false;
+        }
 
-      USR_FATAL_CONT(actual, "because actual argument with type '%s' is "
-                             "passed to formal '%s'",
-                             toString(actualType),
-                             toString(formalType));
+        USR_FATAL_CONT(actual, "because actual argument with type '%s' is "
+                               "passed to formal '%s'",
+                               toString(actualType),
+                               toString(formalType));
+      }
 
       return true;
     }
   }
+
+  if (resolved) *resolved = true;
+
+  if (checkOnly) return true;
 
   // Instead of refactoring wrapper machinery, create a wrapper for
   // this particular call and resolve it normally.

--- a/compiler/resolution/preFold.cpp
+++ b/compiler/resolution/preFold.cpp
@@ -810,6 +810,8 @@ static Expr* preFoldPrimResolves(CallExpr* call) {
           INT_ASSERT(expr);
         } break;
       }
+    } else if (call->isIndirectCall()) {
+      resolveFunctionPointerCall(call, true, &didResolveExpr);
 
     // Otherwise, it is a normal call, so rely on 'tryResolveCall'.
     } else {

--- a/modules/packages/Futures.chpl
+++ b/modules/packages/Futures.chpl
@@ -308,10 +308,7 @@ module Futures {
       if !canResolveMethod(taskFn, "retType") then
         compilerError("cannot determine return type of task function");
     } else {
-      proc _wrapper(fn) {
-        return fn();
-      }
-      if !canResolve("_wrapper", taskFn) then
+      if !canResolveCall(taskFn) then
         compilerError("async() task function (expecting arguments) provided without arguments");
     }
     var f: Future(_retType(taskFn));
@@ -337,10 +334,7 @@ module Futures {
       if !canResolveMethod(taskFn, "retType") then
         compilerError("cannot determine return type of task function");
     } else {
-      proc _wrapper(fn, args...) {
-        return fn((...args));
-      }
-      if !canResolve("_wrapper", taskFn, (...args)) then
+      if !canResolveCall(taskFn, (...args)) then
        compilerError("async() task function provided with mismatching arguments");
     }
     var f: Future(_retType(taskFn, (...args)));

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -466,6 +466,7 @@ module ChapelIO {
       var start : byteIndex;
       if typeName.startsWith("proc") then start = 4;
       else if (typeName.startsWith("wide proc")) then start = 9;
+      else if typeName.startsWith("extern proc") then start = 11;
       else assert(false, "Unexpected function format: " + typeName);
 
       const parenIndex = typeName.find("(");

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1744,10 +1744,11 @@ module List {
                          Reflection.canResolveCall(updater, i, slot)
                        else
                          Reflection.canResolveMethod(updater, "this", i, slot);
-      param str = if useProcedurePointers then " for arguments ("
-                  else ".this() for arguments (";
+      param str = if useProcedurePointers then "' for arguments ("
+                  else ".this()' for arguments (";
+      param kind = if useProcedurePointers then "updater '" else "method '";
       if !resolves then
-        compilerError('`list.update()` failed to resolve updater ' +
+        compilerError('`list.update()` failed to resolve ' + kind +
                       updater.type:string + str +
                       i.type:string + ', ' + slot.type:string + ')');
 

--- a/modules/standard/List.chpl
+++ b/modules/standard/List.chpl
@@ -1740,9 +1740,15 @@ module List {
       // Print a prettier error message if arguments fail resolve, to avoid
       // pointing into module code.
       import Reflection;
-      if !Reflection.canResolveMethod(updater, "this", i, slot) then
-        compilerError('`list.update()` failed to resolve method ' +
-                      updater.type:string + '.this() for arguments (' +
+      param resolves = if useProcedurePointers then
+                         Reflection.canResolveCall(updater, i, slot)
+                       else
+                         Reflection.canResolveMethod(updater, "this", i, slot);
+      param str = if useProcedurePointers then " for arguments ("
+                  else ".this() for arguments (";
+      if !resolves then
+        compilerError('`list.update()` failed to resolve updater ' +
+                      updater.type:string + str +
                       i.type:string + ', ' + slot.type:string + ')');
 
       return updater(i, slot);

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -380,9 +380,9 @@ module Map {
                    Reflection.canResolveCall(updater, key, val)
                  else
                    Reflection.canResolveMethod(updater, "this", key, val);
-      param str = if useProcedurePointers then " for arguments ("
-            else ".this() for arguments (";
-      param kind = if useProcedurePointers then "updater " else "method ";
+      param str = if useProcedurePointers then "' for arguments ("
+            else ".this()' for arguments (";
+      param kind = if useProcedurePointers then "updater '" else "method '";
       if !resolves then
         compilerError('`map.update()` failed to resolve ' + kind +
                       updater.type:string + str +

--- a/modules/standard/Map.chpl
+++ b/modules/standard/Map.chpl
@@ -376,9 +376,16 @@ module Map {
       ref val = table.table[slot].val;
 
       import Reflection;
-      if !Reflection.canResolveMethod(updater, "this", key, val) then
-        compilerError('`map.update()` failed to resolve method ' +
-                      updater.type:string + '.this() for arguments (' +
+      param resolves = if useProcedurePointers then
+                   Reflection.canResolveCall(updater, key, val)
+                 else
+                   Reflection.canResolveMethod(updater, "this", key, val);
+      param str = if useProcedurePointers then " for arguments ("
+            else ".this() for arguments (";
+      param kind = if useProcedurePointers then "updater " else "method ";
+      if !resolves then
+        compilerError('`map.update()` failed to resolve ' + kind +
+                      updater.type:string + str +
                       key.type:string + ', ' + val.type:string + ')');
 
       return updater(key, val);

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -370,6 +370,26 @@ proc canResolveTypeMethod(type t, param fname : string) param : bool do
 proc canResolveTypeMethod(type t, param fname : string, args ...) param : bool do
   return __primitive("method call and fn resolves", t, fname, (...args));
 
+/* Returns ``true`` if a call to a first-class function can be resolved
+   without any arguments.
+
+  .. note:: Does not attempt to resolve the body of the invoked function.
+
+    */
+@unstable(reason="The 'canResolve...' family of procedures are unstable")
+proc canResolveCall(fn) param : bool do
+  return __primitive("resolves", fn());
+
+/* Returns ``true`` if a call to a first-class function can be resolved with
+   the given arguments.
+
+  .. note:: Does not attempt to resolve the body of the invoked function.
+
+    */
+@unstable(reason="The 'canResolve...' family of procedures are unstable")
+proc canResolveCall(fn, args...) param : bool do
+  return __primitive("resolves", fn((...args)));
+
 // TODO -- do we need a different version of can resolve with ref this?
 
 /* Returns the line number of the call to this function. */

--- a/modules/standard/Reflection.chpl
+++ b/modules/standard/Reflection.chpl
@@ -376,6 +376,7 @@ proc canResolveTypeMethod(type t, param fname : string, args ...) param : bool d
   .. note:: Does not attempt to resolve the body of the invoked function.
 
     */
+@chpldoc.nodoc
 @unstable(reason="The 'canResolve...' family of procedures are unstable")
 proc canResolveCall(fn) param : bool do
   return __primitive("resolves", fn());
@@ -386,6 +387,7 @@ proc canResolveCall(fn) param : bool do
   .. note:: Does not attempt to resolve the body of the invoked function.
 
     */
+@chpldoc.nodoc
 @unstable(reason="The 'canResolve...' family of procedures are unstable")
 proc canResolveCall(fn, args...) param : bool do
   return __primitive("resolves", fn((...args)));

--- a/test/functions/fcf/pointers/TestResolves.chpl
+++ b/test/functions/fcf/pointers/TestResolves.chpl
@@ -1,0 +1,34 @@
+
+use Reflection;
+
+proc helper(arg: int) {
+  return arg*2;
+}
+
+proc other(arg: int) {
+  return arg*3;
+}
+
+proc caller(in fn, arg) {
+  writeln("caller: ", __primitive("resolves", fn(arg)));
+}
+
+proc main() {
+  writeln("helper: ", __primitive("resolves", helper(5)));
+  var x = if numLocales > 100 then other else helper;
+  writeln("stored: ", __primitive("resolves", x(5)));
+  caller(x, 5);
+  caller(helper, 5);
+  var y = proc(arg: int) {
+    return arg*4;
+  };
+  writeln("anon: ", __primitive("resolves", y(5)));
+
+  writeln("\n--- failures ---");
+  // These should all fail to resolve, but not crash the compiler.
+  writeln("helper: ", __primitive("resolves", helper("not an int")));
+  writeln("stored: ", __primitive("resolves", x("not an int")));
+  caller(x, "not an int");
+  caller(helper, "not an int");
+  writeln("anon: ", __primitive("resolves", y("not an int")));
+}

--- a/test/functions/fcf/pointers/TestResolves.good
+++ b/test/functions/fcf/pointers/TestResolves.good
@@ -1,0 +1,17 @@
+TestResolves.chpl:16: In function 'main':
+TestResolves.chpl:18: warning: function 'other' is mentioned but not called, so it is being captured as a first-class function
+TestResolves.chpl:18: note: 'other' is a parenful function, so it needs '(...)' to be called
+TestResolves.chpl:18: warning: function 'helper' is mentioned but not called, so it is being captured as a first-class function
+TestResolves.chpl:18: note: 'helper' is a parenful function, so it needs '(...)' to be called
+helper: true
+stored: true
+caller: true
+caller: true
+anon: true
+
+--- failures ---
+helper: false
+stored: false
+caller: false
+caller: false
+anon: false

--- a/test/io/sungeun/funcPtr2.c
+++ b/test/io/sungeun/funcPtr2.c
@@ -1,0 +1,6 @@
+
+#include "funcPtr2.h"
+
+int blah(void) {
+  return 0;
+}

--- a/test/io/sungeun/funcPtr2.compopts
+++ b/test/io/sungeun/funcPtr2.compopts
@@ -1,0 +1,1 @@
+funcPtr2.h funcPtr2.c

--- a/test/io/sungeun/funcPtr2.h
+++ b/test/io/sungeun/funcPtr2.h
@@ -1,0 +1,2 @@
+
+int blah(void);

--- a/test/library/standard/List/listUpdateBadWorker.good
+++ b/test/library/standard/List/listUpdateBadWorker.good
@@ -1,2 +1,2 @@
 listUpdateBadWorker.chpl:11: In function 'test':
-listUpdateBadWorker.chpl:16: error: `list.update()` failed to resolve method myWorker.this() for arguments (int(64), r)
+listUpdateBadWorker.chpl:16: error: `list.update()` failed to resolve method 'myWorker.this()' for arguments (int(64), r)

--- a/test/library/standard/Map/testUpdateBadWorker.good
+++ b/test/library/standard/Map/testUpdateBadWorker.good
@@ -1,2 +1,2 @@
 testUpdateBadWorker.chpl:11: In function 'test':
-testUpdateBadWorker.chpl:15: error: `map.update()` failed to resolve method myWorker.this() for arguments (int(64), r)
+testUpdateBadWorker.chpl:15: error: `map.update()` failed to resolve method 'myWorker.this()' for arguments (int(64), r)


### PR DESCRIPTION
This PR updates the implementation of ``PRIM_RESOLVES`` to handle procedure pointers. Previously the implementation relied on ``tryResolveCall``, which does not handle indirect calls. Instead, we can check for indirect calls explicitly and invoke ``resolveFunctionPointerCall``, which has been modified to optionally check only for the ability to dispatch.

With this PR I have also introduced a new function to the ``Reflection`` module named ``canResolveCall``. ``canResolve`` will not just check for the ability to invoke a call, but will also resolve the function's body. The latter is possible for functions passed in by their identifier, but not for indirect calls, and so I opted to use a different name. It's an open question as to whether we want to document this unstable function.

With this function, I can update the ``Futures``, ``List``, and ``Map`` modules to correctly handle procedure pointers.

This PR also includes a minor fix to the printing of extern procedure pointers.

Testing:
- [x] local paratest
- [x] gasnet paratest