### PR TITLE
Turn procedure pointers on by default

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2074,6 +2074,24 @@ static void codegen_header(std::set<const char*> & cnames,
     }
   }
 
+  // After denormalization, we won't necessarily know if a TypeSymbol for a
+  // FunctionType is 'alive', and so we need to actually check the uses of
+  // VarSymbols and ArgSymbols
+  forv_Vec(VarSymbol, var, gVarSymbols) {
+    if (auto ft = toFunctionType(var->type->getValType())) {
+      if (var->isUsed()) {
+        fnTypesToCodegen.insert(ft);
+      }
+    }
+  }
+  forv_Vec(ArgSymbol, arg, gArgSymbols) {
+    if (auto ft = toFunctionType(arg->type->getValType())) {
+      if (arg->isUsed()) {
+        fnTypesToCodegen.insert(ft);
+      }
+    }
+  }
+
   for (auto ft : fnTypesToCodegen) {
     // Non-determinism here doesn't matter since we sort below.
     types.push_back(ft->symbol);

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -86,7 +86,7 @@ module ChapelBase {
   enum iterKind {leader, follower, standalone};
 
   // This flag toggles on the new pointer-based implementation.
-  config param useProcedurePointers = false;
+  config param useProcedurePointers = true;
 
   proc chpl_enableProcPtrs(type t) param {
     if !useProcedurePointers then return false;

--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -460,6 +460,7 @@ module ChapelIO {
 
       // TODO: handle dynamically loaded procs
       if name == "" then name = "<unknown procedure>";
+      if name.startsWith("chpl_anon_proc") then name = "";
 
       const typeName = t1:string;
 
@@ -469,8 +470,10 @@ module ChapelIO {
       else if typeName.startsWith("extern proc") then start = 11;
       else assert(false, "Unexpected function format: " + typeName);
 
+      if name != "" then name = " " + name;
+
       const parenIndex = typeName.find("(");
-      const ret = typeName[..<start] + " " + name + typeName[parenIndex..];
+      const ret = typeName[..<start] + name + typeName[parenIndex..] + " { ... }";
       return ret;
     } else {
       return chpl_stringify_wrapper(x);

--- a/test/functions/fcf/ExternBlock.bad
+++ b/test/functions/fcf/ExternBlock.bad
@@ -1,3 +1,3 @@
-ExternBlock.chpl:13: error: extern procedure argument types should be extern types - 'proc(x: int, y: int): int' is not
+ExternBlock.chpl:13: error: extern procedure argument types should be extern types - 'proc(const in x: int, const in y: int): int' is not
 ExternBlock.chpl:17: note: when instantiated from here
 ExternBlock.chpl:23: note: when instantiated from here

--- a/test/functions/fcf/ImplicitConversionDiscardFormalName.bad
+++ b/test/functions/fcf/ImplicitConversionDiscardFormalName.bad
@@ -1,2 +1,1 @@
-ImplicitConversionDiscardFormalName.chpl:2: error: cannot initialize 'proc(_: int): int' from a 'proc(i: int): int'
-note: An additional error is hidden. Use --print-additional-errors to see it.
+ImplicitConversionDiscardFormalName.chpl:5: error: Cannot assign to proc(_: int): int from proc(j: int): int

--- a/test/functions/fcf/ParseCastPrecedence.bad
+++ b/test/functions/fcf/ParseCastPrecedence.bad
@@ -1,8 +1,1 @@
-ParseCastPrecedence.chpl:4: error: could not find a copy initializer ('init=') for type 'shared ' from type 'shared '
-$CHPL_HOME/modules/internal/SharedObject.chpl:251: note: this candidate did not match: _shared.init=(pragma"nil from arg"in take: owned)
-ParseCastPrecedence.chpl:4: note: because actual argument #1 is a type
-$CHPL_HOME/modules/internal/SharedObject.chpl:251: note: but is passed to non-type formal 'in take: owned'
-ParseCastPrecedence.chpl:4: note: other candidates are:
-$CHPL_HOME/modules/internal/SharedObject.chpl:277: note:   _shared.init=(pragma"nil from arg"const ref src: _shared)
-$CHPL_HOME/modules/internal/SharedObject.chpl:299: note:   _shared.init=(src: borrowed)
-note: and 2 other candidates, use --print-all-candidates to see them
+ParseCastPrecedence.chpl:4: error: illegal assignment of type to value

--- a/test/functions/fcf/pointers/TestMethods.good
+++ b/test/functions/fcf/pointers/TestMethods.good
@@ -9,4 +9,4 @@ void
 int(64)
 1*bool
 (int(64),real(64),string)
-proc multi(x: int, y: real, z: string)
+proc multi(x: int, y: real, z: string) { ... }

--- a/test/functions/jturner/fun_call_mismatch.good
+++ b/test/functions/jturner/fun_call_mismatch.good
@@ -1,1 +1,1 @@
-fun_call_mismatch.chpl:3: error: illegal access of first class function
+fun_call_mismatch.chpl:3: error: incorrect number of arguments - expected '1', but found '0'

--- a/test/functions/vass/return-type-function-failure.good
+++ b/test/functions/vass/return-type-function-failure.good
@@ -1,9 +1,2 @@
 return-type-function-failure.chpl:4: In function 'valfun':
-return-type-function-failure.chpl:5: error: could not find a copy initializer ('init=') for type 'proc(): int' from type 'int(64)'
-$CHPL_HOME/modules/internal/SharedObject.chpl:nnnn: note: this candidate did not match: _shared.init=(pragma"nil from arg"in take: owned)
-return-type-function-failure.chpl:5: note: because actual argument #1 with type 'int(64)'
-$CHPL_HOME/modules/internal/SharedObject.chpl:nnnn: note: is passed to formal 'in take: owned'
-return-type-function-failure.chpl:5: note: other candidates are:
-$CHPL_HOME/modules/internal/SharedObject.chpl:nnnn: note:   _shared.init=(pragma"nil from arg"const ref src: _shared)
-$CHPL_HOME/modules/internal/SharedObject.chpl:nnnn: note:   _shared.init=(src: borrowed)
-note: and 2 other candidates, use --print-all-candidates to see them
+return-type-function-failure.chpl:5: error: cannot initialize return value of type 'proc(): int' from '1'

--- a/test/library/packages/DynamicLoading/bad-config/ErrorIfConfigParamNotSet.compopts
+++ b/test/library/packages/DynamicLoading/bad-config/ErrorIfConfigParamNotSet.compopts
@@ -1,0 +1,1 @@
+-suseProcedurePointers=false

--- a/test/library/standard/List/contains/listContainsInvalidPred.good
+++ b/test/library/standard/List/contains/listContainsInvalidPred.good
@@ -1,5 +1,5 @@
 $CHPL_HOME/modules/standard/List.chpl:nnnn: In method '_findHelper':
-$CHPL_HOME/modules/standard/List.chpl:nnnn: error: illegal access of first class function
+$CHPL_HOME/modules/standard/List.chpl:nnnn: error: incorrect number of arguments - expected '0', but found '1'
   $CHPL_HOME/modules/standard/List.chpl:nnnn: called as (list(int(64),false))._findHelper(start: int(64), end: int(64), x: proc(): bool, param usePredicate = true) from method 'find'
   $CHPL_HOME/modules/standard/List.chpl:nnnn: called as (list(int(64),false)).find(predicate: proc(): bool, start: int(64), end: int(64)) from method 'contains'
   listContainsInvalidPred.chpl:6: called as (list(int(64),false)).contains(predicate: proc(): bool)

--- a/test/library/standard/List/listUpdateBadWorker.good
+++ b/test/library/standard/List/listUpdateBadWorker.good
@@ -1,2 +1,2 @@
 listUpdateBadWorker.chpl:11: In function 'test':
-listUpdateBadWorker.chpl:16: error: `list.update()` failed to resolve method 'myWorker.this()' for arguments (int(64), r)
+listUpdateBadWorker.chpl:16: error: `list.update()` failed to resolve updater 'myWorker' for arguments (int(64), r)

--- a/test/library/standard/Map/testUpdateBadWorker.good
+++ b/test/library/standard/Map/testUpdateBadWorker.good
@@ -1,2 +1,2 @@
 testUpdateBadWorker.chpl:11: In function 'test':
-testUpdateBadWorker.chpl:15: error: `map.update()` failed to resolve method 'myWorker.this()' for arguments (int(64), r)
+testUpdateBadWorker.chpl:15: error: `map.update()` failed to resolve updater 'myWorker' for arguments (int(64), r)

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -21,6 +21,7 @@ Initializing Modules:
         ChapelNumLocales
        DefaultRectangular
         ChapelArray
+         ArrayViewSlice
          ChapelPrivatization
          ChapelDomain
           FormattedIO

--- a/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
+++ b/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
@@ -1,1 +1,1 @@
-Removed 39 dead modules.
+Removed 38 dead modules.

--- a/test/technotes/doc-examples/FirstClassProceduresCastOffFormalName.bad
+++ b/test/technotes/doc-examples/FirstClassProceduresCastOffFormalName.bad
@@ -1,2 +1,1 @@
-FirstClassProceduresCastOffFormalName.chpl:12: error: cannot initialize 'proc(_: int, _: int): int' from a 'proc(x: int, y: int): int'
-note: An additional error is hidden. Use --print-additional-errors to see it.
+FirstClassProceduresCastOffFormalName.chpl:16: error: Cannot assign to proc(_: int, _: int): int from proc(a: int, b: int): int

--- a/test/technotes/doc-examples/FirstClassProceduresInvalidAssignment.good
+++ b/test/technotes/doc-examples/FirstClassProceduresInvalidAssignment.good
@@ -1,1 +1,1 @@
-FirstClassProceduresInvalidAssignment.chpl:11: error: Cannot assign to borrowed chpl_fcf_int64_t_x_int64_t_y__int64_t? from borrowed chpl_fcf_int64_t_a_int64_t_b__int64_t?
+FirstClassProceduresInvalidAssignment.chpl:11: error: Cannot assign to proc(x: int, y: int): int from proc(a: int, b: int): int


### PR DESCRIPTION
This PR turns procedure pointers on by default via the ``useProcedurePointers`` flag.

Testing:
- [x] local paratest
- [x] gasnet paratest
- [x] basic ofi testing
- [x] C backend