### PR TITLE
Fix debugger breakpoints in the compiler with LLDB 22+

### DIFF
--- a/compiler/etc/chpl_lldb_debuggerBreakHere.py
+++ b/compiler/etc/chpl_lldb_debuggerBreakHere.py
@@ -1,15 +1,58 @@
-def debuggerBreakHere_callback(frame, bp_loc, internal_dict):
-    thread = frame.GetThread()
-    thread.SetSelectedFrame(1)
+import lldb
 
-    curFrame = thread.GetSelectedFrame()
-    fn = curFrame.GetFunction()
-    if fn and fn.name.startswith("debuggerBreakHere("):
-        thread.SetSelectedFrame(2)
+
+class DebuggerBreakHereStopHook:
+    def __init__(self, target, extra_args, internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, stream):
+        thread = exe_ctx.GetThread()
+        if not thread or not thread.IsValid():
+            return True
+
+        # only do something if we hit the debuggerBreakHere breakpoint
+        stopReason = thread.GetStopReason()
+        if stopReason != lldb.eStopReasonBreakpoint:
+            return True
+        count = thread.GetStopReasonDataCount()
+        if count < 2:
+            return True
+        brkId = thread.GetStopReasonDataAtIndex(0)
+        breakpointInfo = (
+            thread.GetProcess().GetTarget().FindBreakpointByID(brkId)
+        )
+        isNamedDebuggerBreakHere = (
+            breakpointInfo
+            and breakpointInfo.IsValid()
+            and breakpointInfo.MatchesName("debuggerBreakHere")
+        )
+        numLocations = breakpointInfo.GetNumLocations()
+        if numLocations < 1:
+            return True
+        location = breakpointInfo.GetLocationAtIndex(0)
+        if not location or not location.IsValid():
+            return True
+        breakFunc = location.GetAddress().GetFunction()
+        isBreakOnDebuggerBreakHere = (
+            breakFunc
+            and breakFunc.IsValid()
+            and breakFunc.GetName().startswith("debuggerBreakHere(")
+        )
+
+        if not (isNamedDebuggerBreakHere or isBreakOnDebuggerBreakHere):
+            return True
+
+        thread.SetSelectedFrame(1)
+
+        curFrame = thread.GetSelectedFrame()
+        fn = curFrame.GetFunction()
+        if fn and fn.name.startswith("debuggerBreakHere("):
+            thread.SetSelectedFrame(2)
+        return True
 
 
 def __lldb_init_module(debugger, internal_dict):
-    debugger.HandleCommand("breakpoint command delete debuggerBreakHere")
+    debugger.HandleCommand("target stop-hook delete 1")
     debugger.HandleCommand(
-        "breakpoint command add --python-function chpl_lldb_debuggerBreakHere.debuggerBreakHere_callback debuggerBreakHere"
+        "target stop-hook add --script-class chpl_lldb_debuggerBreakHere.DebuggerBreakHereStopHook"
     )


### PR DESCRIPTION
Fixes the debugger breakpoints for the compiler with new LLDB versions, similar to https://github.com/chapel-lang/chapel/pull/28836

[Reviewed by @benharsh]