### PR TITLE
SHA pin version of all Github Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
     - name: make check
       run: |
         ./util/buildRelease/smokeTest chpl
@@ -39,7 +39,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
     - name: make frontend-docs
       run: |
         make frontend-docs
@@ -50,7 +50,7 @@ jobs:
         ./util/buildRelease/smokeTest quickstart chapel-py docs
         tar -cvf docs.tar.gz -C doc/html .
     - name: upload docs
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: documentation
         path: docs.tar.gz
@@ -63,7 +63,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
     - name: make mason
       # Use a quickstart config to keep it from running to long
       # While there, run a make check in that config for more coverage
@@ -78,7 +78,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
     - name: run dyno linters
       run: |
         CHPL_HOME=$PWD CHPL_HOST_COMPILER=clang make run-dyno-linters
@@ -91,7 +91,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
     - name: make test-dyno-with-asserts
       # 'make modules' so the ChapelSysCTypes module is available
       run: |
@@ -116,7 +116,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
     - name: set llvm_none make check
       run: |
        CHPL_LLVM=none ./util/buildRelease/smokeTest chpl
@@ -128,7 +128,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 100000
     - name: Set ownership
@@ -157,7 +157,7 @@ jobs:
       - name: count PR commits
         run: echo "PR_NUM_COMMITS=$(( ${{ github.event.pull_request.commits }} + 2 ))" >> "${GITHUB_ENV}"
       - name: checkout commits on PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: ${{ env.PR_NUM_COMMITS }}
       - name: check commits for large files
@@ -210,7 +210,7 @@ jobs:
     needs: make_doc
     steps:
       - name: download docs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: documentation
 
@@ -221,7 +221,7 @@ jobs:
           echo "${{ secrets.WEBSITE_KNOWN_HOSTS}}" > ~/.ssh/known_hosts
 
       - name: push docs (retrying)
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@v4.0.0
         with:
           max_attempts: 3
           timeout_seconds: 60

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: make check
       run: |
         ./util/buildRelease/smokeTest chpl
@@ -39,7 +39,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: make frontend-docs
       run: |
         make frontend-docs
@@ -50,7 +50,7 @@ jobs:
         ./util/buildRelease/smokeTest quickstart chapel-py docs
         tar -cvf docs.tar.gz -C doc/html .
     - name: upload docs
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: documentation
         path: docs.tar.gz
@@ -63,7 +63,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: make mason
       # Use a quickstart config to keep it from running to long
       # While there, run a make check in that config for more coverage
@@ -78,7 +78,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: run dyno linters
       run: |
         CHPL_HOME=$PWD CHPL_HOST_COMPILER=clang make run-dyno-linters
@@ -91,7 +91,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: make test-dyno-with-asserts
       # 'make modules' so the ChapelSysCTypes module is available
       run: |
@@ -116,7 +116,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: set llvm_none make check
       run: |
        CHPL_LLVM=none ./util/buildRelease/smokeTest chpl
@@ -128,7 +128,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 100000
     - name: Set ownership
@@ -157,7 +157,7 @@ jobs:
       - name: count PR commits
         run: echo "PR_NUM_COMMITS=$(( ${{ github.event.pull_request.commits }} + 2 ))" >> "${GITHUB_ENV}"
       - name: checkout commits on PR branch
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: ${{ env.PR_NUM_COMMITS }}
       - name: check commits for large files
@@ -210,7 +210,7 @@ jobs:
     needs: make_doc
     steps:
       - name: download docs
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: documentation
 
@@ -221,7 +221,7 @@ jobs:
           echo "${{ secrets.WEBSITE_KNOWN_HOSTS}}" > ~/.ssh/known_hosts
 
       - name: push docs (retrying)
