### PR TITLE
dlopen: Replace more uses of program symbols in the runtime

### DIFF
--- a/runtime/include/chpl-prginfo-data-macro.h
+++ b/runtime/include/chpl-prginfo-data-macro.h
@@ -36,7 +36,7 @@ E_CONSTANT(mainHasArgs, int)
 E_CONSTANT(CHPL_LAUNCHER, const char*)
 
 /** CODE-GENERATED
-    The path to '$CHPL_HOME/third-party' when this program was compiled.A
+    The path to '$CHPL_HOME/third-party' when this program was compiled.
 */
 E_CONSTANT(CHPL_THIRD_PARTY, const char*)
 

--- a/runtime/include/chpl-prginfo-data-macro.h
+++ b/runtime/include/chpl-prginfo-data-macro.h
@@ -36,6 +36,11 @@ E_CONSTANT(mainHasArgs, int)
 E_CONSTANT(CHPL_LAUNCHER, const char*)
 
 /** CODE-GENERATED
+    The path to '$CHPL_HOME/third-party' when this program was compiled.A
+*/
+E_CONSTANT(CHPL_THIRD_PARTY, const char*)
+
+/** CODE-GENERATED
     Whether or not 'main' should preserve the delimiter when parsing args.
 */
 E_CONSTANT(mainPreserveDelimiter, int)

--- a/runtime/include/chpl-prginfo-program-only-decls.h
+++ b/runtime/include/chpl-prginfo-program-only-decls.h
@@ -62,15 +62,20 @@ extern const char* CHPL_TARGET_CPU;
 extern const char* CHPL_TARGET_PLATFORM;
 extern const char* CHPL_UNWIND;
 extern const char* CHPL_HOME;
+extern const char* CHPL_COMM;
 extern const char* CHPL_LAUNCHER;
 extern const char* CHPL_GASNET_SEGMENT;
 extern const char* CHPL_LLVM_BIN_DIR;
+extern const char* CHPL_TARGET_MEM;
+extern const char* CHPL_THIRD_PARTY;
 extern const int CHPL_INTERLEAVE_MEM;
 extern const int CHPL_STACK_CHECKS;
 extern const int CHPL_CACHE_REMOTE;
 extern const int chpl_sizeSymTable;
 extern const int chpl_filenumSymTable[];
 extern const c_string chpl_funSymTable[];
+extern const c_string chpl_filenameTable[];
+extern const int chpl_filenameTableSize;
 
 
 #endif

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -51,8 +51,6 @@ extern const char* CHPL_THIRD_PARTY;
 extern const c_string chpl_filenameTable[];
 extern const int32_t chpl_filenameTableSize;
 
