### PR TITLE
dlopen: Replace more symbols in `chplcgfns.h`

### DIFF
--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -35,9 +35,6 @@
 extern "C" {
 #endif
 
-// Is the cache supposed to be enabled? (set at compile time)
-extern const int CHPL_CACHE_REMOTE;
-
 #if defined(__SANITIZE_ADDRESS__)
 #define CHPL_ASAN 1
 #endif
@@ -55,6 +52,9 @@ extern const int CHPL_CACHE_REMOTE;
 static inline
 void chpl_cache_warn_if_disabled(void)
 {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          CHPL_CACHE_REMOTE);
+
   if (CHPL_CACHE_REMOTE && !chpl_env_rt_get_bool("CACHE_QUIET", false)) {
     if (CHPL_ASAN) {
       chpl_warning("Disabling --cache-remote due to incompatibility with "
@@ -69,6 +69,9 @@ void chpl_cache_warn_if_disabled(void)
 static inline
 int chpl_cache_enabled(void)
 {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          CHPL_CACHE_REMOTE);
+
   // The remote cache is not compatible with ASan, and it uses thread local
   // storage, so if tasks can migrate between threads we lose our ability to
   // correctly fence.

--- a/runtime/include/chpl-prginfo-data-macro.h
+++ b/runtime/include/chpl-prginfo-data-macro.h
@@ -31,6 +31,11 @@
 E_CONSTANT(mainHasArgs, int)
 
 /** CODE-GENERATED
+    The launcher setting that was used when this program was compiled.
+*/
+E_CONSTANT(CHPL_LAUNCHER, const char*)
+
+/** CODE-GENERATED
     Whether or not 'main' should preserve the delimiter when parsing args.
 */
 E_CONSTANT(mainPreserveDelimiter, int)

--- a/runtime/include/chpl-prginfo-program-only-decls.h
+++ b/runtime/include/chpl-prginfo-program-only-decls.h
@@ -27,6 +27,9 @@
 // DO NOT INCLUDE THIS HEADER WITHIN RUNTIME CODE!
 //
 
+//
+// This header fixes issues with '--incremental' compilation.
+//
 // This header is a workaround for the fact that the compiler cannot tell
 // the types of certain global compiler-generated symbols such as
 // 'CreateConfigVarTable' or 'mainHasArgs' because it previously relied
@@ -49,7 +52,25 @@
 extern void CreateConfigVarTable(void);
 extern const int mainHasArgs;
 extern const int mainPreserveDelimiter;
+extern const char* chpl_compileCommand;
 extern char* chpl_executionCommand;
+extern const char* chpl_compileDirectory;
+extern const char* chpl_saveCDir;
 extern const int warnUnstable;
+extern const char* CHPL_LOCALE_MODEL;
+extern const char* CHPL_TARGET_CPU;
+extern const char* CHPL_TARGET_PLATFORM;
+extern const char* CHPL_UNWIND;
+extern const char* CHPL_HOME;
+extern const char* CHPL_LAUNCHER;
+extern const char* CHPL_GASNET_SEGMENT;
+extern const char* CHPL_LLVM_BIN_DIR;
+extern const int CHPL_INTERLEAVE_MEM;
+extern const int CHPL_STACK_CHECKS;
+extern const int CHPL_CACHE_REMOTE;
+extern const int chpl_sizeSymTable;
+extern const int chpl_filenumSymTable[];
+extern const c_string chpl_funSymTable[];
+
 
 #endif

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -52,7 +52,6 @@ extern const char* CHPL_NETWORK_ATOMICS;
 extern const char* CHPL_HWLOC;
 extern const char* CHPL_LLVM;
 extern const char* CHPL_LLVM_BIN_DIR;
-extern const char* CHPL_AUX_FILESYS;
 extern const char* CHPL_UNWIND;
 extern const char* CHPL_RUNTIME_LIB;
 extern const char* CHPL_RUNTIME_INCL;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -52,7 +52,6 @@ extern const char* CHPL_RUNTIME_LIB;
 extern const char* CHPL_RUNTIME_INCL;
 extern const char* CHPL_THIRD_PARTY;
 extern const int CHPL_CACHE_REMOTE;
-extern const int CHPL_INTERLEAVE_MEM;
 
 // Sorted lookup table of filenames used with insertLineNumbers for error
 // messages and logging. Defined in chpl_compilation_config.c (needed by launchers)

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -54,7 +54,6 @@ extern const char* CHPL_COMM_SUBSTRATE;
 extern const char* CHPL_GASNET_SEGMENT;
 extern const char* CHPL_COMM_OFI_OOB;
 extern const char* CHPL_LAUNCHER;
-extern const char* CHPL_TIMERS;
 extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_MAKE;
 extern const char* CHPL_ATOMICS;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* CHPL_LOCALE_MODEL;
 extern const char* CHPL_COMM;
 extern const char* CHPL_COMM_SUBSTRATE;
 extern const char* CHPL_GASNET_SEGMENT;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* CHPL_TARGET_PLATFORM;
 extern const char* CHPL_TARGET_COMPILER;
 extern const char* CHPL_TARGET_CPU;
 extern const char* CHPL_LOCALE_MODEL;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -46,7 +46,6 @@ extern const char* CHPL_COMM;
 extern const char* CHPL_GASNET_SEGMENT;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;
-extern const char* CHPL_ATOMICS;
 extern const char* CHPL_LLVM;
 extern const char* CHPL_LLVM_BIN_DIR;
 extern const char* CHPL_UNWIND;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -53,7 +53,6 @@ extern const char* CHPL_COMM;
 extern const char* CHPL_COMM_SUBSTRATE;
 extern const char* CHPL_GASNET_SEGMENT;
 extern const char* CHPL_COMM_OFI_OOB;
-extern const char* CHPL_TASKS;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TIMERS;
 extern const char* CHPL_TARGET_MEM;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -52,7 +52,6 @@ extern const char* CHPL_LOCALE_MODEL;
 extern const char* CHPL_COMM;
 extern const char* CHPL_COMM_SUBSTRATE;
 extern const char* CHPL_GASNET_SEGMENT;
-extern const char* CHPL_COMM_OFI_OOB;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_MAKE;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -62,7 +62,6 @@ extern const char* CHPL_MAKE;
 extern const char* CHPL_ATOMICS;
 extern const char* CHPL_NETWORK_ATOMICS;
 extern const char* CHPL_HWLOC;
-extern const char* CHPL_RE2;
 extern const char* CHPL_LLVM;
 extern const char* CHPL_LLVM_BIN_DIR;
 extern const char* CHPL_AUX_FILESYS;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* CHPL_TARGET_COMPILER;
 extern const char* CHPL_TARGET_CPU;
 extern const char* CHPL_LOCALE_MODEL;
 extern const char* CHPL_COMM;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* CHPL_HOST_COMPILER;
 extern const char* CHPL_TARGET_PLATFORM;
 extern const char* CHPL_TARGET_COMPILER;
 extern const char* CHPL_TARGET_CPU;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -53,7 +53,6 @@ extern const int32_t chpl_filenameTableSize;
 
 // Lookup tables used as a symbol table by the stack unwinder for translating
 // C symbols into Chapel symbols. Defined in chpl_compilation_config.c
-extern const int chpl_filenumSymTable[];
 extern const int32_t chpl_sizeSymTable;
 
 /* generated */

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* CHPL_HOST_PLATFORM;
 extern const char* CHPL_HOST_COMPILER;
 extern const char* CHPL_TARGET_PLATFORM;
 extern const char* CHPL_TARGET_COMPILER;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -48,7 +48,6 @@ extern const char* CHPL_GASNET_SEGMENT;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_ATOMICS;
-extern const char* CHPL_NETWORK_ATOMICS;
 extern const char* CHPL_HWLOC;
 extern const char* CHPL_LLVM;
 extern const char* CHPL_LLVM_BIN_DIR;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -51,10 +51,6 @@ extern const char* CHPL_THIRD_PARTY;
 extern const c_string chpl_filenameTable[];
 extern const int32_t chpl_filenameTableSize;
 
-// Lookup tables used as a symbol table by the stack unwinder for translating
-// C symbols into Chapel symbols. Defined in chpl_compilation_config.c
-extern const int32_t chpl_sizeSymTable;
-
 /* generated */
 extern const chpl_fn_p chpl_ftable[];
 extern const chpl_fn_info chpl_finfo[];

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* chpl_compileCommand;
 extern const char* chpl_compileVersion;
 extern const char* chpl_compileDirectory;
 extern const char* chpl_saveCDir;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -44,7 +44,6 @@ extern "C" {
 /* defined in chpl_compilation_config.c: */
 extern const char* CHPL_COMM;
 extern const char* CHPL_TARGET_MEM;
-extern const char* CHPL_LLVM_BIN_DIR;
 extern const char* CHPL_THIRD_PARTY;
 
 // Sorted lookup table of filenames used with insertLineNumbers for error

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -48,7 +48,6 @@ extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_LLVM;
 extern const char* CHPL_LLVM_BIN_DIR;
 extern const char* CHPL_UNWIND;
-extern const char* CHPL_RUNTIME_LIB;
 extern const char* CHPL_RUNTIME_INCL;
 extern const char* CHPL_THIRD_PARTY;
 extern const int CHPL_CACHE_REMOTE;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -53,7 +53,6 @@ extern const int32_t chpl_filenameTableSize;
 
 // Lookup tables used as a symbol table by the stack unwinder for translating
 // C symbols into Chapel symbols. Defined in chpl_compilation_config.c
-extern const c_string chpl_funSymTable[];
 extern const int chpl_filenumSymTable[];
 extern const int32_t chpl_sizeSymTable;
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* CHPL_HOME;
 extern const char* CHPL_HOST_PLATFORM;
 extern const char* CHPL_HOST_COMPILER;
 extern const char* CHPL_TARGET_PLATFORM;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -46,7 +46,6 @@ extern const char* CHPL_COMM;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_LLVM_BIN_DIR;
-extern const char* CHPL_UNWIND;
 extern const char* CHPL_THIRD_PARTY;
 
 // Sorted lookup table of filenames used with insertLineNumbers for error

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -43,7 +43,6 @@ extern "C" {
 
 /* defined in chpl_compilation_config.c: */
 extern const char* CHPL_COMM;
-extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_LLVM_BIN_DIR;
 extern const char* CHPL_THIRD_PARTY;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -117,9 +117,6 @@ extern void* const chpl_global_serialize_table[];
 extern const char* const chpl_mem_descs[];
 extern const int chpl_mem_numDescs;
 
-extern const int launcher_is_mli;
-extern const char* launcher_mli_real_name;
-
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* chpl_compileDirectory;
 extern const char* chpl_saveCDir;
 
 extern const char* CHPL_HOME;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -43,7 +43,6 @@ extern "C" {
 
 /* defined in chpl_compilation_config.c: */
 extern const char* CHPL_COMM;
-extern const char* CHPL_GASNET_SEGMENT;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_LLVM;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,8 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* chpl_saveCDir;
-
 extern const char* CHPL_HOME;
 extern const char* CHPL_HOST_PLATFORM;
 extern const char* CHPL_HOST_COMPILER;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -49,7 +49,6 @@ extern const char* CHPL_LLVM_BIN_DIR;
 extern const char* CHPL_UNWIND;
 extern const char* CHPL_RUNTIME_INCL;
 extern const char* CHPL_THIRD_PARTY;
-extern const int CHPL_CACHE_REMOTE;
 
 // Sorted lookup table of filenames used with insertLineNumbers for error
 // messages and logging. Defined in chpl_compilation_config.c (needed by launchers)

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -47,7 +47,6 @@ extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_LLVM_BIN_DIR;
 extern const char* CHPL_UNWIND;
-extern const char* CHPL_RUNTIME_INCL;
 extern const char* CHPL_THIRD_PARTY;
 
 // Sorted lookup table of filenames used with insertLineNumbers for error

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -47,7 +47,6 @@ extern const char* CHPL_GASNET_SEGMENT;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_ATOMICS;
-extern const char* CHPL_HWLOC;
 extern const char* CHPL_LLVM;
 extern const char* CHPL_LLVM_BIN_DIR;
 extern const char* CHPL_UNWIND;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* chpl_compileVersion;
 extern const char* chpl_compileDirectory;
 extern const char* chpl_saveCDir;
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -61,7 +61,6 @@ extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_MAKE;
 extern const char* CHPL_ATOMICS;
 extern const char* CHPL_NETWORK_ATOMICS;
-extern const char* CHPL_GMP;
 extern const char* CHPL_HWLOC;
 extern const char* CHPL_RE2;
 extern const char* CHPL_LLVM;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -53,7 +53,6 @@ extern const char* CHPL_UNWIND;
 extern const char* CHPL_RUNTIME_LIB;
 extern const char* CHPL_RUNTIME_INCL;
 extern const char* CHPL_THIRD_PARTY;
-extern const int CHPL_STACK_CHECKS;
 extern const int CHPL_CACHE_REMOTE;
 extern const int CHPL_INTERLEAVE_MEM;
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -47,7 +47,6 @@ extern const char* CHPL_COMM_SUBSTRATE;
 extern const char* CHPL_GASNET_SEGMENT;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;
-extern const char* CHPL_MAKE;
 extern const char* CHPL_ATOMICS;
 extern const char* CHPL_NETWORK_ATOMICS;
 extern const char* CHPL_HWLOC;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* CHPL_TARGET_CPU;
 extern const char* CHPL_LOCALE_MODEL;
 extern const char* CHPL_COMM;
 extern const char* CHPL_COMM_SUBSTRATE;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -45,7 +45,6 @@ extern "C" {
 extern const char* CHPL_COMM;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;
-extern const char* CHPL_LLVM;
 extern const char* CHPL_LLVM_BIN_DIR;
 extern const char* CHPL_UNWIND;
 extern const char* CHPL_RUNTIME_INCL;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -43,7 +43,6 @@ extern "C" {
 
 /* defined in chpl_compilation_config.c: */
 extern const char* CHPL_COMM;
-extern const char* CHPL_COMM_SUBSTRATE;
 extern const char* CHPL_GASNET_SEGMENT;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_TARGET_MEM;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -52,7 +52,6 @@ extern const char* CHPL_LOCALE_MODEL;
 extern const char* CHPL_COMM;
 extern const char* CHPL_COMM_SUBSTRATE;
 extern const char* CHPL_GASNET_SEGMENT;
-extern const char* CHPL_LIBFABRIC;
 extern const char* CHPL_COMM_OFI_OOB;
 extern const char* CHPL_TASKS;
 extern const char* CHPL_LAUNCHER;

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -33,6 +33,7 @@
 #define _chpl_tasks_impl_fns_h_
 
 #include "chpl-locale-model.h"
+#include "chpl-prginfo.h"
 #include "chpltypes.h"
 
 #include <assert.h>
@@ -181,6 +182,8 @@ static inline
 void chpl_task_setSubloc(c_sublocid_t full_subloc)
 {
     qthread_shepherd_id_t curr_shep;
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            CHPL_LOCALE_MODEL);
 
     // We allow using c_sublocid_none to represent the CPU in the gpu locale
     // model. This isn't currently used by the numa (or other locale) models.

--- a/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
+++ b/runtime/include/tasks/qthreads/chpl-tasks-impl-fns.h
@@ -182,13 +182,12 @@ static inline
 void chpl_task_setSubloc(c_sublocid_t full_subloc)
 {
     qthread_shepherd_id_t curr_shep;
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            CHPL_LOCALE_MODEL);
 
     // We allow using c_sublocid_none to represent the CPU in the gpu locale
     // model. This isn't currently used by the numa (or other locale) models.
     assert(isActualSublocID(full_subloc) || full_subloc == c_sublocid_none ||
-        !strcmp(CHPL_LOCALE_MODEL, "gpu"));
+        !strcmp(CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                     CHPL_LOCALE_MODEL), "gpu"));
 
     // Only change sublocales if the caller asked for a particular one,
     // which is not the current one, and we're a (movable) task.

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -713,6 +713,8 @@ void printAdditionalHelpEntry(const argDescTuple_t* argTuple,
 // on-the-fly in runtime/etc/Makefile.launcher.
 extern const char launcher_real_suffix[];
 extern const char launcher_exe_suffix[];    // May be the empty string.
+extern const int launcher_is_mli;
+extern const char launcher_mli_real_name[];
 
 static char* chpl_real_binary_name;
 

--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -885,6 +885,7 @@ int chpl_launcher_main(int argc, char* argv[]) {
 void chpl_launcher_no_colocales_error(const char *name) {
   char msg[100];
   if (name == NULL) {
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, CHPL_LAUNCHER);
     name = CHPL_LAUNCHER;
   }
   snprintf(msg, sizeof(msg), "'%s' launcher does not support co-locales.", name);

--- a/runtime/src/chpl-unwind.c
+++ b/runtime/src/chpl-unwind.c
@@ -242,6 +242,9 @@ static int chpl_unwind_refineGetLineNum(void *addr) {
 static unsigned int chpl_unwind_getLineNum(unw_cursor_t* cursor,
                                            unw_word_t wordValue,
                                            int tableIdx) {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_filenumSymTable);
+
   // use the procedure line number
   unsigned int line = chpl_filenumSymTable[tableIdx + 1];
 
@@ -332,6 +335,8 @@ static void chpl_stack_unwind_helper(enum chpl_stack_unwind_mode mode, char sep,
 
   CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                           chpl_funSymTable);
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_filenumSymTable);
 
   // This loop does the effective stack unwind, see libunwind documentation
   while (unw_step(&cursor) > 0) {

--- a/runtime/src/chpl-unwind.c
+++ b/runtime/src/chpl-unwind.c
@@ -330,6 +330,9 @@ static void chpl_stack_unwind_helper(enum chpl_stack_unwind_mode mode, char sep,
     }
   }
 
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_funSymTable);
+
   // This loop does the effective stack unwind, see libunwind documentation
   while (unw_step(&cursor) > 0) {
     unw_get_proc_name(&cursor, buffer, sizeof(buffer), &wordValue);

--- a/runtime/src/chpl-unwind.c
+++ b/runtime/src/chpl-unwind.c
@@ -319,6 +319,9 @@ static void chpl_stack_unwind_helper(enum chpl_stack_unwind_mode mode, char sep,
   char** strPtr = (char**)out;
   char sepstr[2] = {sep, '\0'};
 
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_sizeSymTable);
+
   if (chpl_sizeSymTable > 0) {
     switch (mode) {
       case CHPL_STACK_UNWIND_MODE_FILE:

--- a/runtime/src/chpl-unwind.c
+++ b/runtime/src/chpl-unwind.c
@@ -121,6 +121,9 @@ static int chpl_unwind_refineGetLineNum(void *addr) {
   // then space
   // then the address
 
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          CHPL_LLVM_BIN_DIR);
+
   int scriptLen = strlen(script);
   int llvmBinDirLen = strlen(CHPL_LLVM_BIN_DIR);
 

--- a/runtime/src/chpl-unwind.c
+++ b/runtime/src/chpl-unwind.c
@@ -29,6 +29,7 @@
 
 #include "chplrt.h"
 #include "chpl-linefile-support.h"
+#include "chpl-prginfo.h"
 #include "chplcgfns.h"
 
 #include "chpl-unwind.h"
@@ -383,6 +384,9 @@ void chpl_stack_unwind(FILE* out, char sep) {
   if (!should_print) {
     return;
   }
+
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, CHPL_UNWIND);
+
   chpl_stack_unwind_helper(CHPL_STACK_UNWIND_MODE_FILE, sep, out);
   if (!user_set && strcmp(CHPL_UNWIND, "none") != 0) {
     fprintf(out, "%cDisable full stacktrace by setting 'CHPL_RT_UNWIND=0'%c", sep, sep);

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -29,6 +29,7 @@
 #include "chpl-tasks-callbacks.h"
 #include "chpl-comm-callbacks.h"
 #include "chpl-linefile-support.h"
+#include "chpl-prginfo.h"
 #include <stdint.h>
 #include <string.h>
 #include <unistd.h>
@@ -166,8 +167,11 @@ void chpl_vdebug_start (const char *fileroot, double now) {
 
   // Dump directory names, file names and function names
   if (chpl_nodeID == 0) {
-    int ix;
-    int numFIDnames;
+    int ix = 0;
+    int numFIDnames = 0;
+
+    CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                              chpl_compileDirectory);
 
     chpl_dprintf (chpl_vdebug_fd, "CHPL_HOME: %s\n", CHPL_HOME);
     chpl_dprintf (chpl_vdebug_fd, "DIR: %s\n", chpl_compileDirectory);

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -169,11 +169,11 @@ void chpl_vdebug_start (const char *fileroot, double now) {
   if (chpl_nodeID == 0) {
     int ix = 0;
     int numFIDnames = 0;
+    chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
 
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_compileDirectory);
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_saveCDir);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_compileDirectory);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_saveCDir);
+    CHPL_RT_PRGINFO_DECLARE(prg, CHPL_HOME);
 
     chpl_dprintf (chpl_vdebug_fd, "CHPL_HOME: %s\n", CHPL_HOME);
     chpl_dprintf (chpl_vdebug_fd, "DIR: %s\n", chpl_compileDirectory);

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -170,10 +170,10 @@ void chpl_vdebug_start (const char *fileroot, double now) {
     int ix = 0;
     int numFIDnames = 0;
 
-    CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                              chpl_compileDirectory);
-    CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                              chpl_saveCDir);
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_compileDirectory);
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_saveCDir);
 
     chpl_dprintf (chpl_vdebug_fd, "CHPL_HOME: %s\n", CHPL_HOME);
     chpl_dprintf (chpl_vdebug_fd, "DIR: %s\n", chpl_compileDirectory);

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -172,6 +172,8 @@ void chpl_vdebug_start (const char *fileroot, double now) {
 
     CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                               chpl_compileDirectory);
+    CHPL_RT_PRGINFO_DATA_TEMP(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                              chpl_saveCDir);
 
     chpl_dprintf (chpl_vdebug_fd, "CHPL_HOME: %s\n", CHPL_HOME);
     chpl_dprintf (chpl_vdebug_fd, "DIR: %s\n", chpl_compileDirectory);

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -671,6 +671,8 @@ void chpl_reportMemInfo(void) {
   if (memLeaksLog && strcmp(memLeaksLog, "")) {
     CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                             chpl_executionCommand);
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_compileCommand);
 
     memLogFile = fopen(memLeaksLog, "a");
     fprintf(memLogFile, "\nCompiler Command : %s\n", chpl_compileCommand);

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -148,7 +148,7 @@ static chpl_bool chpl_lldb_supports_python(void) {
 }
 
 int chpl_comm_run_in_gdb(int argc, char* argv[], int gdbArgnum, int* status) {
-
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, CHPL_HOME);
   char* command = (char*)"gdb -q";
 
   const char* gdb_commands = chpl_glom_strings(2, CHPL_HOME, "/runtime/etc/debug/gdb.commands");
@@ -179,7 +179,7 @@ int chpl_comm_run_in_gdb(int argc, char* argv[], int gdbArgnum, int* status) {
 }
 
 int chpl_comm_run_in_lldb(int argc, char* argv[], int lldbArgnum, int* status) {
-
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, CHPL_HOME);
   char* command = (char*)"lldb";
 
   const char* lldb_commands = chpl_glom_strings(2, CHPL_HOME, "/runtime/etc/debug/lldb.commands");

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -32,6 +32,7 @@
 #include "chplcgfns.h"
 #include "chpl-gen-includes.h"
 #include "chpl-linefile-support.h"
+#include "chpl-prginfo.h"
 
 // Don't get warning macros for chpl_comm_get etc
 #include "chpl-comm-no-warning-macros.h"

--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -70,6 +70,9 @@ void chpl_comm_preLaunch(int32_t numLocales) {
     chpl_env_set("FI_SOCKETS_PE_WAITTIME", "0", 0);
   }
 
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          CHPL_TARGET_PLATFORM);
+
   if (strcmp(CHPL_TARGET_PLATFORM, "hpe-cray-ex") == 0) {
     //
     // On HPE Cray EX systems, temporarily work around a PMI bug by

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1485,6 +1485,8 @@ chpl_bool isUseableProvider(struct fi_info* info) {
   static struct sockaddr_in6 t2;
   static chpl_bool initialized = false;
   static chpl_bool darwin = false;
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          CHPL_TARGET_PLATFORM);
 
   if (! initialized) {
     darwin = !strcmp(CHPL_TARGET_PLATFORM, "darwin");
@@ -2203,6 +2205,9 @@ void init_ofiFabricDomain(void) {
   //
   OFI_CHK(fi_fabric(ofi_info->fabric_attr, &ofi_fabric, NULL));
 
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          CHPL_TARGET_PLATFORM);
+
   if (strcmp(CHPL_TARGET_PLATFORM, "hpe-cray-ex") == 0
       && chpl_env_rt_get_bool("COMM_OFI_SLINGSHOT_CHECK_ENV", true)) {
     heedSlingshotSettings(ofi_info);
@@ -2247,6 +2252,8 @@ struct fi_info* getBaseProviderHints(chpl_bool* pTxAttrsForced) {
   const char* prov_name = getProviderName();
   struct fi_info* hints;
   CHK_TRUE((hints = fi_allocinfo()) != NULL);
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          CHPL_TARGET_PLATFORM);
 
   hints->caps = (FI_MSG | FI_MULTI_RECV
                  | FI_RMA | FI_LOCAL_COMM | FI_REMOTE_COMM);
@@ -3583,6 +3590,8 @@ void init_fixedHeap(void) {
     // that can meet our base requirements has FI_MR_ALLOCATED set to
     // indicate it wants one.
     //
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            CHPL_TARGET_PLATFORM);
     if (!strcmp(CHPL_TARGET_PLATFORM, "cray-xc") ||
         !strcmp(CHPL_TARGET_PLATFORM, "hpe-cray-ex")) {
       createHeap = true;

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -617,6 +617,7 @@ void chpl_mem_layerInit(void) {
   void* heap_base;
   size_t heap_size;
 
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_PRGINFO_ROOT, CHPL_INTERLEAVE_MEM);
   interleave_mem = chpl_env_rt_get_bool("INTERLEAVE_MEMORY", CHPL_INTERLEAVE_MEM);
   CHPL_JE_LG_ARENA = get_num_arenas()-1;
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -562,13 +562,12 @@ static void setupAvailableParallelism(int32_t maxThreads) {
 }
 
 static chpl_bool setupGuardPages(void) {
+    chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
     const char *armArch = "arm-thunderx";
     chpl_bool guardPagesEnabled = true;
     // default value set by compiler (--[no-]stack-checks)
-    chpl_bool defaultVal = (CHPL_STACK_CHECKS == 1);
-
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            CHPL_TARGET_CPU);
+    chpl_bool defaultVal = CHPL_RT_PRGINFO_DATA(prg, CHPL_STACK_CHECKS) == 1;
+    CHPL_RT_PRGINFO_DECLARE(prg, CHPL_TARGET_CPU);
 
     // Setup guard pages. Default to enabling guard pages, only disabling them
     // under the following conditions (Precedence high-to-low):

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -564,6 +564,9 @@ static chpl_bool setupGuardPages(void) {
     // default value set by compiler (--[no-]stack-checks)
     chpl_bool defaultVal = (CHPL_STACK_CHECKS == 1);
 
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            CHPL_TARGET_CPU);
+
     // Setup guard pages. Default to enabling guard pages, only disabling them
     // under the following conditions (Precedence high-to-low):
     //  - Guard pages disabled at configure time

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -44,6 +44,7 @@
 #include "chpl-mem.h"
 #include "chplsys.h"
 #include "chpl-linefile-support.h"
+#include "chpl-prginfo.h"
 #include "chpl-tasks.h"
 #include "chpl-tasks-callbacks-internal.h"
 #include "chpl-tasks-impl.h"
@@ -685,6 +686,9 @@ static void setupWorkStealing(void) {
 
 static void setupSpinWaiting(void) {
   const char *crayPlatform = "cray-x";
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          CHPL_TARGET_PLATFORM);
+
   if (chpl_topo_isOversubscribed()) {
     chpl_qt_setenv("SPINCOUNT", "300", 0);
   } else if (strncmp(crayPlatform, CHPL_TARGET_PLATFORM, strlen(crayPlatform)) == 0) {

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1003,13 +1003,12 @@ void chpl_task_addTask(chpl_fn_int_t       fid,
                        int32_t             filename)
 {
     chpl_fn_p requested_fn = chpl_ftable[fid];
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            CHPL_LOCALE_MODEL);
 
     // We allow using c_sublocid_none to represent the CPU in the gpu locale
     // model. This isn't currently used by the numa (or other locale) models.
     assert(isActualSublocID(full_subloc) || full_subloc == c_sublocid_none ||
-        !strcmp(CHPL_LOCALE_MODEL, "gpu"));
+        !strcmp(CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                     CHPL_LOCALE_MODEL), "gpu"));
 
     PROFILE_INCR(profile_task_addTask,1);
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -524,6 +524,9 @@ static void setupAvailableParallelism(int32_t maxThreads) {
         //
         {
             int numNumaDomains = chpl_topo_getNumNumaDomains();
+            CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                    CHPL_LOCALE_MODEL);
+
             if (hwpar < numNumaDomains
                 && strcmp(CHPL_LOCALE_MODEL, "flat") != 0) {
                 char msg[100];
@@ -1001,6 +1004,8 @@ void chpl_task_addTask(chpl_fn_int_t       fid,
                        int32_t             filename)
 {
     chpl_fn_p requested_fn = chpl_ftable[fid];
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            CHPL_LOCALE_MODEL);
 
     // We allow using c_sublocid_none to represent the CPU in the gpu locale
     // model. This isn't currently used by the numa (or other locale) models.

--- a/runtime/src/threads/pthreads/threads-pthreads.c
+++ b/runtime/src/threads/pthreads/threads-pthreads.c
@@ -30,6 +30,7 @@
 #include "chpl-tasks.h"
 #include "config.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 #include "chplsys.h"
 #include <assert.h>
 #include <errno.h>

--- a/runtime/src/threads/pthreads/threads-pthreads.c
+++ b/runtime/src/threads/pthreads/threads-pthreads.c
@@ -113,7 +113,8 @@ void                   chpl_free_pthread_stack(void*);
 void chpl_init_heap_stack(void){
 
   // We don't want a guard page, but we want the stack in the heap
-  if (CHPL_STACK_CHECKS == 0) {
+  if (CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                           CHPL_STACK_CHECKS) == 0) {
     chpl_alloc_stack_in_heap = true;
     chpl_use_guard_page      = false;
     return;

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -199,6 +199,7 @@ void chpl_topo_pre_comm_init(char *accessiblePUsMask) {
   // the future.
   //
   do_set_area_membind = true;
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_PRGINFO_ROOT, CHPL_GASNET_SEGMENT);
   if ((strcmp(CHPL_COMM, "gasnet") == 0
        && strcmp(CHPL_GASNET_SEGMENT, "everything") != 0)) {
       do_set_area_membind = false;


### PR DESCRIPTION
Replace more lesser-used symbols in `chplcgfns.h` with uses of data fields from `chpl_rt_prginfo*`. Some of the symbols in the header are declared but never used or defined, so remove them entirely.

TESTING

- [x] `standard`
- [x] `COMM=gasnet`
- [x] `C backend`

Reviewed by @benharsh. Thanks!