### PR TITLE
Improve error messages for bad where clauses

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1745,7 +1745,7 @@ setupFunctionDecl(FnSymbol*   fn,
 
   if (optWhere)
   {
-    fn->where = new BlockStmt(optWhere);
+    fn->where = new BlockStmt(new CallExpr("chpl_validateWhere", optWhere));;
   }
 
   if (optLifetimeConstraints)

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -636,7 +636,7 @@ static void moveAndCheckInterfaceConstraints() {
       // The following conditional strives to pluck 'implements'
       // statements out of this pattern, leaving anything else
       // intact, or removing it if nothing's left.
-      //      
+      //
       if (CallExpr* call = toCallExpr(icon->parentExpr)) {
         // unwrap the compiler-inserted where-clause validation if it's there
         if (call->isNamed("chpl_validateWhere")) {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -621,21 +621,20 @@ static void moveAndCheckInterfaceConstraints() {
 
     FnSymbol* fn = toFnSymbol(icon->parentSymbol);
     if (fn != nullptr) {
-      // TODO: I think we know we'll never hit this case now?
-      if (BlockStmt* block = toBlockStmt(icon->parentExpr)) {
-        if (fn->where == block) {
-          icon->remove();
-          fn->addInterfaceConstraint(icon);
-          if (block->body.empty())
-            block->remove();
-          continue;
-        }
-      } else if (CallExpr* call = toCallExpr(icon->parentExpr)) {
+      if (CallExpr* call = toCallExpr(icon->parentExpr)) {
         // unwrap the compiler-inserted where-clause validation if it's there
         if (call->isNamed("chpl_validateWhere")) {
           icon->remove();
           fn->addInterfaceConstraint(icon);
-          call->parentExpr->remove(); // remove the BlockStmt containing it
+          if (BlockStmt* block = toBlockStmt(call->parentExpr)) {
+            if (block->body.empty()) {
+              block->remove();
+            } else {
+              INT_FATAL("Unexpected non-empty block in where clause");
+            }
+          } else {
+            INT_FATAL("Unexpected parent expression in where clause");
+          }
           continue;
         } else if (isInWhereBlock(fn, call)) {
           if (!call->isNamed("&&")) {
@@ -653,6 +652,8 @@ static void moveAndCheckInterfaceConstraints() {
         if (icon->list == &(ifcInfo->interfaceConstraints))
           continue; // this constraint is already in the right spot, due to
                     // handleReceiverFormals() -> desugarInterfaceAsType()
+      } else {
+        INT_FATAL("Unexpected case in moveAndCheckInterfaceConstraints()");
       }
     }
 

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -627,6 +627,7 @@ static void moveAndCheckInterfaceConstraints() {
           icon->remove();
           fn->addInterfaceConstraint(icon);
           if (BlockStmt* block = toBlockStmt(call->parentExpr)) {
+            call->remove();
             if (block->body.empty()) {
               block->remove();
             } else {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -621,6 +621,22 @@ static void moveAndCheckInterfaceConstraints() {
 
     FnSymbol* fn = toFnSymbol(icon->parentSymbol);
     if (fn != nullptr) {
+
+      // If this 'implements' statement appears within a 'where'
+      // clause, it should take one of the following forms at this
+      // point:
+      //
+      // - BlockStmt
+      //   - CallExpr("chpl_validateWhere")
+      //     - ImplementsStmt()
+      //     - CallExpr("&&")
+      //       - ImplementsStmt() | expr
+      //       - expr | ImplementsStmt()
+      //
+      // The following conditional strives to pluck 'implements'
+      // statements out of this pattern, leaving anything else
+      // intact, or removing it if nothing's left.
+      //      
       if (CallExpr* call = toCallExpr(icon->parentExpr)) {
         // unwrap the compiler-inserted where-clause validation if it's there
         if (call->isNamed("chpl_validateWhere")) {

--- a/compiler/passes/normalize.cpp
+++ b/compiler/passes/normalize.cpp
@@ -621,6 +621,7 @@ static void moveAndCheckInterfaceConstraints() {
 
     FnSymbol* fn = toFnSymbol(icon->parentSymbol);
     if (fn != nullptr) {
+      // TODO: I think we know we'll never hit this case now?
       if (BlockStmt* block = toBlockStmt(icon->parentExpr)) {
         if (fn->where == block) {
           icon->remove();
@@ -630,8 +631,14 @@ static void moveAndCheckInterfaceConstraints() {
           continue;
         }
       } else if (CallExpr* call = toCallExpr(icon->parentExpr)) {
-        if (isInWhereBlock(fn, call)) {
-          if (! call->isNamed("&&")) {
+        // unwrap the compiler-inserted where-clause validation if it's there
+        if (call->isNamed("chpl_validateWhere")) {
+          icon->remove();
+          fn->addInterfaceConstraint(icon);
+          call->parentExpr->remove(); // remove the BlockStmt containing it
+          continue;
+        } else if (isInWhereBlock(fn, call)) {
+          if (!call->isNamed("&&")) {
             USR_FATAL_CONT(icon, "combining an 'implements' constraint"
                   " with others is currently supported only using '&&'");
             continue;

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -913,9 +913,11 @@ bool evaluateWhereClause(FnSymbol* fn) {
 
     SymExpr* se = toSymExpr(fn->where->body.last());
 
+    /*
     if (se == NULL) {
       USR_FATAL(fn->where, "invalid where clause");
     }
+    */
 
     if (se->symbol() == gFalse) {
       cleanupWhereClause(fn->where, se);
@@ -927,7 +929,9 @@ bool evaluateWhereClause(FnSymbol* fn) {
       return true;
     }
 
+    /*
     USR_FATAL(fn->where, "invalid where clause");
+    */
   }
 
   return true;

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -913,14 +913,16 @@ bool evaluateWhereClause(FnSymbol* fn) {
 
     SymExpr* se = toSymExpr(fn->where->body.last());
 
-    if (se->symbol() == gFalse) {
+    if (se == NULL) {
+      INT_FATAL("Unexpected expression type after evaluating 'where' clause");
+    } else if (se->symbol() == gFalse) {
       cleanupWhereClause(fn->where, se);
       return false;
-    }
-
-    if (se->symbol() == gTrue) {
+    } else if (se->symbol() == gTrue) {
       cleanupWhereClause(fn->where, se);
       return true;
+    } else {
+      INT_FATAL("Non-param-bool symbol after evaluating 'where' clause");
     }
   }
 

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -913,12 +913,6 @@ bool evaluateWhereClause(FnSymbol* fn) {
 
     SymExpr* se = toSymExpr(fn->where->body.last());
 
-    /*
-    if (se == NULL) {
-      USR_FATAL(fn->where, "invalid where clause");
-    }
-    */
-
     if (se->symbol() == gFalse) {
       cleanupWhereClause(fn->where, se);
       return false;
@@ -928,10 +922,6 @@ bool evaluateWhereClause(FnSymbol* fn) {
       cleanupWhereClause(fn->where, se);
       return true;
     }
-
-    /*
-    USR_FATAL(fn->where, "invalid where clause");
-    */
   }
 
   return true;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -3526,4 +3526,14 @@ module ChapelBase {
 
     return equals;
   }
+
+  proc chpl_validateWhere(param test) param : bool {
+    if test.type != bool then
+      compilerError("a 'where' clause expression must evaluate to a 'param bool', but got a 'param " + test.type:string + "' instead");
+    return test;
+  }
+
+  proc chpl_validateWhere(test) param : bool {
+    compilerError("a 'where' clause expression must be a 'param', but got a non-'param'");
+  }
 }

--- a/test/functions/diten/badwhere.good
+++ b/test/functions/diten/badwhere.good
@@ -1,3 +1,3 @@
 badwhere.chpl:4: In function 'foo':
-badwhere.chpl:4: error: invalid where clause
+badwhere.chpl:4: error: a 'where' clause expression must be a 'param', but got a non-'param'
   badwhere.chpl:1: called as foo(x: string, y: string, z: bool)

--- a/test/functions/whereClauses/whereClauseIntAndArrayArg.chpl
+++ b/test/functions/whereClauses/whereClauseIntAndArrayArg.chpl
@@ -1,0 +1,8 @@
+var ax: [1..10] real = 1.0;
+var yc = wrong(ax);
+proc wrong(
+   const in ax: [] real
+   ): real
+   where (ax.rank == 1): int {
+   return 0.0;
+}

--- a/test/functions/whereClauses/whereClauseIntAndArrayArg.good
+++ b/test/functions/whereClauses/whereClauseIntAndArrayArg.good
@@ -1,0 +1,3 @@
+whereClauseIntAndArrayArg.chpl:3: In function 'wrong':
+whereClauseIntAndArrayArg.chpl:3: error: a 'where' clause expression must evaluate to a 'param bool', but got a 'param int(64)' instead
+  whereClauseIntAndArrayArg.chpl:1: called as wrong(ax: [domain(1,int(64),one)] real(64))

--- a/test/functions/whereClauses/whereClauseNonParam.good
+++ b/test/functions/whereClauses/whereClauseNonParam.good
@@ -1,2 +1,2 @@
 whereClauseNonParam.chpl:1: In function 'foo':
-whereClauseNonParam.chpl:1: error: invalid where clause
+whereClauseNonParam.chpl:1: error: a 'where' clause expression must be a 'param', but got a non-'param'

--- a/test/functions/whereClauses/whereClauseNonParamGeneric.good
+++ b/test/functions/whereClauses/whereClauseNonParamGeneric.good
@@ -1,3 +1,3 @@
 whereClauseNonParamGeneric.chpl:1: In function 'foo':
-whereClauseNonParamGeneric.chpl:1: error: invalid where clause
+whereClauseNonParamGeneric.chpl:1: error: a 'where' clause expression must be a 'param', but got a non-'param'
   whereClauseNonParamGeneric.chpl:1: called as foo(x: int(64), y: int(64))

--- a/test/functions/whereClauses/whereClauseReal.chpl
+++ b/test/functions/whereClauses/whereClauseReal.chpl
@@ -1,0 +1,6 @@
+var ax: [1..10] real = 1.0;
+var yc = wrong();
+proc wrong(): real
+  where (ax.rank == 1): real {
+   return 0.0;
+}

--- a/test/functions/whereClauses/whereClauseReal.good
+++ b/test/functions/whereClauses/whereClauseReal.good
@@ -1,0 +1,2 @@
+whereClauseReal.chpl:3: In function 'wrong':
+whereClauseReal.chpl:3: error: a 'where' clause expression must evaluate to a 'param bool', but got a 'param real(64)' instead

--- a/test/functions/whereClauses/whereClauseRealAndArrayArg.chpl
+++ b/test/functions/whereClauses/whereClauseRealAndArrayArg.chpl
@@ -1,0 +1,8 @@
+var ax: [1..10] real = 1.0;
+var yc = wrong(ax);
+proc wrong(
+   const in ax: [] real
+   ): real
+   where (ax.rank == 1): real {
+   return 0.0;
+}

--- a/test/functions/whereClauses/whereClauseRealAndArrayArg.good
+++ b/test/functions/whereClauses/whereClauseRealAndArrayArg.good
@@ -1,0 +1,3 @@
+whereClauseRealAndArrayArg.chpl:3: In function 'wrong':
+whereClauseRealAndArrayArg.chpl:3: error: a 'where' clause expression must evaluate to a 'param bool', but got a 'param real(64)' instead
+  whereClauseRealAndArrayArg.chpl:1: called as wrong(ax: [domain(1,int(64),one)] real(64))


### PR DESCRIPTION
This is a simple approach to improving `where` clause errors by leveraging a (new) internal module helper routine that checks whether the expression is a `param bool` or not and generates a helpful error when it's not.

The implementation is complicated somewhat by `implements` clauses, as the compiler's processing of them assumes a certain structural form—either that the `implements` is the top-level expression, or that it's part of an `&&` expression.  Here, I updated the pass that pulls `implements` clauses out of `where` clauses to reflect the new structure caused by the helper routine.

Implementation essentially involved:
* adding the helper routine, `chpl_validateWhere()` to `modules/internal/ChapelBase.chpl`
* adding a call to it in `compiler/AST/build.cpp`
* removing the old, vague compiler-generated messages about badly-formed `where` clauses from `compiler/resolution/generics.cpp`, as the new ones supercede them
* updating the processing of `implements` in `compiler/passes/normalize.cpp` to be aware of the new structure
  * I also added more failure messages in the event that the structure is not as expected where before, they could seemingly fall through silently in some cases(?)
* adding tests from #28882 to lock in behavior and updating tests that used the old error message wording

Resolves #28882