-extern const chpl_fn_info chpl_finfo[];
-
 //
 // chpl_globals_registry is an array of size chpl_numGlobalsOnHeap
 // storing ptr_wide_ptr_t, that is, local addresses of wide pointers.

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_THIRD_PARTY;
 
 // Sorted lookup table of filenames used with insertLineNumbers for error

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -44,8 +44,6 @@ extern "C" {
 /* defined in chpl_compilation_config.c: */
 extern const char* CHPL_THIRD_PARTY;
 
-extern const int32_t chpl_filenameTableSize;
-
 //
 // chpl_globals_registry is an array of size chpl_numGlobalsOnHeap
 // storing ptr_wide_ptr_t, that is, local addresses of wide pointers.

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -63,8 +63,6 @@ extern const int chpl_private_broadcast_table_len;
 
 extern void* const chpl_global_serialize_table[];
 
-extern const int chpl_mem_numDescs;
-
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -44,9 +44,6 @@ extern "C" {
 /* defined in chpl_compilation_config.c: */
 extern const char* CHPL_THIRD_PARTY;
 
-// Sorted lookup table of filenames used with insertLineNumbers for error
-// messages and logging. Defined in chpl_compilation_config.c (needed by launchers)
-extern const c_string chpl_filenameTable[];
 extern const int32_t chpl_filenameTableSize;
 
 //

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -63,14 +63,6 @@ extern const int chpl_private_broadcast_table_len;
 
 extern void* const chpl_global_serialize_table[];
 
-//
-// The compiler generates a separate array of descriptions for the
-// allocation types it defines.  Indices into that compiler-generated
-// array conceptually start after the CHPL_RT_MD_NUM enum value in
-// chpl-mem.h).  This is that compiler-generated array, and how many
-// entries it has (also defined in the generated code).
-//
-extern const char* const chpl_mem_descs[];
 extern const int chpl_mem_numDescs;
 
 #ifdef __cplusplus

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -42,7 +42,6 @@ extern "C" {
 #endif
 
 /* defined in chpl_compilation_config.c: */
-extern const char* CHPL_COMM;
 extern const char* CHPL_TARGET_MEM;
 extern const char* CHPL_THIRD_PARTY;
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -41,9 +41,6 @@
 extern "C" {
 #endif
 
-/* defined in chpl_compilation_config.c: */
-extern const char* CHPL_THIRD_PARTY;
-
 //
 // chpl_globals_registry is an array of size chpl_numGlobalsOnHeap
 // storing ptr_wide_ptr_t, that is, local addresses of wide pointers.

--- a/runtime/src/chpl-linefile-support.c
+++ b/runtime/src/chpl-linefile-support.c
@@ -70,9 +70,10 @@ c_string chpl_lookupFilename(const int32_t idx) {
     }
     }
   } else {
-    if (idx < chpl_filenameTableSize) {
-      return CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                                  chpl_filenameTable)[idx];
+    chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
+
+    if (idx < CHPL_RT_PRGINFO_DATA(prg, chpl_filenameTableSize)) {
+      return CHPL_RT_PRGINFO_DATA(prg, chpl_filenameTable)[idx];
     } else {
       snprintf(CHPL_TLS_GET(unknownFileBuffer), 48,
                "<unknown file idx %" PRId32 ">", idx);

--- a/runtime/src/chpl-linefile-support.c
+++ b/runtime/src/chpl-linefile-support.c
@@ -27,6 +27,7 @@
 #include "chpl-thread-local-storage.h"
 
 #include "chpl-linefile-support.h"
+#include "chpl-prginfo.h"
 
 static const char *savedFilename;
 
@@ -70,7 +71,8 @@ c_string chpl_lookupFilename(const int32_t idx) {
     }
   } else {
     if (idx < chpl_filenameTableSize) {
-      return chpl_filenameTable[idx];
+      return CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                  chpl_filenameTable)[idx];
     } else {
       snprintf(CHPL_TLS_GET(unknownFileBuffer), 48,
                "<unknown file idx %" PRId32 ">", idx);

--- a/runtime/src/chpl-mem-desc.c
+++ b/runtime/src/chpl-mem-desc.c
@@ -27,6 +27,7 @@
 #include "chpl-mem-desc.h"
 #include "chpltypes.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -54,8 +55,8 @@ static struct md_desc_type rt_md[] = {
 
 
 const char* chpl_mem_descString(chpl_mem_descInt_t mdi) {
-  if (mdi < CHPL_RT_MD_NUM)
-    return rt_md[mdi].string;
+  if (mdi < CHPL_RT_MD_NUM) return rt_md[mdi].string;
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_mem_descs);
   return chpl_mem_descs[mdi-CHPL_RT_MD_NUM];
 }
 

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -175,6 +175,7 @@ void chpl_vdebug_start (const char *fileroot, double now) {
     CHPL_RT_PRGINFO_DECLARE(prg, chpl_saveCDir);
     CHPL_RT_PRGINFO_DECLARE(prg, CHPL_HOME);
     CHPL_RT_PRGINFO_DECLARE(prg, chpl_filenameTable);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_filenameTableSize);
 
     chpl_dprintf (chpl_vdebug_fd, "CHPL_HOME: %s\n", CHPL_HOME);
     chpl_dprintf (chpl_vdebug_fd, "DIR: %s\n", chpl_compileDirectory);

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -191,6 +191,9 @@ void chpl_vdebug_start (const char *fileroot, double now) {
                       chpl_filenameTable[ix]);
       }
     }
+
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_finfo);
+
     for (numFIDnames = 0; chpl_finfo[numFIDnames].name != NULL; numFIDnames++);
     chpl_dprintf (chpl_vdebug_fd, "FIDNsize: %d\n", numFIDnames);
     for (ix = 0; ix < numFIDnames; ix++)

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -174,6 +174,7 @@ void chpl_vdebug_start (const char *fileroot, double now) {
     CHPL_RT_PRGINFO_DECLARE(prg, chpl_compileDirectory);
     CHPL_RT_PRGINFO_DECLARE(prg, chpl_saveCDir);
     CHPL_RT_PRGINFO_DECLARE(prg, CHPL_HOME);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_filenameTable);
 
     chpl_dprintf (chpl_vdebug_fd, "CHPL_HOME: %s\n", CHPL_HOME);
     chpl_dprintf (chpl_vdebug_fd, "DIR: %s\n", chpl_compileDirectory);

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -420,6 +420,8 @@ static void printMemAllocsByType(_Bool forLeaks,
   memTableEntry* me;
   int i;
   const int numberWidth   = 9;
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_mem_numDescs);
   const int numEntries = CHPL_RT_MD_NUM+chpl_mem_numDescs;
 
   if (!chpl_memTrack) {
@@ -482,6 +484,9 @@ void chpl_printMemAllocsByType(int32_t lineno, int32_t filename) {
 static chpl_mem_descInt_t
 find_desc(const char* descString)
 {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_mem_numDescs);
+
   const int numEntries = CHPL_RT_MD_NUM+chpl_mem_numDescs;
   for (chpl_mem_descInt_t i = 0; i < numEntries; ++i)
     if (! strcmp(descString, chpl_mem_descString(i)))

--- a/runtime/src/comm/ugni/comm-ugni-heap-pages.c
+++ b/runtime/src/comm/ugni/comm-ugni-heap-pages.c
@@ -31,6 +31,7 @@
 #include "chpl-env.h"
 #include "comm-ugni-heap-pages.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 
 
 //
@@ -74,6 +75,7 @@ void set_hps(void)
   // hugepages, then the heap page size is the hugepage size.
   //
   char* ev;
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, CHPL_TARGET_MEM);
   if (strcmp(CHPL_TARGET_MEM, "jemalloc") == 0
       && chpl_env_rt_get("MAX_HEAP_SIZE", NULL) == NULL
       && (ev = getenv("HUGETLB_DEFAULT_PAGE_SIZE")) != NULL) {

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3306,6 +3306,9 @@ void SIGBUS_handler(int signo, siginfo_t *info, void *context)
         // Only try to provide a source file if we can give at least some
         // of it, and without using snprintf() in chpl_lookupFilename()).
         //
+        CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                chpl_filenameTableSize);
+
         if (bufi > 10
             && mr_mregs_supplement[mr_i].fn >= 0
             && mr_mregs_supplement[mr_i].fn < chpl_filenameTableSize) {

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1992,6 +1992,9 @@ void chpl_comm_post_task_init(void)
                      0, 0);
       }
 
