### PR TITLE
Use new CUDA=>12.9 `cub::DeviceReduce::Arg{Min,Max}` interface

### DIFF
--- a/runtime/src/gpu/amd/gpu-amd-cub.cc
+++ b/runtime/src/gpu/amd/gpu-amd-cub.cc
@@ -57,35 +57,6 @@ GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL, Max, max)
 
 #undef DEF_ONE_REDUCE_RET_VAL
 
-#if defined(CHPL_ROCM_VERSION) && CHPL_ROCM_VERSION >= 710
-#define DEF_ONE_REDUCE_RET_VAL_IDX(impl_kind, chpl_kind, data_type) \
-void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
-                                                    data_type* val, int* idx,\
-                                                    void* stream) {\
-  data_type* result_val; \
-  int* result_idx; \
-  ROCM_CALL(hipMalloc(&result_val, sizeof(data_type))); \
-  ROCM_CALL(hipMalloc(&result_idx, sizeof(int))); \
-  void* temp = NULL; \
-  size_t temp_bytes = 0; \
-  ROCM_CALL(hipcub::DeviceReduce::impl_kind(temp, temp_bytes, data,\
-                                            (data_type*)result_val, \
-                                            (int*)result_idx,\
-                                            n, (hipStream_t)stream)); \
-  ROCM_CALL(hipMalloc(&temp, temp_bytes)); \
-  ROCM_CALL(hipcub::DeviceReduce::impl_kind(temp, temp_bytes, data,\
-                                            (data_type*)result_val, \
-                                            (int*)result_idx,\
-                                            n, (hipStream_t)stream)); \
-  ROCM_CALL(hipMemcpyDtoHAsync(val, result_val, sizeof(data_type),\
-                               (hipStream_t)stream)); \
-  ROCM_CALL(hipMemcpyDtoHAsync(idx, result_idx, sizeof(int),\
-                               (hipStream_t)stream)); \
-  ROCM_CALL(hipFree(result_val)); \
-  ROCM_CALL(hipFree(result_idx)); \
-  ROCM_CALL(hipFree(temp)); \
-}
-#else
 #define DEF_ONE_REDUCE_RET_VAL_IDX(impl_kind, chpl_kind, data_type) \
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
                                                     data_type* val, int* idx,\
@@ -108,7 +79,6 @@ void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
   ROCM_CALL(hipFree(result)); \
   ROCM_CALL(hipFree(temp)); \
 }
-#endif
 
 GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL_IDX, ArgMin, minloc)
 GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL_IDX, ArgMax, maxloc)

--- a/runtime/src/gpu/amd/gpu-amd-cub.cc
+++ b/runtime/src/gpu/amd/gpu-amd-cub.cc
@@ -57,6 +57,35 @@ GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL, Max, max)
 
 #undef DEF_ONE_REDUCE_RET_VAL
 
+#if defined(CHPL_ROCM_VERSION) && CHPL_ROCM_VERSION >= 710
+#define DEF_ONE_REDUCE_RET_VAL_IDX(impl_kind, chpl_kind, data_type) \
+void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
+                                                    data_type* val, int* idx,\
+                                                    void* stream) {\
+  data_type* result_val; \
+  int* result_idx; \
+  ROCM_CALL(hipMalloc(&result_val, sizeof(data_type))); \
+  ROCM_CALL(hipMalloc(&result_idx, sizeof(int))); \
+  void* temp = NULL; \
+  size_t temp_bytes = 0; \
+  ROCM_CALL(hipcub::DeviceReduce::impl_kind(temp, temp_bytes, data,\
+                                            (data_type*)result_val, \
+                                            (int*)result_idx,\
+                                            n, (hipStream_t)stream)); \
+  ROCM_CALL(hipMalloc(&temp, temp_bytes)); \
+  ROCM_CALL(hipcub::DeviceReduce::impl_kind(temp, temp_bytes, data,\
+                                            (data_type*)result_val, \
+                                            (int*)result_idx,\
+                                            n, (hipStream_t)stream)); \
+  ROCM_CALL(hipMemcpyDtoHAsync(val, result_val, sizeof(data_type),\
+                               (hipStream_t)stream)); \
+  ROCM_CALL(hipMemcpyDtoHAsync(idx, result_idx, sizeof(int),\
+                               (hipStream_t)stream)); \
+  ROCM_CALL(hipFree(result_val)); \
+  ROCM_CALL(hipFree(result_idx)); \
+  ROCM_CALL(hipFree(temp)); \
+}
+#else
 #define DEF_ONE_REDUCE_RET_VAL_IDX(impl_kind, chpl_kind, data_type) \
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
                                                     data_type* val, int* idx,\
