### PR TITLE
Allow taking the EX RPM build date from env var

### DIFF
--- a/util/build_configs/cray-internal/chapel_package-cray.bash
+++ b/util/build_configs/cray-internal/chapel_package-cray.bash
@@ -74,7 +74,7 @@ verbose=
 dry_run=
 
 # Timestamp values
-date_ymd=$( date '+%Y%m%d' )
+date_ymd=${RPM_DATE:-$(date '+%Y%m%d')}
 date_hms=$( date '+%H%M%S' )
 
 while getopts :vnkC:T:o:b:p:R:r:h opt; do


### PR DESCRIPTION
Use the value of `RPM_DATE` (if it exists) to set the `date_ymd` variable in the Cray package build scripts.

This change is to prevent an issue can arise when comparing the actual and expected name of the built RPM. The date is used as part of the name of the RPM. The expected name is set close to the start of the build being kicked off, but the actual name is set near the end, by which time it may be tomorrow if the build started close to midnight. When this happens, the output RPM would be rejected for not having the expected name.

Fix this by allowing the date used in the name to be overridden by an environment variable (which can be set at the start of the build by our internal scripts), so they will match.

There may not be any reason to compare the name against a separate expected value anymore, since we only ever build one RPM at a time, but I would rather make minimal changes to these old fragile scripts.

Part of https://github.com/Cray/chapel-private/issues/7544.

[reviewed by @jabraham17 , thanks!]

Testing:
- [x] test run of RPM build job which starts and ends on different dates succeeds