+      CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                              CHPL_TARGET_MEM);
+
       if (strcmp(CHPL_TARGET_MEM, "jemalloc") == 0
           && getenv(chpl_comm_ugni_jemalloc_conf_ev_name()) == NULL) {
         char buf[200];

--- a/runtime/src/launch/amudprun/launch-amudprun.c
+++ b/runtime/src/launch/amudprun/launch-amudprun.c
@@ -23,8 +23,8 @@
 #include "chpllaunch.h"
 #include "chpl-mem.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 
-// To get CHPL_THIRD_PARTY from chpl invocation
 #include "chplcgfns.h"
 
 #define LAUNCH_PATH_HELP WRAP_TO_STR(LAUNCH_PATH)
@@ -104,6 +104,8 @@ int chpl_launch(int argc, char* argv[], int32_t numLocales,
   if (numLocalesPerNode > 1) {
     chpl_launcher_no_colocales_error(NULL);
   }
+
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, CHPL_THIRD_PARTY);
 
   int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("amudprun") + 2;
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);

--- a/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
+++ b/runtime/src/launch/gasnetrun_common/gasnetrun_common.h
@@ -25,6 +25,7 @@
 #include "chpl-env.h"
 #include "chpl-mem.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 
 #ifndef GASNETRUN_LAUNCHER
 #error GASNETRUN_LAUNCHER must be defined
@@ -67,6 +68,8 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
 
 int chpl_launch(int argc, char* argv[], int32_t numLocales,
                 int32_t numLocalesPerNode) {
+
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, CHPL_THIRD_PARTY);
 
   int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen(GASNETRUN_LAUNCHER) + 2;
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);

--- a/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
+++ b/runtime/src/launch/lsf-gasnetrun_ibv/launch-lsf-gasnetrun_ibv.c
@@ -27,6 +27,7 @@
 #include "chpllaunch.h"
 #include "chpl-mem.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 
 #define WRAP_TO_STR(x) TO_STR(x)
 #define TO_STR(x) #x
@@ -44,6 +45,8 @@
 static char _nlbuf[16];
 static char** chpl_launch_create_argv(int argc, char* argv[],
                                       int32_t numLocales) {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, CHPL_THIRD_PARTY);