@@ -79,6 +108,7 @@ void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
   ROCM_CALL(hipFree(result)); \
   ROCM_CALL(hipFree(temp)); \
 }
+#endif
 
 GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL_IDX, ArgMin, minloc)
 GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL_IDX, ArgMax, maxloc)

--- a/runtime/src/gpu/nvidia/gpu-nvidia-cub.cc
+++ b/runtime/src/gpu/nvidia/gpu-nvidia-cub.cc
@@ -65,6 +65,7 @@ GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL, Max, max)
 
 #undef DEF_ONE_REDUCE_RET_VAL
 
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 129
 #define DEF_ONE_REDUCE_RET_VAL_IDX(cub_kind, chpl_kind, data_type) \
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
                                                     data_type* val, int* idx,\
@@ -90,6 +91,30 @@ void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
   CUDA_CALL(cuMemFree(result_idx)); \
   CUDA_CALL(cuMemFree((CUdeviceptr)temp)); \
 }
+#else
+#define DEF_ONE_REDUCE_RET_VAL_IDX(cub_kind, chpl_kind, data_type) \
+void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
+                                                    data_type* val, int* idx,\
+                                                    void* stream) {\
+  using kvp = cub::KeyValuePair<int,data_type>; \
+  CUdeviceptr result; \
+  CUDA_CALL(cuMemAlloc(&result, sizeof(kvp))); \
+  void* temp = NULL; \
+  size_t temp_bytes = 0; \
+  CUDA_CALL(cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
+                              (CUstream)stream));\
+  CUDA_CALL(cuMemAlloc(((CUdeviceptr*)&temp), temp_bytes)); \
+  CUDA_CALL(cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
+                              (CUstream)stream));\
+  kvp result_host; \
+  CUDA_CALL(cuMemcpyDtoHAsync(&result_host, result, sizeof(kvp),\
+                              (CUstream)stream)); \
+  *val = result_host.value; \
+  *idx = result_host.key; \
+  CUDA_CALL(cuMemFree(result)); \
+  CUDA_CALL(cuMemFree((CUdeviceptr)temp)); \
+}
+#endif
 
 GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL_IDX, ArgMin, minloc)
 GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL_IDX, ArgMax, maxloc)

--- a/runtime/src/gpu/nvidia/gpu-nvidia-cub.cc
+++ b/runtime/src/gpu/nvidia/gpu-nvidia-cub.cc
@@ -65,7 +65,7 @@ GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL, Max, max)
 
 #undef DEF_ONE_REDUCE_RET_VAL
 
-#if defined(CUDA_VERSION) && CUDA_VERSION >= 129
+#if defined(CHPL_CUDA_VERSION) && CHPL_CUDA_VERSION >= 129
 #define DEF_ONE_REDUCE_RET_VAL_IDX(cub_kind, chpl_kind, data_type) \
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
                                                     data_type* val, int* idx,\

