### PR TITLE
Fix `writeBits` to not error when writing less bits than the max significant bit

### DIFF
--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -1480,10 +1480,8 @@ qioerr qio_channel_write_bits(const int threadsafe, qio_channel_t* restrict ch, 
 
   if( nbits < 0 ) QIO_RETURN_CONSTANT_ERROR(EINVAL, "negative number of bits");
   if( nbits == 0 ) return 0;
-  if( nbits < 64 && (v >> nbits) != 0 ) {
-    // v must not have any extra bits set.
-    QIO_RETURN_CONSTANT_ERROR(EINVAL, "no more bits");
-  }
+  // if there are significant bits at positions greater than nbits, we ignore them
+  v = nbits < 64 ? ((1LL << nbits) - 1) & v : v;
 
   if( threadsafe ) {
     err = qio_lock(&ch->lock);

--- a/test/io/ferguson/writeBitsNotEnough.chpl
+++ b/test/io/ferguson/writeBitsNotEnough.chpl
@@ -1,0 +1,26 @@
+use IO;
+
+var f = openMemFile();
+
+{
+  var w = f.writer(serializer=new binarySerializer(), locking=false);
+
+  w.writeBits(0b011, 3);
+  w.writeBits(0b011, 2);
+  w.writeBits(0b011, 1); // we have more bits, only write 1 of them
+  w.writeBits((-1):uint(64), 2);
+}
+
+{
+  var r = f.reader(deserializer=new binaryDeserializer(), locking=false);
+
+  var tmp:uint(8);
+  r.readBits(tmp, 3);
+  assert(tmp == 0b011);
+  r.readBits(tmp, 2);
+  assert(tmp == 0b11);
+  r.readBits(tmp, 1);
+  assert(tmp == 0b1);
+  r.readBits(tmp, 2);
+  assert(tmp == 0b11);
+}


### PR DESCRIPTION
Fixes `writeBits` to not throw an error when writing bits less than the maximum significant bit.

For example, `w.writeBits(8, 3)` used to throw an error, now it will just write the 3 lowest bits, which are all 0's.

Resolves https://github.com/chapel-lang/chapel/issues/28668

[Reviewed by @benharsh]