+
   int len = strlen(CHPL_THIRD_PARTY) + strlen(WRAP_TO_STR(LAUNCH_PATH)) + strlen("gasnetrun_ibv") + 2;
   char *cmd = chpl_mem_allocMany(len, sizeof(char), CHPL_RT_MD_COMMAND_BUFFER, -1, 0);
   snprintf(cmd, len * sizeof(char), "%s/%sgasnetrun_ibv", CHPL_THIRD_PARTY,

--- a/runtime/src/launch/mpirun/launch-mpirun.c
+++ b/runtime/src/launch/mpirun/launch-mpirun.c
@@ -24,6 +24,7 @@
 #include "chpl-mem.h"
 #include "chplcgfns.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 
 #define CHPL_SPMD "--spmd"
 
@@ -42,7 +43,8 @@ static char** chpl_launch_create_argv(const char *launch_cmd,
   if (numLocales != 1) {
     chpl_error("For mpirun, specify number of SPMD images via --spmd <#> instead of -nl", 0, 0);
   }
-  if (strcmp(CHPL_COMM, "none") != 0) {
+  if (strcmp(CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                  CHPL_COMM), "none") != 0) {
     chpl_error("mpirun only supports CHPL_COMM=none", 0, 0);
   }
   // Get the number of ranks

--- a/runtime/src/launch/mpirun4ofi/launch-mpirun4ofi.c
+++ b/runtime/src/launch/mpirun4ofi/launch-mpirun4ofi.c
@@ -26,11 +26,13 @@
 #include "chpllaunch.h"
 #include "chpl-mem.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 
 static char** chpl_launch_create_argv(const char *launch_cmd,
                                       int argc, char* argv[],
                                       int32_t numLocales) {
-  if (strcmp(CHPL_COMM, "ofi") != 0) {
+  if (strcmp(CHPL_RT_PRGINFO_DATA(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                  CHPL_COMM), "ofi") != 0) {
     chpl_error("mpirun4ofi only supports CHPL_COMM=ofi", 0, 0);
   }
 

--- a/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
+++ b/runtime/src/launch/pbs-gasnetrun_ibv/launch-pbs-gasnetrun_ibv.c
@@ -30,6 +30,7 @@
 #include "chpl-env.h"
 #include "chpltypes.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 
 #define LAUNCH_PATH_HELP WRAP_TO_STR(LAUNCH_PATH)
 #define WRAP_TO_STR(x) TO_STR(x)
@@ -208,6 +209,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
    * first sentinel would appear in the output and confuse the 'expect'
    * logic.
    */
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, CHPL_THIRD_PARTY);
   fprintf(expectFile, "set timeout -1\n");
   fprintf(expectFile, "set env(CHPL_ENV_EXPECT_SENTINEL_1) CHPL_EXPECT_SENTINEL_1\n");
   fprintf(expectFile, "spawn qsub -z ");

--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -31,6 +31,7 @@
 #include "chpl-mem.h"
 #include "chpltypes.h"
 #include "chpl-error.h"
+#include "chpl-prginfo.h"
 
 #ifndef GASNETRUN_LAUNCHER
 #error GASNETRUN_LAUNCHER must be defined
@@ -325,6 +326,9 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     if (errorfn != NULL)
       fprintf(slurmFile, "#SBATCH -e %s\n", errorfn);
+
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            CHPL_THIRD_PARTY);
 
     fprintf(slurmFile, "%s/%s/%s -n %d -N %d -c 0",
             CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), GASNETRUN_LAUNCHER,

--- a/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
+++ b/runtime/src/launch/slurm-gasnetrun_common/slurm-gasnetrun_common.h
@@ -302,6 +302,9 @@ static char* chpl_launch_create_command(int argc, char* argv[],
   snprintf(slurmFilename, slurmFilenameLen, "%s%d", baseSBATCHFilename,
            (int)mypid);
 
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          CHPL_THIRD_PARTY);
+
   if (getenv("CHPL_LAUNCHER_USE_SBATCH") != NULL) {
     slurmFile = fopen(slurmFilename, "w");
     fprintf(slurmFile, "#!/bin/sh\n\n");
@@ -326,9 +329,6 @@ static char* chpl_launch_create_command(int argc, char* argv[],
 
     if (errorfn != NULL)
       fprintf(slurmFile, "#SBATCH -e %s\n", errorfn);
-
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            CHPL_THIRD_PARTY);
 
     fprintf(slurmFile, "%s/%s/%s -n %d -N %d -c 0",
             CHPL_THIRD_PARTY, WRAP_TO_STR(LAUNCH_PATH), GASNETRUN_LAUNCHER,

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -505,6 +505,10 @@ static void setupAvailableParallelism(int32_t maxThreads) {
         if (0 < maxThreads && maxThreads < hwpar) {
           if (chpl_nodeID == 0) {
             char msg[1024];
+
+            CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                                    CHPL_COMM);
+
             snprintf(msg, sizeof(msg),
                      "The CHPL_COMM setting is limiting the number of threads "
                      "to %d, rather than the hardware's preference of %d.%s",

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -33,6 +33,7 @@
 #include "chpltypes.h"
 #include "chpl-error.h"
 #include "chpl-mem-sys.h"
+#include "chpl-prginfo.h"
 #include "chplexit.h"
 
 #include <errno.h>
@@ -199,7 +200,10 @@ void chpl_topo_pre_comm_init(char *accessiblePUsMask) {
   // the future.
   //
   do_set_area_membind = true;
+
   CHPL_RT_PRGINFO_DECLARE(CHPL_RT_PRGINFO_ROOT, CHPL_GASNET_SEGMENT);
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_PRGINFO_ROOT, CHPL_COMM);
+
   if ((strcmp(CHPL_COMM, "gasnet") == 0
        && strcmp(CHPL_GASNET_SEGMENT, "everything") != 0)) {
       do_set_area_membind = false;

--- a/test/runtime/jhh/colocales/colocales.c
+++ b/test/runtime/jhh/colocales/colocales.c
@@ -95,6 +95,8 @@ int main(int argc, char* argv[]) {
   if (numCoLocales > 0) {
     setenv("CHPL_RT_LOCALES_PER_NODE", numCoLocalesStr, 1);
   }
+
+  setupProgramInfoHereManually();
   chpl__init_colocales(0, 0); // unsure why this is needed
   chpl_topo_pre_comm_init(mask);
   chpl_comm_init(NULL, NULL);

--- a/test/runtime/jhh/colocales/colocales.chpl
+++ b/test/runtime/jhh/colocales/colocales.chpl
@@ -1,2 +1,8 @@
-// This is an empty file used to create the Chapel library.
-;
+// This is a file used to create an otherwise empty Chapel library. Its main
+// purpose is to provide access into the runtime. However, since it
+// initializes the runtime in a non-standard way, it also needs to manually
+// prepare program information so that the runtime can function.
+export proc setupProgramInfoHereManually() {
+  use ChapelProgramRegistration;
+  chpl_programInfoHere.registerAsRoot();
+}

--- a/test/runtime/jhh/cpuKinds/cpuKinds.c
+++ b/test/runtime/jhh/cpuKinds/cpuKinds.c
@@ -40,6 +40,7 @@ int main(int argc, char* argv[]) {
     exit(1);
   }
 
+  setupProgramInfoHereManually();
   chpl__init_cpuKinds(0, 0); // unsure why this is needed
   chpl_set_num_locales_on_node(1);
   chpl_topo_pre_comm_init(mask);

--- a/test/runtime/jhh/cpuKinds/cpuKinds.chpl
+++ b/test/runtime/jhh/cpuKinds/cpuKinds.chpl
@@ -1,2 +1,8 @@
-// This is an empty file used to create the Chapel library.
-;
+// This is a file used to create an otherwise empty Chapel library. Its main
+// purpose is to provide access into the runtime. However, since it
+// initializes the runtime in a non-standard way, it also needs to manually
+// prepare program information so that the runtime can function.
+export proc setupProgramInfoHereManually() {
+  use ChapelProgramRegistration;
+  chpl_programInfoHere.registerAsRoot();
+}

--- a/test/runtime/jhh/misc/tester.c
+++ b/test/runtime/jhh/misc/tester.c
@@ -40,6 +40,7 @@ int main(int argc, char* argv[]) {
     exit(1);
   }
 
+  setupProgramInfoHereManually();
   chpl__init_tester(0, 0); // unsure why this is needed
   chpl_set_num_locales_on_node(1);
   chpl_topo_pre_comm_init(mask);

--- a/test/runtime/jhh/misc/tester.chpl
+++ b/test/runtime/jhh/misc/tester.chpl
@@ -1,2 +1,8 @@
-// This is an empty file used to create the Chapel library.
-;
+// This is a file used to create an otherwise empty Chapel library. Its main
+// purpose is to provide access into the runtime. However, since it
+// initializes the runtime in a non-standard way, it also needs to manually
+// prepare program information so that the runtime can function.
+export proc setupProgramInfoHereManually() {
+  use ChapelProgramRegistration;
+  chpl_programInfoHere.registerAsRoot();
+}


### PR DESCRIPTION
This PR replaces more direct uses of program symbols in the runtime with indirect uses from a `chpl_rt_prginfo*` struct. It removes the corresponding symbol declarations from `chplcgfns.h`.

- [x] `standard`
- [x] `C backend`
- [x] `COMM=gasnet`
- [x] Build with `COMM=ofi`
- [x] Build with `gasnet-asan` and test `fastAndIncremental.chpl`
- [x] Build with a variety of GASNET launchers

Reviewed by @benharsh. Thanks!