### PR TITLE
Make 'CHPL_COMM' a launcher-visible constant

### DIFF
--- a/runtime/include/chpl-prginfo-data-macro.h
+++ b/runtime/include/chpl-prginfo-data-macro.h
@@ -277,7 +277,7 @@ E_CALLBACK_RT(chpl_localeModel_sublocToExecutionSubloc, c_sublocid_t,
 /** CODE-GENERATED
     Value of '$CHPL_COMM' when this program was compiled.
 */
-E_CONSTANT_RT(CHPL_COMM, const char*)
+E_CONSTANT(CHPL_COMM, const char*)
 
 /** CODE-GENERATED
     If '--stack-checks' was set when this program was compiled.


### PR DESCRIPTION
Try to fix a nightly test failure. The `mpicc` launcher needs to read `CHPL_COMM`, but I had accidentally marked that as a runtime-only constant. Adjust so that both the launchers and runtime can see it.