### PR TITLE
Add 15 day update delay (cooldown) to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 15


### PR DESCRIPTION
Set the [`cooldown` option on Dependabot](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) to be more conservative in Actions updates, to reduce risk of being bitten by a supply-chain attack.

Currently set to 15 days.

[reviewed by @jabraham17 , thanks!]