### PR TITLE
Fix broken nightly testing due to dlopen-related PR

### DIFF
--- a/runtime/include/chpl-prginfo.h
+++ b/runtime/include/chpl-prginfo.h
@@ -210,7 +210,12 @@ chpl_rt_prg_id chpl_rt_prginfo_id(chpl_rt_prginfo* prg);
 const char* chpl_rt_prginfo_load_path(chpl_rt_prginfo* prg);
 
 /** Fetch a pointer to the main argument for a given program. */
-chpl_main_argument* chpl_rt_prginfo_main_argument(chpl_rt_prginfo* prg);
+static inline chpl_main_argument*
+chpl_rt_prginfo_main_argument(chpl_rt_prginfo* prg) {
+  CHPL_RT_PRGINFO_DECLARE(prg, chpl_genMainArgPtr);
+  chpl_main_argument* ret = chpl_genMainArgPtr();
+  return ret;
+}
 
 // Private implementation details.
 #include "chpl-prginfo-detail.h"

--- a/runtime/src/chpl-prginfo.c
+++ b/runtime/src/chpl-prginfo.c
@@ -237,9 +237,3 @@ void chpl_rt_prginfo_dump_data_entries(chpl_rt_prginfo* prg,
 
   #include "chpl-prginfo-data-macro-adapter.h"
 }
-
-chpl_main_argument* chpl_rt_prginfo_main_argument(chpl_rt_prginfo* prg) {
-  CHPL_RT_PRGINFO_DECLARE(prg, chpl_genMainArgPtr);
-  chpl_main_argument* ret = chpl_genMainArgPtr();
-  return ret;
-}


### PR DESCRIPTION
This should fix a bunch of broken nightly test builds caused by the launcher bundle not being able to build due to linker errors. A helper function was defined in RT-only code - move its definition into the header as a `static inline` function.

Embarrassingly, in #28857 I did not run a `COMM=gasnet` paratest because I was too fixated on not breaking the C backend again. From now on, I'll have to run three paratests to be safe: `standard`, `COMM=gasnet`, and `C backend`.

- [x] Test with `COMM=gasnet`

Reviewed by @jabraham17. Thanks!