### PR TITLE
dlopen: Adjust the implementation of "broadcasting global variables"

### DIFF
--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -1191,10 +1191,6 @@ initPrimitive() {
 
   prim_def(PRIM_REGISTER_GLOBAL_VAR, "_register_global_var", returnInfoVoid, true, true);
   prim_def(PRIM_BROADCAST_GLOBAL_VARS, "_broadcast_global_vars", returnInfoVoid, true, true);
-  // ('_private_broadcast' sym)
-  // Later, a structure index is inserted ahead
-  // of the symbol, so it ends up as
-  // ('_private_broadcast' index sym).
   prim_def(PRIM_PRIVATE_BROADCAST, "_private_broadcast", returnInfoVoid, true);
 
   prim_def(PRIM_INT_ERROR, "_internal_error", returnInfoVoid, true);

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -6205,8 +6205,14 @@ DEFINE_PRIM(REGISTER_GLOBAL_VAR) {
     codegenCall("chpl_registerGlobalVar", idx,
                 codegenCast("ptr_wide_ptr_t", ptr_wide_ptr));
 }
+
+// TODO: Mark this as a primitive that needs line/file information?
 DEFINE_PRIM(BROADCAST_GLOBAL_VARS) {
-    codegenCall("chpl_comm_broadcast_global_vars", call->get(1));
+  // Call the module code wrapper.
+  std::vector<GenRet> args(2);
+  args[0] = call->linenum();
+  args[1] = new_IntSymbol(getFilenameTableIndex(call->fname()), INT_SIZE_32);
+  codegenCallWithArgs("chpl_broadcastGlobalVars", args);
 }
 DEFINE_PRIM(PRIVATE_BROADCAST) {
     codegenCall("chpl_comm_broadcast_private",

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -6206,14 +6206,14 @@ DEFINE_PRIM(REGISTER_GLOBAL_VAR) {
                 codegenCast("ptr_wide_ptr_t", ptr_wide_ptr));
 }
 
-// TODO: Mark this as a primitive that needs line/file information?
 DEFINE_PRIM(BROADCAST_GLOBAL_VARS) {
   // Call the module code wrapper.
   std::vector<GenRet> args(2);
-  args[0] = call->linenum();
-  args[1] = new_IntSymbol(getFilenameTableIndex(call->fname()), INT_SIZE_32);
+  args[0] = call->get(1);   // Line
+  args[1] = call->get(2);   // File
   codegenCallWithArgs("chpl_broadcastGlobalVars", args);
 }
+
 DEFINE_PRIM(PRIVATE_BROADCAST) {
     codegenCall("chpl_comm_broadcast_private",
                 call->get(1),

--- a/compiler/passes/insertWideReferences.cpp
+++ b/compiler/passes/insertWideReferences.cpp
@@ -2007,7 +2007,7 @@ static void heapAllocateGlobalsTail(FnSymbol* heapAllocateGlobals,
   for_vector(Symbol, sym, heapVars) {
     heapAllocateGlobals->insertAtTail(new CallExpr(PRIM_REGISTER_GLOBAL_VAR, new_IntSymbol(i++), sym));
   }
-  heapAllocateGlobals->insertAtTail(new CallExpr(PRIM_BROADCAST_GLOBAL_VARS, new_IntSymbol(i)));
+  heapAllocateGlobals->insertAtTail(new CallExpr(PRIM_BROADCAST_GLOBAL_VARS));
   heapAllocateGlobals->insertAtTail(new CallExpr(PRIM_RETURN, gVoid));
   numGlobalsOnHeap = i;
 }

--- a/modules/internal/ChapelRuntimeInterface.chpl
+++ b/modules/internal/ChapelRuntimeInterface.chpl
@@ -19,9 +19,11 @@
  */
 
 module ChapelRuntimeInterface {
-  use ChapelBase, CTypes;
+  use ChapelBase, ChapelProgramRegistration, CTypes;
 
   extern type wide_ptr_t;
+
+  inline proc ptrToPrgInfoHere do return chpl_programInfoHere.asPtr();
 
   // The compiler will generate code that calls this procedure in order to
   // deterministically populate the 'chpl_globals_registry' on all locales.
@@ -30,5 +32,18 @@ module ChapelRuntimeInterface {
     // Extern, but declared by the compiler and lives in program code.
     extern var chpl_globals_registry: c_ptr(c_ptr(wide_ptr_t));
     chpl_globals_registry[idx] = ptrToWidePtr;
+  }
+
+  // These pragmas will be useful for debugging what is going on when a RT
+  // shim is called. As well, some runtime functions need this information
+  // to be passed.
+  //
+  // TODO: Replace me with a new pragma that means the same thing.
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  export proc chpl_broadcastGlobalVars() {
+    param cname = 'chpl_rt_comm_broadcast_global_vars';
+    extern cname proc fn(prg: c_ptr(chpl_rt_prginfo)): void;
+    fn(ptrToPrgInfoHere);
   }
 }

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -24,20 +24,21 @@
 #include <stdint.h>
 #include "chpltypes.h"
 #include "chpl-mem-desc.h"
+#include "chpl-prginfo.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 //
-// Support for broadcasting globals.  Comm layer implementations must
-// supply this.  It is called collectively.  On node 0 it must arrange
+// Support for broadcasting globals. Comm layer implementations must
+// supply this. It is called collectively. On node 0 it must arrange
 // that all the global variable wide pointers are in a buffer that can
 // be the source of a GET from the other nodes and return either that
-// buffer's address (if it wants it freed later) or NULL.  On all other
+// buffer's address (if it wants it freed later) or NULL. On all other
 // nodes it should return the node-0 local address of that buffer.
 //
-wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void);
+wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg);
 
 //
 // These are runtime-private copies of chpl_private_broadcast_table[]

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -32,6 +32,7 @@
 #include "chpl-comm-locales.h"
 #include "chpl-mem-consistency.h"
 #include "chpl-mem-desc.h"
+#include "chpl-prginfo.h"
 #include "chplcgfns.h"
 
 #ifdef __cplusplus
@@ -352,7 +353,7 @@ chpl_bool chpl_comm_regMemFree(void* p, size_t size) {
 // on that locale. Then, the compiler invokes this function in order to
 // broadcast and set the wide pointers on each locale.
 //
-void chpl_comm_broadcast_global_vars(int numGlobals);
+void chpl_rt_comm_broadcast_global_vars(chpl_rt_prginfo* prg);
 
 //
 // This routine is used by the generated Chapel code to broadcast

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -57,7 +57,7 @@ void chpl_rt_comm_broadcast_global_vars(chpl_rt_prginfo* prg) {
   //            after the communication, otherwise NULL.
   // On other nodes: retrieve the node 0 local address of that buffer.
   //
-  wide_ptr_t* buf_on_0 = chpl_comm_broadcast_global_vars_helper();
+  wide_ptr_t* buf_on_0 = chpl_rt_comm_broadcast_global_vars_impl(prg);
 
   //
   // On node 0: barrier to ensure the other nodes have the global vars;

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -50,15 +50,14 @@ static int32_t   localRank = -1;
 static int32_t   numColocalesOnNode = 1;
 
 
-void chpl_comm_broadcast_global_vars(int numGlobals) {
+void chpl_rt_comm_broadcast_global_vars(chpl_rt_prginfo* prg) {
   //
   // On node 0: gather up the global variables' wide pointers into a
   //            buffer; return that buffer if it needs deallocating
   //            after the communication, otherwise NULL.
   // On other nodes: retrieve the node 0 local address of that buffer.
   //
-  wide_ptr_t* buf_on_0;
-  buf_on_0 = chpl_comm_broadcast_global_vars_helper();
+  wide_ptr_t* buf_on_0 = chpl_comm_broadcast_global_vars_helper();
 
   //
   // On node 0: barrier to ensure the other nodes have the global vars;
@@ -77,10 +76,8 @@ void chpl_comm_broadcast_global_vars(int numGlobals) {
       chpl_mem_free(buf_on_0, 0, 0);
     }
   } else {
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_globals_registry);
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_numGlobalsOnHeap);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_globals_registry);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_numGlobalsOnHeap);
 
     wide_ptr_t* buf;
     size_t size = chpl_numGlobalsOnHeap * sizeof(*buf);

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1180,7 +1180,21 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
     CHPL_RT_PRGINFO_DECLARE(prg, chpl_globals_registry);
     CHPL_RT_PRGINFO_DECLARE(prg, chpl_numGlobalsOnHeap);
 
+    // TODO: This is racey. How do we prevent that?
+    // TODO: A quick hack here is to just allocate some large segment e.g.,
+    //       say 1024 wide pointers long and error if a program exceeds that
+    //       number of global variables.
+    // TODO: And then we can just adjust the caller algorithm to work in
+    //       chunks of e.g., 1024 in the case that there are more globals.
+    int needed_global_table_size = chpl_numGlobalsOnHeap * sizeof(wide_ptr_t)
+                                 + GASNETT_PAGESIZE;
+    if (needed_global_table_size > seginfo_table[0].size) {
+      chpl_internal_error("gasnet segment used to communicate global vars "
+                          "is not large enough");
+    }
+
     for (int i = 0; i < chpl_numGlobalsOnHeap; i++) {
+      // Populate the segment buffer with the wide pointer values from L0.
       ((wide_ptr_t*) seginfo_table[0].addr)[i] = *chpl_globals_registry[i];
     }
     chpl_comm_barrier("fill node 0 globals buf");

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1168,7 +1168,7 @@ void chpl_comm_impl_regMemHeapInfo(void** start_p, size_t* size_p) {
 #endif
 }
 
-wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
+wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
   //
   // Gather the global variables' wide pointers on node 0 into the
   // buffer at the front of our communicable segment.  We don't have
@@ -1177,10 +1177,8 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
   // node 0 has filled in that buffer, however.
   //
   if (chpl_nodeID == 0) {
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_globals_registry);
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_numGlobalsOnHeap);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_globals_registry);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_numGlobalsOnHeap);
 
     for (int i = 0; i < chpl_numGlobalsOnHeap; i++) {
       ((wide_ptr_t*) seginfo_table[0].addr)[i] = *chpl_globals_registry[i];

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -245,7 +245,9 @@ void chpl_comm_rollcall(void) {
   chpl_msg(2, "executing on a single node\n");
 }
 
-wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) { return NULL; }
+wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
+  return NULL;
+}
 
 void chpl_comm_broadcast_private(int id, size_t size) { }
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3309,7 +3309,7 @@ void chpl_comm_rollcall(void) {
 // Chapel global and private variable support
 //
 
-wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
+wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
   DBG_PRINTF(DBG_IFACE_SETUP, "%s()", __func__);
 
   //
@@ -3320,10 +3320,8 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
 
   wide_ptr_t* buf = NULL;
   if (chpl_nodeID == 0) {
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_globals_registry);
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_numGlobalsOnHeap);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_globals_registry);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_numGlobalsOnHeap);
 
     CHPL_CALLOC(buf, chpl_numGlobalsOnHeap);
     for (int i = 0; i < chpl_numGlobalsOnHeap; i++) {

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3914,7 +3914,7 @@ void regMemBroadcast(int mr_i, int mr_cnt, chpl_bool send_mreg_cnt)
 }
 
 
-wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
+wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
   //
   // Gather the global variables' wide pointers on node 0 into a
   // buffer, and broadcast the address of that buffer to the other
@@ -3922,10 +3922,8 @@ wide_ptr_t* chpl_comm_broadcast_global_vars_helper(void) {
   //
   wide_ptr_t* buf;
   if (chpl_nodeID == 0) {
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_globals_registry);
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                            chpl_numGlobalsOnHeap);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_globals_registry);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_numGlobalsOnHeap);
 
     buf = (wide_ptr_t*) chpl_mem_allocMany(chpl_numGlobalsOnHeap, sizeof(*buf),
                                            CHPL_RT_MD_COMM_PER_LOC_INFO, 0, 0);


### PR DESCRIPTION
This PR adjusts the implementation of "broadcasting global variables" in the runtime to be sensitive to multiple Chapel programs. It focuses on the gasnet comm layer.

It renames the runtime function to `chpl_rt_broadcast_global_vars` (adding the `_rt_` prefix). It renames the per-comm-layer implementation to have the `_rt_` prefix and the suffix `_impl` to establish a convention. It adds a module-code shim called `chpl_broadcastGlobalVars` which the compiler uses during codegen. I've dropped the `numGlobals` argument of the function since it was never used. I've also adjusted codegen for the primitive the compiler uses to properly pass along line/file info.

Future work for the gasnet comm layer will need to adjust the memory segment that is used to communicate the L0 globals. Right now, we hard crash by calling `chpl_internal_error` if the space required by a new program is greater than the root program. A better strategy might be to use some fixed segment size and adjust the caller algorithm to work in batches if needed, or to just reallocate and re-register the segment.

TESTING

- [x] `standard`
- [x] `COMM=gasnet`
- [x] `COMM=gasnet`, `COMPILER=gnu`
- [x] Build with `COMM=ofi`
- [x] Build with `gasnet-asan` and run `fastAndIncremental.chpl`

Reviewed by @jabraham17. Thanks!