### PR TITLE
Larger Spectral Norm Benchmark Case

### DIFF
--- a/test/GRAPHFILES
+++ b/test/GRAPHFILES
@@ -147,6 +147,7 @@ studies/shootout/submitted/regexdna-submitted.graph
 studies/shootout/submitted/regexdnaredux-submitted.graph
 studies/shootout/submitted/revcomp-submitted.graph
 studies/shootout/submitted/spectralnorm-submitted.graph
+studies/shootout/submitted/spectralnorm-submitted-40000.graph
 # suite: Shootout extras
 studies/shootout/fasta/fasta-extras.graph
 studies/shootout/fasta/fastaredux.graph

--- a/test/studies/shootout/submitted/spectralnorm-submitted-40000.graph
+++ b/test/studies/shootout/submitted/spectralnorm-submitted-40000.graph
@@ -1,0 +1,5 @@
+perfkeys: real, real
+graphkeys: release, submitted, submitted (2)
+files: spectralnorm-submitted-40000.dat, spectralnorm2-40000.dat
+graphtitle: Submitted Spectral Norm Shootout Benchmark for 40000x40000
+ylabel: Time (seconds)

--- a/test/studies/shootout/submitted/spectralnorm.perfexecopts
+++ b/test/studies/shootout/submitted/spectralnorm.perfexecopts
@@ -1,1 +1,2 @@
 --n=5500
+--n=40000 # spectralnorm-submitted-40000

--- a/test/studies/shootout/submitted/spectralnorm2.perfexecopts
+++ b/test/studies/shootout/submitted/spectralnorm2.perfexecopts
@@ -1,1 +1,2 @@
 --n=5500  # spectralnorm2
+--n=40000 # spectralnorm2-submitted-40000


### PR DESCRIPTION
This adds a larger spectral norm benchmark case since the existing problem sizes result in near trivial running times.