-        uses: nick-fields/retry@v4.0.0
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 3
           timeout_seconds: 60

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -37,7 +37,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4.1.0
         with:

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -37,22 +37,22 @@ jobs:
       packages: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Docker Image
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: ${{ env.DOCKERFILE }}
           # example: ghcr.io/chapel-lang/chapel-github-ci:latest
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
       - name: Push Docker Image if on main
         if: github.repository_owner == 'chapel-lang' && ((github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') || (github.event_name == 'schedule'))
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           file: ${{ env.DOCKERFILE }}
           push: true

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -30,7 +30,7 @@ jobs:
               echo "FILES_CHANGED=$(echo '$PR_LINK/files' )" >> $GITHUB_ENV
 
       - name: checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.
         with:
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
               echo 'EOF' >> $GITHUB_ENV
 
       - name: Send mail
-        uses: dawidd6/action-send-mail@v17
+        uses: dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c # v17
         with:
            # Required mail server address if not connection_url:
            server_address: ${{ secrets.SMTP_PROVIDER}}

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -30,7 +30,7 @@ jobs:
               echo "FILES_CHANGED=$(echo '$PR_LINK/files' )" >> $GITHUB_ENV
 
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         # To get git diff on the files that were changed in the PR checkout with fetch-depth 2.
         with:
           fetch-depth: 0

--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout this repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Fetch released version of Chapel formula
       run: |

--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout this repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v6.0.2
 
     - name: Fetch released version of Chapel formula
       run: |

--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: psf/black@stable
+      - uses: psf/black@26.5.1
         with:
           options: "--check --verbose --line-length 80 --extend-exclude '^/(third-party|test)/'"
           src: "."
-      - uses: psf/black@stable
+      - uses: psf/black@26.5.1
         with:
           options: "--check --verbose --line-length 80 --extend-exclude '(install|build)/'"
           src: "third-party/chpl-venv"

--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -6,7 +6,7 @@ jobs:
   check-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - uses: psf/black@26.5.1
         with:
           options: "--check --verbose --line-length 80 --extend-exclude '^/(third-party|test)/'"

--- a/.github/workflows/python-format-CI.yml
+++ b/.github/workflows/python-format-CI.yml
@@ -6,12 +6,12 @@ jobs:
   check-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: psf/black@26.5.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # 26.5.1
         with:
           options: "--check --verbose --line-length 80 --extend-exclude '^/(third-party|test)/'"
           src: "."
-      - uses: psf/black@26.5.1
+      - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # 26.5.1
         with:
           options: "--check --verbose --line-length 80 --extend-exclude '(install|build)/'"
           src: "third-party/chpl-venv"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,7 +9,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v6
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           severity: error
           ignore_paths: ./test/* ./third-party/*

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0
         with:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           severity: error
           ignore_paths: ./test/* ./third-party/*

--- a/.github/workflows/test-language-server.yml
+++ b/.github/workflows/test-language-server.yml
@@ -16,7 +16,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: test chpl-language-server
       run: |
         make test-chpl-language-server -j`util/buildRelease/chpl-make-cpu_count`

--- a/.github/workflows/test-language-server.yml
+++ b/.github/workflows/test-language-server.yml
@@ -16,7 +16,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
     - name: test chpl-language-server
       run: |
         make test-chpl-language-server -j`util/buildRelease/chpl-make-cpu_count`


### PR DESCRIPTION
Pin every Github Action we use to a full SHA version.

As part of this, I changed the version specifier (which is now only visible in a comment) to full tag names (`v6` -> `v6.0.2`). I'm hoping Dependabot version updates are smart enough to update this, and feared they might not be for the abbreviated names, but in any case it doesn't hurt.

I manually set all versions to a full tag name (including changing `psf/black@stable` to its latest release, and `ludeeus/action-shellcheck` from an existing SHA pin to its latest release), then ran the tool https://github.com/mheap/pin-github-action to SHA pin everything. I didn't manually check the SHAs it came up with, since 1) if it gave a non-existent SHA, the workflow run will fail and we'll catch it, and 2) if it gave a SHA that isn't the latest release, the next Dependabot run will update it.

Once this is merged, I think we should turn on the setting to require that all Actions are SHA-pinned to run (https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions).

[reviewed by @jabraham17 , thanks!]