### PR TITLE
dlopen: Replace references to 'chpl_ftable'

### DIFF
--- a/runtime/include/chpl-gen-includes.h
+++ b/runtime/include/chpl-gen-includes.h
@@ -31,6 +31,7 @@
 #include "chpl-comm-compiler-macros.h"
 #include "chplcgfns.h"
 #include "chpl-locale-model.h"
+#include "chpl-prginfo.h"
 #include "chpl-tasks.h"
 #include "chpltypes.h"
 
@@ -45,6 +46,7 @@ extern "C" {
 static inline
 void chpl_ftable_call(chpl_fn_int_t fid, void* bundle)
 {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
   (*chpl_ftable[fid])(bundle);
 }
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -51,8 +51,6 @@ extern const char* CHPL_THIRD_PARTY;
 extern const c_string chpl_filenameTable[];
 extern const int32_t chpl_filenameTableSize;
 
-/* generated */
-extern const chpl_fn_p chpl_ftable[];
 extern const chpl_fn_info chpl_finfo[];
 
 //
@@ -63,8 +61,10 @@ extern const chpl_fn_info chpl_finfo[];
 //
 extern const int chpl_numGlobalsOnHeap;
 extern ptr_wide_ptr_t chpl_globals_registry[];
+
 extern void* const chpl_private_broadcast_table[];
 extern const int chpl_private_broadcast_table_len;
+
 extern void* const chpl_global_serialize_table[];
 
 //

--- a/runtime/src/chpl-dynamic-loading.c
+++ b/runtime/src/chpl-dynamic-loading.c
@@ -30,10 +30,12 @@
 #include "chplrt.h"
 #include "chpl-dynamic-loading.h"
 #include "chplcgfns.h"
+#include "chpl-prginfo.h"
 
 int CHPL_RTLD_LAZY = RTLD_LAZY;
 
 void** chpl_get_ftable(void) {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
   return (void**) chpl_ftable;
 }
 

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -341,6 +341,7 @@ void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
                              chpl_comm_on_bundle_t *arg, size_t arg_size,
                              int ln, int32_t fn) {
   assert(node==0);
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
 
   chpl_task_startMovedTask(fid, chpl_ftable[fid],
                            chpl_comm_on_bundle_task_bundle(arg), arg_size,

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -71,6 +71,7 @@
 #include "chpl-mem.h"
 #include "chpl-mem-desc.h"
 #include "chpl-mem-sys.h"
+#include "chpl-prginfo.h"
 #include "chplsys.h"
 #include "chpl-tasks.h"
 #include "chpltypes.h"
@@ -4198,6 +4199,8 @@ void rf_handler(gni_cq_entry_t* ev)
         if (f_c->comm.rf_done != NULL) {
           fn = (chpl_fn_p) fork_call_wrapper_blocking;
         } else {
+          CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                  chpl_ftable);
           fn = (chpl_fn_p) chpl_ftable[f_c->comm.fid];
         }
         chpl_task_startMovedTask(f_c->comm.fid,

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -37,6 +37,7 @@
 #include "chpltypes.h"
 #include "chpl-linefile-support.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 #include <stdio.h>
 #include <string.h>
 #include <signal.h>
@@ -500,6 +501,8 @@ void chpl_task_addTask(chpl_fn_int_t fid,
   // begin critical section
   chpl_thread_mutexLock(&threading_lock);
 
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
+
   (void) add_to_task_pool(fid, chpl_ftable[fid], arg, arg_size,
                           false, lineno, filename);
 
@@ -512,6 +515,7 @@ void chpl_task_taskCallFTable(chpl_fn_int_t fid,
                         void* arg, size_t arg_size,
                         c_sublocid_t subloc,
                         int lineno, int32_t filename) {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
   taskCallBody(fid, chpl_ftable[fid], arg, arg_size, subloc, lineno, filename);
 }
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1002,6 +1002,8 @@ void chpl_task_addTask(chpl_fn_int_t       fid,
                        int                 lineno,
                        int32_t             filename)
 {
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
+
     chpl_fn_p requested_fn = chpl_ftable[fid];
 
     // We allow using c_sublocid_none to represent the CPU in the gpu locale
@@ -1075,6 +1077,7 @@ void chpl_task_taskCallFTable(chpl_fn_int_t fid,
 {
     PROFILE_INCR(profile_task_taskCallFTable,1);
 
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
     taskCallBody(fid, chpl_ftable[fid], arg, arg_size, subloc, lineno, filename);
 }
 


### PR DESCRIPTION
This PR replaces references to the symbol `chpl_ftable` with `chpl_rt_prginfo*` struct reads.

TESTING

- [x] `standard`
- [x] `C backend`
- [x] `COMM=gasnet`
- [x] Build with `COMM=ofi`
- [x] Build with `gasnet-asan`

Reviewed by @benharsh. Thanks!