### PR TITLE
dlopen: Migrate `chpl_comm_register_global_var` to module code

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -6202,8 +6202,7 @@ DEFINE_PRIM(REGISTER_GLOBAL_VAR) {
     }
 #endif
 
-    codegenCall("chpl_comm_register_global_var",
-                idx,
+    codegenCall("chpl_registerGlobalVar", idx,
                 codegenCast("ptr_wide_ptr_t", ptr_wide_ptr));
 }
 DEFINE_PRIM(BROADCAST_GLOBAL_VARS) {

--- a/modules/internal/ChapelRuntimeInterface.chpl
+++ b/modules/internal/ChapelRuntimeInterface.chpl
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module ChapelRuntimeInterface {
+  use ChapelBase, CTypes;
+
+  extern type wide_ptr_t;
+
+  export
+  proc chpl_registerGlobalVar(idx: c_int, ptrToWidePtr: c_ptr(wide_ptr_t)) {
+    // Extern, but declared by the compiler and lives in program code.
+    extern var chpl_globals_registry: c_ptr(c_ptr(wide_ptr_t));
+    chpl_globals_registry[idx] = ptrToWidePtr;
+  }
+}

--- a/modules/internal/ChapelRuntimeInterface.chpl
+++ b/modules/internal/ChapelRuntimeInterface.chpl
@@ -23,8 +23,10 @@ module ChapelRuntimeInterface {
 
   extern type wide_ptr_t;
 
-  export
-  proc chpl_registerGlobalVar(idx: c_int, ptrToWidePtr: c_ptr(wide_ptr_t)) {
+  // The compiler will generate code that calls this procedure in order to
+  // deterministically populate the 'chpl_globals_registry' on all locales.
+  export proc
+  chpl_registerGlobalVar(idx: c_int, ptrToWidePtr: c_ptr(wide_ptr_t)) {
     // Extern, but declared by the compiler and lives in program code.
     extern var chpl_globals_registry: c_ptr(c_ptr(wide_ptr_t));
     chpl_globals_registry[idx] = ptrToWidePtr;

--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -91,4 +91,5 @@ module ChapelStandard {
   use ChapelDynamicLoading;
   use ChapelProgramEntrypoints;
   use ChapelProgramRegistration;
+  use ChapelRuntimeInterface;
 }

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -338,27 +338,20 @@ chpl_bool chpl_comm_regMemFree(void* p, size_t size) {
 }
 
 //
-// These routines are used by the Chapel runtime to broadcast the
-// locations of module-level ("global") variables to all locales
-// so that all locales can put/get the value of a global variable
-// directly, knowing where it lives remotely.
+// This routine is used by the Chapel runtime to broadcast the locations of
+// module-level ("global") variables within a program to all locales so that
+// all locales can put/get the value of a global variable directly, knowing
+// where it lives remotely.
 //
-// The named symbol for a global var is a wide pointer referring to
-// that global's heap-allocated space on node 0.  At program start,
-// all of these wide pointers must be communicated from node 0 to
-// all the other nodes.  To achieve this, the compiler-emitted code
-// first calls chpl_comm_register_global_var() on every node for
-// each global (passing a global var index which starts at 0 and
-// increments each time, and the address of the global's named
-// symbol), then finally calls chpl_comm_broadcast_global_vars().
-// The implementation of these two could either broadcast the wide
-// pointer values one by one in the 'register' calls and then do
-// nothing in the 'broadcast' call, or batch up the wide pointers
-// in the 'register' calls and actually do a broadcast in the
-// 'broadcast' call.  Currently we do the latter in order to
-// reduce startup overhead.
+// The named symbol for a global var is a wide pointer referring to that
+// global's heap-allocated space on node 0. At program start, all of these
+// wide pointers must be communicated from node 0 to all the other nodes.
 //
-void chpl_comm_register_global_var(int i, wide_ptr_t* ptr_to_wide_ptr);
+// To achieve this, the compiler-emitted code first prepares an array on
+// every locale that contains addresses of wide pointers for every global
+// on that locale. Then, the compiler invokes this function in order to
+// broadcast and set the wide pointers on each locale.
+//
 void chpl_comm_broadcast_global_vars(int numGlobals);
 
 //

--- a/runtime/include/chpl-prginfo-data-macro.h
+++ b/runtime/include/chpl-prginfo-data-macro.h
@@ -76,8 +76,14 @@ E_CONSTANT_RT(chpl_private_broadcast_table_len, int)
 E_CONSTANT_RT(chpl_global_serialize_table, void* const*)
 
 /** CODE-GENERATED | WRITEABLE
+
     A table of local addresses of wide pointers containing global vars.
-    This table is writeable memory.
+    This table is writeable memory. Its size is specified by the constant
+    'chpl_numGlobalsOnHeap', defined below.
+
+    This table is used primarily by 'chpl_comm_broadcast_global_vars()',
+    which assists in broadcasting the addresses of heap-allocated globals
+    to every locale at program initialization.
 */
 E_CONSTANT_RT(chpl_globals_registry, wide_ptr_t**)
 

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -48,7 +48,6 @@ extern "C" {
 // chpl_comm_broadcast_global_vars(), respectively, declared below.
 //
 extern const int chpl_numGlobalsOnHeap;
-extern ptr_wide_ptr_t chpl_globals_registry[];
 
 extern void* const chpl_private_broadcast_table[];
 extern const int chpl_private_broadcast_table_len;

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -41,14 +41,6 @@
 extern "C" {
 #endif
 
-//
-// chpl_globals_registry is an array of size chpl_numGlobalsOnHeap
-// storing ptr_wide_ptr_t, that is, local addresses of wide pointers.
-// It is filled in and used by chpl_comm_register_global_var() and
-// chpl_comm_broadcast_global_vars(), respectively, declared below.
-//
-extern const int chpl_numGlobalsOnHeap;
-
 extern void* const chpl_private_broadcast_table[];
 extern const int chpl_private_broadcast_table_len;
 

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -32,6 +32,7 @@
 #include "chpl-gpu-diags.h"
 #include "chpl-env.h"
 #include "chpl-mem.h"
+#include "chpl-prginfo.h"
 #include "chpl-topo.h"
 
 // Don't get warning macros for chpl_comm_get etc.
@@ -53,6 +54,8 @@ static int32_t   numColocalesOnNode = 1;
 // Global variable broadcast support.
 //
 void chpl_comm_register_global_var(int i, wide_ptr_t *ptr_to_wide_ptr) {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_globals_registry);
   chpl_globals_registry[i] = ptr_to_wide_ptr;
 }
 
@@ -84,6 +87,9 @@ void chpl_comm_broadcast_global_vars(int numGlobals) {
       chpl_mem_free(buf_on_0, 0, 0);
     }
   } else {
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_globals_registry);
+
     wide_ptr_t* buf;
     size_t size = chpl_numGlobalsOnHeap * sizeof(*buf);
     buf = (wide_ptr_t*)

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -89,6 +89,8 @@ void chpl_comm_broadcast_global_vars(int numGlobals) {
   } else {
     CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                             chpl_globals_registry);
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_numGlobalsOnHeap);
 
     wide_ptr_t* buf;
     size_t size = chpl_numGlobalsOnHeap * sizeof(*buf);

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -50,16 +50,6 @@ static int32_t   localRank = -1;
 static int32_t   numColocalesOnNode = 1;
 
 
-//
-// Global variable broadcast support.
-//
-void chpl_comm_register_global_var(int i, wide_ptr_t *ptr_to_wide_ptr) {
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                          chpl_globals_registry);
-  chpl_globals_registry[i] = ptr_to_wide_ptr;
-}
-
-
 void chpl_comm_broadcast_global_vars(int numGlobals) {
   //
   // On node 0: gather up the global variables' wide pointers into a

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -969,6 +969,9 @@ void chpl_comm_pre_mem_init(void) {
     // of the global variable locations; everyone else will just peek at its copy.  So
     // locale 0 sets up its segment to an appropriate size:
     //
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_numGlobalsOnHeap);
+
     int global_table_size = chpl_numGlobalsOnHeap * sizeof(wide_ptr_t) + GASNETT_PAGESIZE;
     void* global_table = sys_malloc(global_table_size);
     seginfo_table[0].addr = ((void *)(((uint8_t*)global_table) +
@@ -1152,6 +1155,9 @@ void chpl_comm_rollcall(void) {
 
 void chpl_comm_impl_regMemHeapInfo(void** start_p, size_t* size_p) {
 #if defined(GASNET_SEGMENT_FAST) || defined(GASNET_SEGMENT_LARGE)
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_numGlobalsOnHeap);
+
   *start_p = chpl_numGlobalsOnHeap * sizeof(wide_ptr_t)
              + (char*)seginfo_table[chpl_nodeID].addr;
   *size_p  = seginfo_table[chpl_nodeID].size
@@ -1173,6 +1179,8 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
   if (chpl_nodeID == 0) {
     CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                             chpl_globals_registry);
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_numGlobalsOnHeap);
 
     for (int i = 0; i < chpl_numGlobalsOnHeap; i++) {
       ((wide_ptr_t*) seginfo_table[0].addr)[i] = *chpl_globals_registry[i];

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -43,6 +43,7 @@
 #include "chpl-error.h"
 #include "chpl-mem-desc.h"
 #include "chpl-mem-sys.h" // mem layer not initialized in init, need sys alloc
+#include "chpl-prginfo.h"
 
 // Don't get warning macros for chpl_comm_get etc
 #include "chpl-comm-no-warning-macros.h"
@@ -1170,6 +1171,9 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
   // node 0 has filled in that buffer, however.
   //
   if (chpl_nodeID == 0) {
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_globals_registry);
+
     for (int i = 0; i < chpl_numGlobalsOnHeap; i++) {
       ((wide_ptr_t*) seginfo_table[0].addr)[i] = *chpl_globals_registry[i];
     }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3322,6 +3322,8 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
   if (chpl_nodeID == 0) {
     CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                             chpl_globals_registry);
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_numGlobalsOnHeap);
 
     CHPL_CALLOC(buf, chpl_numGlobalsOnHeap);
     for (int i = 0; i < chpl_numGlobalsOnHeap; i++) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3317,8 +3317,12 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
   // buffer, and broadcast the address of that buffer to the other
   // nodes.
   //
-  wide_ptr_t* buf;
+
+  wide_ptr_t* buf = NULL;
   if (chpl_nodeID == 0) {
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_globals_registry);
+
     CHPL_CALLOC(buf, chpl_numGlobalsOnHeap);
     for (int i = 0; i < chpl_numGlobalsOnHeap; i++) {
       buf[i] = *chpl_globals_registry[i];

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3924,6 +3924,8 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
   if (chpl_nodeID == 0) {
     CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                             chpl_globals_registry);
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_numGlobalsOnHeap);
 
     buf = (wide_ptr_t*) chpl_mem_allocMany(chpl_numGlobalsOnHeap, sizeof(*buf),
                                            CHPL_RT_MD_COMM_PER_LOC_INFO, 0, 0);

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3922,6 +3922,9 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
   //
   wide_ptr_t* buf;
   if (chpl_nodeID == 0) {
+    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            chpl_globals_registry);
+
     buf = (wide_ptr_t*) chpl_mem_allocMany(chpl_numGlobalsOnHeap, sizeof(*buf),
                                            CHPL_RT_MD_COMM_PER_LOC_INFO, 0, 0);
     for (int i = 0; i < chpl_numGlobalsOnHeap; i++) {

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -246,6 +246,8 @@ ChapelProgramRegistration
   from print-module-resolution.ChapelStandard.ChapelProgramEntrypoints.ChapelProgramRegistration
 ChapelProgramEntrypoints
   from print-module-resolution.ChapelStandard.ChapelProgramEntrypoints
+ChapelRuntimeInterface
+  from print-module-resolution.ChapelStandard.ChapelRuntimeInterface
 ChapelStandard
   from print-module-resolution.ChapelStandard
 print-module-resolution

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -67,6 +67,7 @@ Initializing Modules:
     ChapelProgramEntrypoints
      ChapelProgramRegistration
       ChapelSetProgramInfoDataEntries
+    ChapelRuntimeInterface
     AlignedTSupport
    printModuleInitOrder
     moduleInitTest


### PR DESCRIPTION
This PR migrates the RT function `chpl_comm_register_global_var` to live in module code. It introduces a new internal module called `ChapelRuntimeInterface.chpl`. In the future much more stuff will live in this module. For now, it only contains a single procedure `chpl_registerGlobalVar`, which is functionally identical to its old runtime equivalent.

TESTING

- [x] `standard`
- [x] `COMM=gasnet`, `COMPILER=gnu`
- [x] Build with `COMM=ofi`, `COMPILER=gnu`
- [x] Build with `gasnet-asan` and run `fastAndIncremental.chpl`

Reviewed by @jabraham17. Thanks!