--- a/runtime/src/gpu/nvidia/gpu-nvidia-cub.cc
+++ b/runtime/src/gpu/nvidia/gpu-nvidia-cub.cc
@@ -69,22 +69,25 @@ GPU_DEV_CUB_WRAP(DEF_ONE_REDUCE_RET_VAL, Max, max)
 void chpl_gpu_impl_##chpl_kind##_reduce_##data_type(data_type* data, int n,\
                                                     data_type* val, int* idx,\
                                                     void* stream) {\
-  using kvp = cub::KeyValuePair<int,data_type>; \
-  CUdeviceptr result; \
-  CUDA_CALL(cuMemAlloc(&result, sizeof(kvp))); \
+  CUdeviceptr result_val; \
+  CUdeviceptr result_idx; \
+  CUDA_CALL(cuMemAlloc(&result_val, sizeof(data_type))); \
+  CUDA_CALL(cuMemAlloc(&result_idx, sizeof(int))); \
   void* temp = NULL; \
   size_t temp_bytes = 0; \
-  CUDA_CALL(cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
+  CUDA_CALL(cub::DeviceReduce::cub_kind(temp, temp_bytes, data,\
+                              (data_type*)result_val, (int*)result_idx, n,\
                               (CUstream)stream));\
   CUDA_CALL(cuMemAlloc(((CUdeviceptr*)&temp), temp_bytes)); \
-  CUDA_CALL(cub::DeviceReduce::cub_kind(temp, temp_bytes, data, (kvp*)result, n,\
+  CUDA_CALL(cub::DeviceReduce::cub_kind(temp, temp_bytes, data,\
+                              (data_type*)result_val, (int*)result_idx, n,\
                               (CUstream)stream));\
-  kvp result_host; \
-  CUDA_CALL(cuMemcpyDtoHAsync(&result_host, result, sizeof(kvp),\
+  CUDA_CALL(cuMemcpyDtoHAsync(val, result_val, sizeof(data_type),\
                               (CUstream)stream)); \
-  *val = result_host.value; \
-  *idx = result_host.key; \
-  CUDA_CALL(cuMemFree(result)); \
+  CUDA_CALL(cuMemcpyDtoHAsync(idx, result_idx, sizeof(int),\
+                              (CUstream)stream)); \
+  CUDA_CALL(cuMemFree(result_val)); \
+  CUDA_CALL(cuMemFree(result_idx)); \
   CUDA_CALL(cuMemFree((CUdeviceptr)temp)); \
 }
 

--- a/util/chplenv/chpl_gpu.py
+++ b/util/chplenv/chpl_gpu.py
@@ -453,8 +453,10 @@ def get_runtime_compile_args():
         system.append("-isystem" + os.path.join(sdk_path, "include"))
         system.append("-isystem" + os.path.join(sdk_path, "hip", "include"))
 
-        major_version = get_sdk_version().split(".")[0]
+        major_version, minor_version = get_sdk_version().split(".")[:2]
         bundled.append("-DCHPL_ROCM_VERSION_MAJOR=" + major_version)
+        bundled.append("-DCHPL_ROCM_VERSION_MINOR=" + minor_version)
+        bundled.append("-DCHPL_ROCM_VERSION=" + major_version + minor_version)
 
     return bundled, system
 


### PR DESCRIPTION
Conditionally define `DEF_ONE_REDUCE_RET_VAL_IDX` to use the new CUDA 12.9 interface for the cub `ArgMin` and `ArgMax` functions, fixing deprecation warnings.

The upstream change is https://github.com/NVIDIA/cccl/pull/3148.

This is propagated to hipcub in https://github.com/ROCm/rocm-libraries/pull/1246 and will be present in ROCm 7.1, however this PR doesn't make that update; it actually makes and reverts it, due to not enough capacity to test this in advance. It does include adding `CHPL_ROCM_VERSION_MINOR` and `CHPL_ROCM_VERSION` macros to be used when we need to update.

[reviewed by @jabraham17 , thanks!]

Testing:
- [x] works with CUDA 12.9
- [x] still works with CUDA 12.8 