### PR TITLE
Improve where clause errors

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1725,6 +1725,27 @@ BlockStmt* buildExternExportFunctionDecl(Flag externOrExport, Expr* paramCNameEx
   return blockFnDef;
 }
 
+static Expr* wrapNonImplementsWhereExprs(Expr* whereExpr) {
+  CallExpr* call = toCallExpr(whereExpr);
+
+  // leave 'implements' clauses alone; they don't need validation
+  if (isIfcConstraint(whereExpr)) {
+    return whereExpr;
+
+  // wrap most expressions in a validation to make sure they're param bool
+  } else if (!call || !call->isNamed("&&")) {
+    return new CallExpr("chpl_validateWhere", whereExpr);
+
+  // but pick apart && clauses because they may contain multiple 'implements'
+  // clauses or arbitrary expressions (or a mix?); note that implements must
+  // currently be separated by "&&"
+  } else {
+    call->get(1)->replace(wrapNonImplementsWhereExprs(call->get(1)->copy()));
+    call->get(2)->replace(wrapNonImplementsWhereExprs(call->get(2)->copy()));
+    return call;
+  }
+}
+
 void
 setupFunctionDecl(FnSymbol*   fn,
                   RetTag      optRetTag,
@@ -1745,7 +1766,7 @@ setupFunctionDecl(FnSymbol*   fn,
 
   if (optWhere)
   {
-    fn->where = new BlockStmt(new CallExpr("chpl_validateWhere", optWhere));;
+    fn->where = new BlockStmt(wrapNonImplementsWhereExprs(optWhere));
   }
 
   if (optLifetimeConstraints)

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1745,7 +1745,7 @@ setupFunctionDecl(FnSymbol*   fn,
 
   if (optWhere)
   {
-    fn->where = new BlockStmt(optWhere);
+    fn->where = new BlockStmt(new CallExpr("chpl_validateWhere", optWhere));;
   }
 
   if (optLifetimeConstraints)

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -913,9 +913,11 @@ bool evaluateWhereClause(FnSymbol* fn) {
 
     SymExpr* se = toSymExpr(fn->where->body.last());
 
+    /*
     if (se == NULL) {
       USR_FATAL(fn->where, "invalid where clause");
     }
+    */
 
     if (se->symbol() == gFalse) {
       cleanupWhereClause(fn->where, se);
@@ -927,7 +929,9 @@ bool evaluateWhereClause(FnSymbol* fn) {
       return true;
     }
 
+    /*
     USR_FATAL(fn->where, "invalid where clause");
+    */
   }
 
   return true;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -3526,4 +3526,14 @@ module ChapelBase {
 
     return equals;
   }
+
+  proc chpl_validateWhere(param test) param : bool {
+    if test.type != bool then
+      compilerError("a 'where' clause expression must evaluate to a 'param bool', but got a 'param " + test.type:string + "' instead");
+    return test;
+  }
+
+  proc chpl_validateWhere(test) param : bool {
+    compilerError("a 'where' clause expression must be a 'param', but got a non-'param'");
+  }
 }

--- a/test/functions/diten/badwhere.good
+++ b/test/functions/diten/badwhere.good
@@ -1,3 +1,3 @@
 badwhere.chpl:4: In function 'foo':
-badwhere.chpl:4: error: invalid where clause
+badwhere.chpl:4: error: a 'where' clause expression must be a 'param', but got a non-'param'
   badwhere.chpl:1: called as foo(x: string, y: string, z: bool)

--- a/test/functions/whereClauses/whereClauseIntAndArrayArg.chpl
+++ b/test/functions/whereClauses/whereClauseIntAndArrayArg.chpl
@@ -1,0 +1,8 @@
+var ax: [1..10] real = 1.0;
+var yc = wrong(ax);
+proc wrong(
+   const in ax: [] real
+   ): real
+   where (ax.rank == 1): int {
+   return 0.0;
+}

--- a/test/functions/whereClauses/whereClauseIntAndArrayArg.good
+++ b/test/functions/whereClauses/whereClauseIntAndArrayArg.good
@@ -1,0 +1,3 @@
+whereClauseIntAndArrayArg.chpl:3: In function 'wrong':
+whereClauseIntAndArrayArg.chpl:3: error: a 'where' clause expression must evaluate to a 'param bool', but got a 'param int(64)' instead
+  whereClauseIntAndArrayArg.chpl:1: called as wrong(ax: [domain(1,int(64),one)] real(64))

--- a/test/functions/whereClauses/whereClauseNonParam.good
+++ b/test/functions/whereClauses/whereClauseNonParam.good
@@ -1,2 +1,2 @@
 whereClauseNonParam.chpl:1: In function 'foo':
-whereClauseNonParam.chpl:1: error: invalid where clause
+whereClauseNonParam.chpl:1: error: a 'where' clause expression must be a 'param', but got a non-'param'

--- a/test/functions/whereClauses/whereClauseNonParamGeneric.good
+++ b/test/functions/whereClauses/whereClauseNonParamGeneric.good
@@ -1,3 +1,3 @@
 whereClauseNonParamGeneric.chpl:1: In function 'foo':
-whereClauseNonParamGeneric.chpl:1: error: invalid where clause
+whereClauseNonParamGeneric.chpl:1: error: a 'where' clause expression must be a 'param', but got a non-'param'
   whereClauseNonParamGeneric.chpl:1: called as foo(x: int(64), y: int(64))

--- a/test/functions/whereClauses/whereClauseReal.chpl
+++ b/test/functions/whereClauses/whereClauseReal.chpl
@@ -1,0 +1,6 @@
+var ax: [1..10] real = 1.0;
+var yc = wrong();
+proc wrong(): real
+  where (ax.rank == 1): real {
+   return 0.0;
+}

--- a/test/functions/whereClauses/whereClauseReal.good
+++ b/test/functions/whereClauses/whereClauseReal.good
@@ -1,0 +1,2 @@
+whereClauseReal.chpl:3: In function 'wrong':
+whereClauseReal.chpl:3: error: a 'where' clause expression must evaluate to a 'param bool', but got a 'param real(64)' instead

--- a/test/functions/whereClauses/whereClauseRealAndArrayArg.chpl
+++ b/test/functions/whereClauses/whereClauseRealAndArrayArg.chpl
@@ -1,0 +1,8 @@
+var ax: [1..10] real = 1.0;
+var yc = wrong(ax);
+proc wrong(
+   const in ax: [] real
+   ): real
+   where (ax.rank == 1): real {
+   return 0.0;
+}

--- a/test/functions/whereClauses/whereClauseRealAndArrayArg.good
+++ b/test/functions/whereClauses/whereClauseRealAndArrayArg.good
@@ -1,0 +1,3 @@
+whereClauseRealAndArrayArg.chpl:3: In function 'wrong':
+whereClauseRealAndArrayArg.chpl:3: error: a 'where' clause expression must evaluate to a 'param bool', but got a 'param real(64)' instead
+  whereClauseRealAndArrayArg.chpl:1: called as wrong(ax: [domain(1,int(64),one)] real(64))


### PR DESCRIPTION
This is a simple approach to improving where clause errors by leveraging a (new) internal module helper routine that checks whether the expression is a `param bool` or not.

The compiler implementation that inserts the checks is complicated somewhat by the `implements …` clause, as the compiler's processing of implements clauses assumes a certain structural form—either that the implements is the top-level expression, or that it's part of an `&&` expression.  Here, I took the approach of searching through the `where` clause, wrapping any non-`implements` clauses in my validation routine.