### PR TITLE
Add some missing header includes that were breaking builds

### DIFF
--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -25,6 +25,7 @@
 #include "chpl-atomics.h"
 #include "chpl-comm-task-decls.h"
 #include "chpl-env.h"
+#include "chpl-prginfo.h"
 #include "chpl-tasks.h"
 #include "chpl-error.h"
 

--- a/runtime/include/chpl-prginfo-data-macro.h
+++ b/runtime/include/chpl-prginfo-data-macro.h
@@ -282,7 +282,7 @@ E_CONSTANT_RT(CHPL_STACK_CHECKS, int)
 /** CODE-GENERATED
     Value of '$CHPL_TARGET_PLATFORM' when this program was compiled.
 */
-E_CONSTANT_RT(CHPL_TARGET_PLATFORM, const char*)
+E_CONSTANT(CHPL_TARGET_PLATFORM, const char*)
 
 /** CODE-GENERATED
     Value of '$CHPL_TARGET_MEM' when this program was compiled.

--- a/runtime/src/comm/ofi/comm-ofi-launch.c
+++ b/runtime/src/comm/ofi/comm-ofi-launch.c
@@ -30,6 +30,7 @@
 #include "chplcgfns.h"
 #include "chpl-comm-launch.h"
 #include "chpl-env.h"
+#include "chpl-prginfo.h"
 
 
 void chpl_comm_preLaunch(int32_t numLocales) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -40,6 +40,7 @@
 #include "chpl-mem.h"
 #include "chpl-mem-sys.h"
 #include "chplsys.h"
+#include "chpl-prginfo.h"
 #include "chpl-tasks.h"
 #include "chpl-topo.h"
 #include "chpltypes.h"

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -31,6 +31,7 @@
 #include "chpl-linefile-support.h"
 #include "chpl-mem.h"
 #include "chpl-mem-desc.h"
+#include "chpl-prginfo.h"
 #include "chpl-topo.h"
 #include "chplcgfns.h"
 #include "chplmemtrack.h"


### PR DESCRIPTION
Fix a bunch broken builds in nightly testing after I merged #28869. I didn't test `COMM=ofi` and that ended up being broken. Surprisingly one of the broken builds was due to `cache-remote`, which is surprising (I thought that was on by default and I definitely tested gasnet).

After double checking by building on `COMM=ofi` I added an extra commit which marks a particular constant as launcher-visible. That should hopefully save nightly more grief (for now...).

Reviewed by @DanilaFe. Thanks!