### PR TITLE
Fix the custom sub_test for mason packages

### DIFF
--- a/test/library/mason/MasonPackageTester
+++ b/test/library/mason/MasonPackageTester
@@ -48,7 +48,9 @@ if [[ $? -eq 0 ]]; then
   echo "[Success matching unit tests for $BRICK_NAME]"
 else
   echo "[Error running unit tests for $BRICK_NAME]"
+  echo "[Output from mason test for $BRICK_NAME]"
+  cat $DIR/mason.exec.log
 fi
+test_end
 
-echo "[Finished subtest $DIR]"
-
+subtest_end


### PR DESCRIPTION
Fixes the custom sub_test for mason packages so that it properly parses

[Reviewed by @DanilaFe]