### PR TITLE
dlopen: Clean up RT's private broadcast API and adjust gasnet

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -6215,9 +6215,13 @@ DEFINE_PRIM(BROADCAST_GLOBAL_VARS) {
 }
 
 DEFINE_PRIM(PRIVATE_BROADCAST) {
-    codegenCall("chpl_comm_broadcast_private",
-                call->get(1),
-                codegenSizeof(call->get(2)->typeInfo()));
+  // Call the module code wrapper.
+  std::vector<GenRet> args(4);
+  args[0] = call->get(1);
+  args[1] = codegenSizeof(call->get(2)->typeInfo());
+  args[2] = call->linenum();
+  args[3] = new_IntSymbol(getFilenameTableIndex(call->fname()), INT_SIZE_32);
+  codegenCallWithArgs("chpl_broadcastPrivate", args);
 }
 
 DEFINE_PRIM(INT_ERROR) {

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -6221,7 +6221,7 @@ DEFINE_PRIM(PRIVATE_BROADCAST) {
   args[1] = codegenSizeof(call->get(2)->typeInfo());
   args[2] = call->linenum();
   args[3] = new_IntSymbol(getFilenameTableIndex(call->fname()), INT_SIZE_32);
-  codegenCallWithArgs("chpl_broadcastPrivate", args);
+  codegenCallWithArgs("chpl_privateBroadcast", args);
 }
 
 DEFINE_PRIM(INT_ERROR) {

--- a/modules/internal/ChapelRuntimeInterface.chpl
+++ b/modules/internal/ChapelRuntimeInterface.chpl
@@ -46,4 +46,14 @@ module ChapelRuntimeInterface {
     extern cname proc fn(prg: c_ptr(chpl_rt_prginfo)): void;
     fn(ptrToPrgInfoHere);
   }
+
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  export proc chpl_broadcastPrivate(idx: int(32), size: c_size_t) {
+    param cname = 'chpl_rt_comm_broadcast_private';
+    extern cname proc fn(prg: c_ptr(chpl_rt_prginfo),
+                         idx: int(32),
+                         size: c_size_t): void;
+    fn(ptrToPrgInfoHere, idx, size);
+  }
 }

--- a/modules/internal/ChapelRuntimeInterface.chpl
+++ b/modules/internal/ChapelRuntimeInterface.chpl
@@ -49,8 +49,8 @@ module ChapelRuntimeInterface {
 
   pragma "insert line file info"
   pragma "always propagate line file info"
-  export proc chpl_broadcastPrivate(idx: int(32), size: c_size_t) {
-    param cname = 'chpl_rt_comm_broadcast_private';
+  export proc chpl_privateBroadcast(idx: int(32), size: c_size_t) {
+    param cname = 'chpl_rt_comm_private_broadcast';
     extern cname proc fn(prg: c_ptr(chpl_rt_prginfo),
                          idx: int(32),
                          size: c_size_t): void;

--- a/runtime/include/chpl-comm-diags.h
+++ b/runtime/include/chpl-comm-diags.h
@@ -28,6 +28,7 @@
 #include "chpl-comm.h"
 #include "chpl-error.h"
 #include "chpl-unwind.h"
+#include "chplcgfns.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -121,9 +122,6 @@ void chpl_comm_diags_copy(chpl_commDiagnostics* cd) {
   CHPL_COMM_DIAGS_VARS_ALL(_COMM_DIAGS_COPY);
 #undef _COMM_DIAGS_COPY
 }
-
-extern chpl_bool chpl_task_setCommDiagsTemporarilyDisabled(chpl_bool);
-extern chpl_bool chpl_task_getCommDiagsTemporarilyDisabled(void);
 
 #define chpl_comm_diags_verbose_printf(is_unstable, format, ...)   \
   do {                                                             \

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -83,9 +83,12 @@ static inline
 void chpl_comm_really_bcast_rt_private(int id) {
   CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
                           chpl_private_broadcast_table_len);
-  chpl_comm_broadcast_private(chpl_private_broadcast_table_len + id,
-                              chpl_rt_priv_bcast_lens[id]);
+  chpl_rt_comm_broadcast_private(NULL, chpl_private_broadcast_table_len + id,
+                                 chpl_rt_priv_bcast_lens[id]);
 }
+
+void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
+                                         size_t size);
 
 #ifdef __cplusplus
 }

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -40,55 +40,74 @@ extern "C" {
 //
 wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg);
 
-//
-// These are runtime-private copies of chpl_private_broadcast_table[]
-// and chpl_private_broadcast_table_len, extended with a few more
-// addresses of runtime-specific variables we also want to be able
-// broadcast around.
-//
-extern void** chpl_rt_priv_bcast_tab;
-extern int chpl_rt_priv_bcast_tab_len;
-extern size_t chpl_rt_priv_bcast_lens[];
+// This "unified" table is allocated at runtime and merges the address table
+// of the root program and the runtime together. This approach is not
+// compatible with dynamic loading, but some comm layers (such as 'ofi') rely
+// upon it and have not been adjusted yet.
+extern void** chpl_rt_unified_private_broadcast_table;
+extern int chpl_rt_unified_private_broadcast_table_len;
 
-#define CHPL_RT_PRV_BCAST_TAB_ENTRIES(MACRO) \
-  MACRO(chpl_verbose_comm)                   \
-  MACRO(chpl_comm_diagnostics)               \
-  MACRO(chpl_comm_diags_print_unstable)      \
-  MACRO(chpl_verbose_comm_stacktrace)        \
-  MACRO(chpl_verbose_gpu)                   \
-  MACRO(chpl_gpu_diagnostics)               \
-  MACRO(chpl_gpu_diags_print_unstable)      \
-  MACRO(chpl_verbose_gpu_stacktrace)        \
-  MACRO(chpl_verbose_mem)
+// Called by the comm layer to initialize the unified broadcast table.
+void chpl_rt_comm_init_unified_private_broadcast_table(void);
 
-#define _RT_PRV_BCAST_M(sym)  chpl_rt_prv_tab_ ## sym ## _idx,
-typedef enum {
-  CHPL_RT_PRV_BCAST_TAB_ENTRIES(_RT_PRV_BCAST_M)
-  chpl_rt_prv_tab_num_idxs,
-} chpl_rt_prv_bcast_tab_idx_t;
-#undef _RT_PRV_BCAST_M
+// Each program has a table of broadcastable symbols, and so does the runtime.
+extern void* chpl_rt_private_broadcast_table_for_rt[];
+extern size_t chpl_rt_private_broadcast_table_for_rt_len;
+extern size_t chpl_rt_private_broadcast_table_for_rt_byte_lens[];
 
-//
-// This is in chpl-comm.c.
-//
-void chpl_comm_init_prv_bcast_tab(void);
+// These are entries for broadcastable symbols that the runtime needs.
+// They do NOT include any per-program symbols. Those can be found
+// in the 'chpl_rt_prginfo*' for a given Chapel program.
+#define CHPL_RT_RUNTIME_PRIVATE_BROADCAST_TABLE_ENTRIES(MACRO__)  \
+  MACRO__(chpl_verbose_comm)                                      \
+  MACRO__(chpl_comm_diagnostics)                                  \
+  MACRO__(chpl_comm_diags_print_unstable)                         \
+  MACRO__(chpl_verbose_comm_stacktrace)                           \
+  MACRO__(chpl_verbose_gpu)                                       \
+  MACRO__(chpl_gpu_diagnostics)                                   \
+  MACRO__(chpl_gpu_diags_print_unstable)                          \
+  MACRO__(chpl_verbose_gpu_stacktrace)                            \
+  MACRO__(chpl_verbose_mem)
 
-//
-// Broadcast one of our runtime-specific variables.
-//
-#define chpl_comm_bcast_rt_private(var) \
-  chpl_comm_really_bcast_rt_private(chpl_rt_prv_tab_ ## var ## _idx)
+// Helper macros for managing the table of runtime symbols.
+#define CHPL_RT_BCAST_TABLE_FOR_RT_PREFIX \
+  chpl_rt_runtime_private_broadcast_table_for_rt_
+#define CHPL_RT_BCAST_TABLE_FOR_RT_ENTRY(sym__) \
+  CHPL_RT_TABLE_PREFIX ## sym__ ## _idx
+#define CHPL_RT_BCAST_TABLE_FOR_RT_ENUM_ENTRY(sym__) \
+  CHPL_RT_TABLE_PREFIX ## sym__ ## _idx ,
 
-static inline
-void chpl_comm_really_bcast_rt_private(int id) {
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                          chpl_private_broadcast_table_len);
-  chpl_rt_comm_broadcast_private(NULL, chpl_private_broadcast_table_len + id,
-                                 chpl_rt_priv_bcast_lens[id]);
+typedef enum chpl_rt_private_broadcast_table_entries_for_rt {
+  CHPL_RT_RUNTIME_PRIVATE_BROADCAST_TABLE_ENTRIES(
+    CHPL_RT_BCAST_TABLE_FOR_RT_ENUM_ENTRY
+  )
+  chpl_rt_runtime_private_broadcast_table_for_rt_num_entries
+} chpl_rt_private_broadcast_table_entries_for_rt;
+#undef CHPL_RT_BCAST_TABLE_FOR_RT_ENTRY_ENUM
+
+static inline void chpl_rt_comm_broadcast_rt_symbol_hook(int32_t idx) {
+  assert(idx >= 0 && idx < chpl_rt_private_broadcast_table_for_rt_len);
+
+  // No program indicates we are asking for a runtime symbol.
+  chpl_rt_prginfo* null_prg = NULL;
+  size_t size = chpl_rt_private_broadcast_table_for_rt_byte_lens[idx];
+  chpl_rt_comm_broadcast_private(null_prg, idx, size);
 }
 
+// Runtime code calls this to broadcast a runtime-specific symbol.
+#define chpl_rt_comm_broadcast_rt_symbol(sym__) do {                \
+  int32_t idx = (int32_t) CHPL_RT_BCAST_TABLE_FOR_RT_ENTRY(sym__);  \
+  chpl_rt_comm_broadcast_rt_symbol_hook(idx);                       \
+} while (0)
+
+// Per comm layer implementation.
 void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
                                          size_t size);
+
+// Given a program info pointer OR a program ID, fetch a broadcast table.
+void* chpl_rt_comm_fetch_broadcast_table(chpl_rt_prginfo* prg,
+                                         chpl_rt_prg_id prg_id,
+                                         size_t* out_table_len);
 
 #ifdef __cplusplus
 }

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -55,9 +55,10 @@ extern void* chpl_rt_private_broadcast_table_for_rt[];
 extern size_t chpl_rt_private_broadcast_table_for_rt_len;
 extern size_t chpl_rt_private_broadcast_table_for_rt_byte_lens[];
 
-// These are entries for broadcastable symbols that the runtime needs.
-// They do NOT include any per-program symbols. Those can be found
-// in the 'chpl_rt_prginfo*' for a given Chapel program.
+// These are entries for broadcastable symbols that the runtime needs. They do
+// NOT include any per-program symbols. Those can be found in the broadcast
+// table for a given Chapel program, see 'chpl_private_broadcast_table' in the
+// header 'chpl-prginfo-data-macro.h'.
 #define CHPL_RT_RUNTIME_PRIVATE_BROADCAST_TABLE_ENTRIES(MACRO__)  \
   MACRO__(chpl_verbose_comm)                                      \
   MACRO__(chpl_comm_diagnostics)                                  \
@@ -86,12 +87,10 @@ typedef enum chpl_rt_private_broadcast_table_entries_for_rt {
 #undef CHPL_RT_BCAST_TABLE_FOR_RT_ENTRY_ENUM
 
 static inline void chpl_rt_comm_broadcast_rt_symbol_hook(int32_t idx) {
-  assert(idx >= 0 && idx < chpl_rt_private_broadcast_table_for_rt_len);
-
-  // No program indicates we are asking for a runtime symbol.
-  chpl_rt_prginfo* null_prg = NULL;
+  assert(0 <= idx && idx < chpl_rt_private_broadcast_table_for_rt_len);
   size_t size = chpl_rt_private_broadcast_table_for_rt_byte_lens[idx];
-  chpl_rt_comm_broadcast_private(null_prg, idx, size);
+  // Passing a 'NULL' program indicates we are asking for a runtime symbol.
+  chpl_rt_comm_broadcast_private(NULL, idx, size);
 }
 
 // Runtime code calls this to broadcast a runtime-specific symbol.
@@ -105,6 +104,9 @@ void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
                                          size_t size);
 
 // Given a program info pointer OR a program ID, fetch a broadcast table.
+// If 'prg' is not 'NULL', it will be used, otherwise 'prg_id' will be used
+// to translate to a 'chpl_rt_prginfo*' on the current locale. If both
+// 'prg' and 'prg_id' are empty then the runtime table will be used instead.
 void* chpl_rt_comm_fetch_broadcast_table(chpl_rt_prginfo* prg,
                                          chpl_rt_prg_id prg_id,
                                          size_t* out_table_len);

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -81,6 +81,8 @@ void chpl_comm_init_prv_bcast_tab(void);
 
 static inline
 void chpl_comm_really_bcast_rt_private(int id) {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_private_broadcast_table_len);
   chpl_comm_broadcast_private(chpl_private_broadcast_table_len + id,
                               chpl_rt_priv_bcast_lens[id]);
 }

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -100,7 +100,7 @@ static inline void chpl_rt_comm_broadcast_rt_symbol_hook(int32_t idx) {
 } while (0)
 
 // Per comm layer implementation.
-void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
+void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size);
 
 // Given a program info pointer OR a program ID, fetch a broadcast table.

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -90,7 +90,7 @@ static inline void chpl_rt_comm_broadcast_rt_symbol_hook(int32_t idx) {
   assert(0 <= idx && idx < chpl_rt_private_broadcast_table_for_rt_len);
   size_t size = chpl_rt_private_broadcast_table_for_rt_byte_lens[idx];
   // Passing a 'NULL' program indicates we are asking for a runtime symbol.
-  chpl_rt_comm_broadcast_private(NULL, idx, size);
+  chpl_rt_comm_private_broadcast(NULL, idx, size);
 }
 
 // Runtime code calls this to broadcast a runtime-specific symbol.
@@ -100,7 +100,7 @@ static inline void chpl_rt_comm_broadcast_rt_symbol_hook(int32_t idx) {
 } while (0)
 
 // Per comm layer implementation.
-void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int32_t id,
+void chpl_rt_comm_private_broadcast_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size);
 
 // Given a program info pointer OR a program ID, fetch a broadcast table.

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -18,8 +18,8 @@
  * limitations under the License.
  */
 
-#ifndef _chpl_comm_internal_h_
-#define _chpl_comm_internal_h_
+#ifndef CHPL_RT_COMM_INTERNAL_H
+#define CHPL_RT_COMM_INTERNAL_H
 
 #include <stdint.h>
 #include "chpltypes.h"

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -378,7 +378,7 @@ void chpl_rt_comm_broadcast_global_vars(chpl_rt_prginfo* prg);
 // values, and during execution to do things like enabling and disabling
 // memory tracking/reporting and comm diagnostics.
 //
-void chpl_comm_broadcast_private(int id, size_t size);
+void chpl_rt_comm_broadcast_private(chpl_rt_prginfo* prg, int id, size_t size);
 
 //
 // Barrier for synchronization between all top-level locales; currently

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -378,7 +378,7 @@ void chpl_rt_comm_broadcast_global_vars(chpl_rt_prginfo* prg);
 // values, and during execution to do things like enabling and disabling
 // memory tracking/reporting and comm diagnostics.
 //
-void chpl_rt_comm_broadcast_private(chpl_rt_prginfo* prg, int32_t id,
+void chpl_rt_comm_private_broadcast(chpl_rt_prginfo* prg, int32_t id,
                                     size_t size);
 
 //

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -378,7 +378,8 @@ void chpl_rt_comm_broadcast_global_vars(chpl_rt_prginfo* prg);
 // values, and during execution to do things like enabling and disabling
 // memory tracking/reporting and comm diagnostics.
 //
-void chpl_rt_comm_broadcast_private(chpl_rt_prginfo* prg, int id, size_t size);
+void chpl_rt_comm_broadcast_private(chpl_rt_prginfo* prg, int32_t id,
+                                    size_t size);
 
 //
 // Barrier for synchronization between all top-level locales; currently

--- a/runtime/include/chpl-prginfo-program-only-decls.h
+++ b/runtime/include/chpl-prginfo-program-only-decls.h
@@ -76,6 +76,7 @@ extern const int chpl_filenumSymTable[];
 extern const c_string chpl_funSymTable[];
 extern const c_string chpl_filenameTable[];
 extern const int chpl_filenameTableSize;
-
+extern void* const chpl_private_broadcast_table[];
+extern const int chpl_private_broadcast_table_len;
 
 #endif

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -41,8 +41,6 @@
 extern "C" {
 #endif
 
-extern const int chpl_private_broadcast_table_len;
-
 extern void* const chpl_global_serialize_table[];
 
 #ifdef __cplusplus

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -41,6 +41,9 @@
 extern "C" {
 #endif
 
+extern chpl_bool chpl_task_setCommDiagsTemporarilyDisabled(chpl_bool);
+extern chpl_bool chpl_task_getCommDiagsTemporarilyDisabled(void);
+
 extern void* const chpl_global_serialize_table[];
 
 #ifdef __cplusplus

--- a/runtime/include/chplcgfns.h
+++ b/runtime/include/chplcgfns.h
@@ -41,7 +41,6 @@
 extern "C" {
 #endif
 
-extern void* const chpl_private_broadcast_table[];
 extern const int chpl_private_broadcast_table_len;
 
 extern void* const chpl_global_serialize_table[];

--- a/runtime/src/chpl-comm-diags.c
+++ b/runtime/src/chpl-comm-diags.c
@@ -48,7 +48,7 @@ static pthread_once_t bcastPrintUnstable_once = PTHREAD_ONCE_INIT;
 static
 void broadcast_print_unstable(void) {
   chpl_bool prevDisabled = chpl_task_setCommDiagsTemporarilyDisabled(true);
-  chpl_comm_bcast_rt_private(chpl_comm_diags_print_unstable);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_comm_diags_print_unstable);
   (void)chpl_task_setCommDiagsTemporarilyDisabled(prevDisabled);
 }
 
@@ -69,8 +69,8 @@ void chpl_comm_startVerbose(chpl_bool stacktrace,
   chpl_verbose_comm = 1;
 
   chpl_bool prevDisabled = chpl_task_setCommDiagsTemporarilyDisabled(true);
-  chpl_comm_bcast_rt_private(chpl_verbose_comm);
-  chpl_comm_bcast_rt_private(chpl_verbose_comm_stacktrace);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_verbose_comm);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_verbose_comm_stacktrace);
   (void)chpl_task_setCommDiagsTemporarilyDisabled(prevDisabled);
 }
 
@@ -84,7 +84,7 @@ void chpl_comm_stopVerbose(int32_t lineno,
   chpl_verbose_comm = 0;
 
   chpl_bool prevDisabled = chpl_task_setCommDiagsTemporarilyDisabled(true);
-  chpl_comm_bcast_rt_private(chpl_verbose_comm);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_verbose_comm);
   (void)chpl_task_setCommDiagsTemporarilyDisabled(prevDisabled);
 }
 
@@ -130,7 +130,7 @@ void chpl_comm_startDiagnostics(chpl_bool print_unstable,
   chpl_comm_diagnostics = 1;
 
   chpl_bool prevDisabled = chpl_task_setCommDiagsTemporarilyDisabled(true);
-  chpl_comm_bcast_rt_private(chpl_comm_diagnostics);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_comm_diagnostics);
   (void)chpl_task_setCommDiagsTemporarilyDisabled(prevDisabled);
 }
 
@@ -145,7 +145,7 @@ void chpl_comm_stopDiagnostics(int32_t lineno, int32_t filename) {
   chpl_comm_diagnostics = 0;
 
   chpl_bool prevDisabled = chpl_task_setCommDiagsTemporarilyDisabled(true);
-  chpl_comm_bcast_rt_private(chpl_comm_diagnostics);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_comm_diagnostics);
   (void)chpl_task_setCommDiagsTemporarilyDisabled(prevDisabled);
 }
 

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -102,6 +102,9 @@ size_t chpl_rt_priv_bcast_lens[chpl_rt_prv_tab_num_idxs] =
 #undef _RT_PRV_BCAST_M
 
 void chpl_comm_init_prv_bcast_tab(void) {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_private_broadcast_table_len);
+
   //
   // Make a copy of chpl_private_broadcast_table[], but with some more of
   // our own entries following the compiler-emitted ones.

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -50,7 +50,7 @@ static int32_t   localRank = -1;
 static int32_t   numColocalesOnNode = 1;
 
 
-void chpl_rt_comm_broadcast_private(chpl_rt_prginfo* prg, int id,
+void chpl_rt_comm_broadcast_private(chpl_rt_prginfo* prg, int32_t id,
                                     size_t size) {
   chpl_rt_comm_broadcast_private_impl(prg, id, size);
 }

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -50,9 +50,9 @@ static int32_t   localRank = -1;
 static int32_t   numColocalesOnNode = 1;
 
 
-void chpl_rt_comm_broadcast_private(chpl_rt_prginfo* prg, int32_t id,
+void chpl_rt_comm_private_broadcast(chpl_rt_prginfo* prg, int32_t id,
                                     size_t size) {
-  chpl_rt_comm_broadcast_private_impl(prg, id, size);
+  chpl_rt_comm_private_broadcast_impl(prg, id, size);
 }
 
 void chpl_rt_comm_broadcast_global_vars(chpl_rt_prginfo* prg) {

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -50,6 +50,11 @@ static int32_t   localRank = -1;
 static int32_t   numColocalesOnNode = 1;
 
 
+void chpl_rt_comm_broadcast_private(chpl_rt_prginfo* prg, int id,
+                                    size_t size) {
+  chpl_rt_comm_broadcast_private_impl(prg, id, size);
+}
+
 void chpl_rt_comm_broadcast_global_vars(chpl_rt_prginfo* prg) {
   //
   // On node 0: gather up the global variables' wide pointers into a

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -113,6 +113,9 @@ void chpl_comm_init_prv_bcast_tab(void) {
                        sizeof(chpl_rt_priv_bcast_tab[0]),
                        CHPL_RT_MD_COMM_UTIL, 0, 0);
 
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                          chpl_private_broadcast_table);
+
   // Duplicate the compiler-emitted entries.
   memcpy(chpl_rt_priv_bcast_tab,
          chpl_private_broadcast_table,

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -97,47 +97,86 @@ void chpl_rt_comm_broadcast_global_vars(chpl_rt_prginfo* prg) {
   }
 }
 
+// Populate the runtime's table of private broadcast constants.
+void* chpl_rt_private_broadcast_table_for_rt[] = {
+  #define EXPAND_PER_ENTRY(sym__) ((void*) &sym__),
+  CHPL_RT_RUNTIME_PRIVATE_BROADCAST_TABLE_ENTRIES(EXPAND_PER_ENTRY)
+  NULL
+  #undef EXPAND_PER_ENTRY
+};
 
-void** chpl_rt_priv_bcast_tab;
-int chpl_rt_priv_bcast_tab_len;
+// Length of runtime table.
+size_t chpl_rt_private_broadcast_table_for_rt_len =
+          chpl_rt_runtime_private_broadcast_table_for_rt_num_entries;
 
-#define _RT_PRV_BCAST_M(sym) sizeof(sym),
-size_t chpl_rt_priv_bcast_lens[chpl_rt_prv_tab_num_idxs] =
-         { CHPL_RT_PRV_BCAST_TAB_ENTRIES(_RT_PRV_BCAST_M) };
-#undef _RT_PRV_BCAST_M
+// Byte lengths of runtime table entries.
+size_t chpl_rt_private_broadcast_table_for_rt_byte_lens[] = {
+  #define EXPAND_PER_ENTRY(sym__) sizeof(sym__),
+  CHPL_RT_RUNTIME_PRIVATE_BROADCAST_TABLE_ENTRIES(EXPAND_PER_ENTRY)
+  0
+  #undef EXPAND_PER_ENTRY
+};
 
-void chpl_comm_init_prv_bcast_tab(void) {
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+// State for the old 'unified' broadcast table.
+void** chpl_rt_unified_private_broadcast_table = NULL;
+int chpl_rt_unified_private_broadcast_table_len = 0;
+
+void chpl_rt_comm_init_unified_private_broadcast_table(void) {
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_PRGINFO_ROOT,
+                          chpl_private_broadcast_table);
+  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_PRGINFO_ROOT,
                           chpl_private_broadcast_table_len);
 
-  //
-  // Make a copy of chpl_private_broadcast_table[], but with some more of
-  // our own entries following the compiler-emitted ones.
-  //
-  chpl_rt_priv_bcast_tab_len = chpl_private_broadcast_table_len
-                               + chpl_rt_prv_tab_num_idxs;
-  chpl_rt_priv_bcast_tab =
-    chpl_mem_allocMany(chpl_rt_priv_bcast_tab_len,
-                       sizeof(chpl_rt_priv_bcast_tab[0]),
+  chpl_rt_unified_private_broadcast_table_len =
+            chpl_private_broadcast_table_len +
+            chpl_rt_private_broadcast_table_for_rt_len;
+
+  chpl_rt_unified_private_broadcast_table =
+    chpl_mem_allocMany(chpl_rt_unified_private_broadcast_table_len,
+                       sizeof(chpl_rt_unified_private_broadcast_table[0]),
                        CHPL_RT_MD_COMM_UTIL, 0, 0);
 
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                          chpl_private_broadcast_table);
-
-  // Duplicate the compiler-emitted entries.
-  memcpy(chpl_rt_priv_bcast_tab,
+  // Copy over the compiler-emitted entries from the root program.
+  memcpy(chpl_rt_unified_private_broadcast_table,
          chpl_private_broadcast_table,
          chpl_private_broadcast_table_len
          * sizeof(chpl_private_broadcast_table[0]));
 
   // Fill in our entries that follow those.
-#define _RT_PRV_BCAST_M(sym)                                            \
-  chpl_rt_priv_bcast_tab[chpl_private_broadcast_table_len               \
-                         + chpl_rt_prv_tab_ ## sym ## _idx] = &sym;
-  CHPL_RT_PRV_BCAST_TAB_ENTRIES(_RT_PRV_BCAST_M)
-#undef _RT_PRV_BCAST_M
+  #define EXPAND_PER_ENTRY(sym__) do {                        \
+    const int idx = chpl_private_broadcast_table_len          \
+                  + CHPL_RT_BCAST_TABLE_FOR_RT_ENTRY(sym__);  \
+    chpl_rt_unified_private_broadcast_table[idx] = &sym__;    \
+  } while (0);
+  CHPL_RT_RUNTIME_PRIVATE_BROADCAST_TABLE_ENTRIES(EXPAND_PER_ENTRY)
+  #undef EXPAND_PER_ENTRY
 }
 
+void* chpl_rt_comm_fetch_broadcast_table(chpl_rt_prginfo* prg,
+                                         chpl_rt_prg_id prg_id,
+                                         size_t* out_table_len) {
+  size_t table_len = 0;
+  void** ret = NULL;
+  bool use_rt_table = prg_id == CHPL_RT_PRGINFO_NULL_ID && prg == NULL;
+
+  if (use_rt_table) {
+    ret = chpl_rt_private_broadcast_table_for_rt;
+    table_len = chpl_rt_private_broadcast_table_for_rt_len;
+
+  } else {
+    chpl_rt_prginfo* p = prg ? prg : CHPL_RT_PRGINFO_FETCH(prg_id);
+    assert(p != NULL);
+    // It is OK to discard constness here, table is read-only anyways.
+    ret = (void*) CHPL_RT_PRGINFO_DATA(p, chpl_private_broadcast_table);
+    table_len = CHPL_RT_PRGINFO_DATA(p, chpl_private_broadcast_table_len);
+  }
+
+  assert(ret != NULL && table_len != 0);
+
+  if (out_table_len != NULL) *out_table_len = table_len;
+
+  return ret;
+}
 
 static pthread_once_t maxHeapSize_once = PTHREAD_ONCE_INIT;
 static ssize_t maxHeapSize;

--- a/runtime/src/chpl-gpu-diags.c
+++ b/runtime/src/chpl-gpu-diags.c
@@ -49,7 +49,7 @@ static pthread_once_t bcastPrintUnstable_once = PTHREAD_ONCE_INIT;
 
 static
 void broadcast_print_unstable(void) {
-  chpl_comm_bcast_rt_private(chpl_gpu_diags_print_unstable);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_gpu_diags_print_unstable);
 }
 
 
@@ -67,8 +67,8 @@ void chpl_gpu_startVerbose(chpl_bool stacktrace,
     chpl_warning("verbose gpu was already started", lineno, filename);
   }
   chpl_verbose_gpu = 1;
-  chpl_comm_bcast_rt_private(chpl_verbose_gpu);
-  chpl_comm_bcast_rt_private(chpl_verbose_gpu_stacktrace);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_verbose_gpu);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_verbose_gpu_stacktrace);
 }
 
 
@@ -77,7 +77,7 @@ void chpl_gpu_stopVerbose(int32_t lineno, int32_t filename) {
     chpl_warning("verbose gpu was never started", lineno, filename);
   }
   chpl_verbose_gpu = 0;
-  chpl_comm_bcast_rt_private(chpl_verbose_gpu);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_verbose_gpu);
 }
 
 
@@ -119,7 +119,7 @@ void chpl_gpu_startDiagnostics(chpl_bool print_unstable,
     chpl_warning("gpu diagnostics was already started", lineno, filename);
   }
   chpl_gpu_diagnostics = 1;
-  chpl_comm_bcast_rt_private(chpl_gpu_diagnostics);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_gpu_diagnostics);
 }
 
 
@@ -131,7 +131,7 @@ void chpl_gpu_stopDiagnostics(int32_t lineno, int32_t filename) {
     chpl_warning("gpu diagnostics was never started", lineno, filename);
   }
   chpl_gpu_diagnostics = 0;
-  chpl_comm_bcast_rt_private(chpl_gpu_diagnostics);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_gpu_diagnostics);
 }
 
 

--- a/runtime/src/chplmemtrack.c
+++ b/runtime/src/chplmemtrack.c
@@ -798,12 +798,12 @@ void chpl_track_realloc_post(void* newMemAlloc,
 
 void chpl_startVerboseMem(void) {
   chpl_verbose_mem = 1;
-  chpl_comm_bcast_rt_private(chpl_verbose_mem);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_verbose_mem);
 }
 
 void chpl_stopVerboseMem(void) {
   chpl_verbose_mem = 0;
-  chpl_comm_bcast_rt_private(chpl_verbose_mem);
+  chpl_rt_comm_broadcast_rt_symbol(chpl_verbose_mem);
 }
 
 void chpl_startVerboseMemHere(void) {

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1205,7 +1205,8 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
   }
 }
 
-void chpl_comm_broadcast_private(int id, size_t size) {
+void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
+                                         size_t size) {
   int  node, offset;
   int  payloadSize = size + sizeof(priv_bcast_t);
   done_t* done;

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1238,6 +1238,10 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
   }
 }
 
+// TODO (@bonachea, thanks!): This naive/non-scalable code was written for
+// GASNet-1 and has not been updated to take advantage of EX. If it ever
+// becomes a problem, we can rewrite it to use e.g., 'gex_Coll_BroadcastNB'
+// which should be simpler to use and scale better.
 void chpl_rt_comm_private_broadcast_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size) {
   chpl_mem_descInt_t pbp_dsc = CHPL_RT_MD_COMM_PRV_BCAST_DATA;
@@ -1248,6 +1252,9 @@ void chpl_rt_comm_private_broadcast_impl(chpl_rt_prginfo* prg, int32_t id,
   int num_offsets = 1;
   void** table = NULL;
   size_t table_len = 0;
+
+  // Check for overflow. TODO: Make this code more robust w.r.t. overflows.
+  assert((size_t) payload_size == size + sizeof(priv_bcast_t));
 
   // Get the broadcast table to use on this node.
   table = chpl_rt_comm_fetch_broadcast_table(prg, 0, &table_len);

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1240,7 +1240,7 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
   }
 }
 
-void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int32_t id,
+void chpl_rt_comm_private_broadcast_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size) {
   chpl_mem_descInt_t pbp_dsc = CHPL_RT_MD_COMM_PRV_BCAST_DATA;
   int node = 0;

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1240,7 +1240,7 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
   }
 }
 
-void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
+void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size) {
   chpl_mem_descInt_t pbp_dsc = CHPL_RT_MD_COMM_PRV_BCAST_DATA;
   int node = 0;

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -522,7 +522,8 @@ static void AM_signal_long(gasnet_token_t token, void *buf, size_t nbytes,
 
 static void AM_priv_bcast(gasnet_token_t token, void* buf, size_t nbytes) {
   priv_bcast_t* pbp = buf;
-  chpl_memcpy(chpl_rt_priv_bcast_tab[pbp->id], pbp->data, pbp->size);
+  chpl_memcpy(chpl_rt_unified_private_broadcast_table[pbp->id], pbp->data,
+              pbp->size);
 
   // Signal that the handler has completed
   GASNET_Safe(gasnet_AMReplyShort2(token, SIGNAL,
@@ -531,7 +532,8 @@ static void AM_priv_bcast(gasnet_token_t token, void* buf, size_t nbytes) {
 
 static void AM_priv_bcast_large(gasnet_token_t token, void* buf, size_t nbytes) {
   priv_bcast_large_t* pblp = buf;
-  chpl_memcpy((char*)chpl_rt_priv_bcast_tab[pblp->id]+pblp->offset, pblp->data, pblp->size);
+  char* start = chpl_rt_unified_private_broadcast_table[pblp->id];
+  chpl_memcpy(start + pblp->offset, pblp->data, pblp->size);
 
   // Signal that the handler has completed
   GASNET_Safe(gasnet_AMReplyShort2(token, SIGNAL,
@@ -998,7 +1000,7 @@ void chpl_comm_pre_mem_init(void) {
 }
 
 void chpl_comm_post_mem_init(void) {
-  chpl_comm_init_prv_bcast_tab();
+  chpl_rt_comm_init_unified_private_broadcast_table();
 }
 
 //
@@ -1218,7 +1220,7 @@ void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
                                           0, 0);
   if (payloadSize <= gasnet_AMMaxMedium()) {
     priv_bcast_t* pbp = chpl_mem_allocMany(1, payloadSize, CHPL_RT_MD_COMM_PRV_BCAST_DATA, 0, 0);
-    chpl_memcpy(pbp->data, chpl_rt_priv_bcast_tab[id], size);
+    chpl_memcpy(pbp->data, chpl_rt_unified_private_broadcast_table[id], size);
     pbp->id = id;
     pbp->size = size;
     for (node = 0; node < chpl_numNodes; node++) {
@@ -1245,7 +1247,9 @@ void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
         thissize = maxsize;
       pblp->offset = offset;
       pblp->size = thissize;
-      chpl_memcpy(pblp->data, (char*)chpl_rt_priv_bcast_tab[id]+offset, thissize);
+      chpl_memcpy(pblp->data,
+                  (char*) chpl_rt_unified_private_broadcast_table[id] + offset,
+                  thissize);
       for (node = 0; node < chpl_numNodes; node++) {
         if (node != chpl_nodeID) {
           pblp->ack = &done[node];

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -224,18 +224,21 @@ typedef struct {
 } large_fork_task_t;
 
 typedef struct {
-  void*   ack;
-  int     id;       // private broadcast table entry to update
-  int     size;     // size of data
-  char    data[0];  // data
+  void*           ack;
+  int             id;       // private broadcast table entry to update
+  int             size;     // size of data
+  chpl_rt_prg_id  prg_id;   // id of program requesting, or '0' for RT
+} priv_bcast_hdr_t;
+
+typedef struct {
+  priv_bcast_hdr_t  hdr;      // header
+  char              data[0];  // data
 } priv_bcast_t;
 
 typedef struct {
-  void* ack;
-  int   id;       // private broadcast table entry to update
-  int   size;     // size of data
-  int   offset;   // offset of piece of data
-  char  data[0];  // data
+  priv_bcast_hdr_t  hdr;      // header
+  int               offset;   // offset of piece of data
+  char              data[0];  // data
 } priv_bcast_large_t;
 
 typedef struct {
@@ -522,22 +525,54 @@ static void AM_signal_long(gasnet_token_t token, void *buf, size_t nbytes,
 
 static void AM_priv_bcast(gasnet_token_t token, void* buf, size_t nbytes) {
   priv_bcast_t* pbp = buf;
-  chpl_memcpy(chpl_rt_unified_private_broadcast_table[pbp->id], pbp->data,
-              pbp->size);
+  priv_bcast_hdr_t hdr = pbp->hdr;
+  size_t table_len = 0;
+  void** table = NULL;
+
+  // Get the broadcast table to use on this node.
+  table = chpl_rt_comm_fetch_broadcast_table(NULL, hdr.prg_id, &table_len);
+
+  // Make sure the index is in bounds.
+  assert(0 <= hdr.id && hdr.id < table_len);
+  (void) table_len;
+
+  void* dst = table[hdr.id];
+  void* src = pbp->data;
+  size_t bytes = hdr.size;
+  chpl_memcpy(dst, src, bytes);
 
   // Signal that the handler has completed
   GASNET_Safe(gasnet_AMReplyShort2(token, SIGNAL,
-                                   Arg0(pbp->ack), Arg1(pbp->ack)));
+                                   Arg0(hdr.ack),
+                                   Arg1(hdr.ack)));
 }
 
-static void AM_priv_bcast_large(gasnet_token_t token, void* buf, size_t nbytes) {
+static void AM_priv_bcast_large(gasnet_token_t token, void* buf,
+                                size_t nbytes) {
   priv_bcast_large_t* pblp = buf;
-  char* start = chpl_rt_unified_private_broadcast_table[pblp->id];
-  chpl_memcpy(start + pblp->offset, pblp->data, pblp->size);
+  priv_bcast_hdr_t hdr = pblp->hdr;
+  size_t table_len = 0;
+  void** table = NULL;
+
+  // Get the broadcast table to use on this node.
+  table = chpl_rt_comm_fetch_broadcast_table(NULL, hdr.prg_id, &table_len);
+
+  // Make sure the index is in bounds.
+  assert(0 <= hdr.id && hdr.id < table_len);
+  (void) table_len;
+
+  // Compute the starting byte offset.
+  char* start = ((char*) table[hdr.id] + pblp->offset);
+
+  void* dst = start;
+  void* src = pblp->data;
+  size_t bytes = hdr.size;
+  chpl_memcpy(dst, src, bytes);
 
   // Signal that the handler has completed
   GASNET_Safe(gasnet_AMReplyShort2(token, SIGNAL,
-                                   Arg0(pblp->ack), Arg1(pblp->ack)));
+                                   Arg0(hdr.ack),
+                                   Arg1(hdr.ack)));
 }
 
 static void AM_free(gasnet_token_t token, gasnet_handlerarg_t a0, gasnet_handlerarg_t a1) {
@@ -999,9 +1034,7 @@ void chpl_comm_pre_mem_init(void) {
   gasnet_set_waitmode(GASNET_WAIT_BLOCK);
 }
 
-void chpl_comm_post_mem_init(void) {
-  chpl_rt_comm_init_unified_private_broadcast_table();
-}
+void chpl_comm_post_mem_init(void) {}
 
 //
 // No support for gdb for now
@@ -1209,61 +1242,83 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
 
 void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
                                          size_t size) {
-  int  node, offset;
-  int  payloadSize = size + sizeof(priv_bcast_t);
-  done_t* done;
-  int numOffsets=1;
+  chpl_mem_descInt_t pbp_dsc = CHPL_RT_MD_COMM_PRV_BCAST_DATA;
+  int node = 0;
+  int offset = 0;
+  int payload_size = size + sizeof(priv_bcast_t);
+  done_t* done = NULL;
+  int num_offsets = 1;
+  void** table = NULL;
+  size_t table_len = 0;
 
-  // This can use the system allocator because it involves internode communication.
-  done = (done_t*) chpl_mem_allocManyZero(chpl_numNodes, sizeof(*done),
-                                          CHPL_RT_MD_COMM_FRK_DONE_FLAG,
-                                          0, 0);
-  if (payloadSize <= gasnet_AMMaxMedium()) {
-    priv_bcast_t* pbp = chpl_mem_allocMany(1, payloadSize, CHPL_RT_MD_COMM_PRV_BCAST_DATA, 0, 0);
-    chpl_memcpy(pbp->data, chpl_rt_unified_private_broadcast_table[id], size);
-    pbp->id = id;
-    pbp->size = size;
+  // Get the broadcast table to use on this node.
+  table = chpl_rt_comm_fetch_broadcast_table(prg, 0, &table_len);
+
+  // Can use the system allocator because it involves internode communication.
+  done = chpl_mem_allocManyZero(chpl_numNodes, sizeof(*done),
+                                CHPL_RT_MD_COMM_FRK_DONE_FLAG,
+                                0, 0);
+
+  if (payload_size <= gasnet_AMMaxMedium()) {
+    priv_bcast_t* pbp = chpl_mem_allocMany(1, payload_size, pbp_dsc, 0, 0);
+    chpl_memcpy(pbp->data, table[id], size);
+
+    pbp->hdr.id = id;
+    pbp->hdr.size = size;
+    pbp->hdr.prg_id = chpl_rt_prginfo_id(prg);
+
     for (node = 0; node < chpl_numNodes; node++) {
       if (node != chpl_nodeID) {
-        pbp->ack = &done[node];
+        pbp->hdr.ack = &done[node];
         init_done_obj(&done[node], 1);
-        GASNET_Safe(gasnet_AMRequestMedium0(node, PRIV_BCAST, pbp, payloadSize));
+        GASNET_Safe(gasnet_AMRequestMedium0(node, PRIV_BCAST, pbp,
+                                            payload_size));
       }
     }
+
     chpl_mem_free(pbp, 0, 0);
   } else {
-    size_t maxpayloadsize = gasnet_AMMaxMedium();
-    size_t maxsize = maxpayloadsize - sizeof(priv_bcast_large_t);
-    priv_bcast_large_t* pblp = chpl_mem_allocMany(1, maxpayloadsize, CHPL_RT_MD_COMM_PRV_BCAST_DATA, 0, 0);
-    pblp->id = id;
-    numOffsets = (size+maxsize)/maxsize;
+    size_t max_payload_size = gasnet_AMMaxMedium();
+    size_t max_size = max_payload_size - sizeof(priv_bcast_large_t);
+    priv_bcast_large_t* pblp = chpl_mem_allocMany(1, max_payload_size,
+                                                  pbp_dsc, 0, 0);
+    pblp->hdr.id = id;
+    pblp->hdr.prg_id = chpl_rt_prginfo_id(prg);
+
+    num_offsets = (size + max_size) / max_size;
+
     for (node = 0; node < chpl_numNodes; node++) {
       if (node != chpl_nodeID)
-        init_done_obj(&done[node], numOffsets);
+        init_done_obj(&done[node], num_offsets);
     }
-    for (offset = 0; offset < size; offset += maxsize) {
-      size_t thissize = size - offset;
-      if (thissize > maxsize)
-        thissize = maxsize;
+
+    for (offset = 0; offset < size; offset += max_size) {
+      size_t this_size = size - offset;
+      if (this_size > max_size) this_size = max_size;
+
+      pblp->hdr.size = this_size;
       pblp->offset = offset;
-      pblp->size = thissize;
-      chpl_memcpy(pblp->data,
-                  (char*) chpl_rt_unified_private_broadcast_table[id] + offset,
-                  thissize);
+      chpl_memcpy(pblp->data, ((char*) table) + offset, this_size);
+
       for (node = 0; node < chpl_numNodes; node++) {
         if (node != chpl_nodeID) {
-          pblp->ack = &done[node];
-          GASNET_Safe(gasnet_AMRequestMedium0(node, PRIV_BCAST_LARGE, pblp, sizeof(priv_bcast_large_t)+thissize));
+          size_t packet_size = sizeof(priv_bcast_large_t) + this_size;
+          pblp->hdr.ack = &done[node];
+          GASNET_Safe(gasnet_AMRequestMedium0(node, PRIV_BCAST_LARGE, pblp,
+                                              packet_size));
         }
       }
     }
+
     chpl_mem_free(pblp, 0, 0);
   }
+
   // wait for the handlers to complete
   for (node = 0; node < chpl_numNodes; node++) {
     if (node != chpl_nodeID)
       GASNET_BLOCKUNTIL(done[node].flag);
   }
+
   chpl_mem_free(done, 0, 0);
 }
 

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -534,7 +534,6 @@ static void AM_priv_bcast(gasnet_token_t token, void* buf, size_t nbytes) {
 
   // Make sure the index is in bounds.
   assert(0 <= hdr.id && hdr.id < table_len);
-  (void) table_len;
 
   void* dst = table[hdr.id];
   void* src = pbp->data;
@@ -559,7 +558,6 @@ static void AM_priv_bcast_large(gasnet_token_t token, void* buf,
 
   // Make sure the index is in bounds.
   assert(0 <= hdr.id && hdr.id < table_len);
-  (void) table_len;
 
   // Compute the starting byte offset.
   char* start = ((char*) table[hdr.id] + pblp->offset);

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -249,7 +249,7 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
   return NULL;
 }
 
-void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
+void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size) {}
 
 void chpl_comm_impl_barrier(const char *msg) { }

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -249,7 +249,8 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
   return NULL;
 }
 
-void chpl_comm_broadcast_private(int id, size_t size) { }
+void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
+                                         size_t size) {}
 
 void chpl_comm_impl_barrier(const char *msg) { }
 

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -249,7 +249,7 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
   return NULL;
 }
 
-void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int32_t id,
+void chpl_rt_comm_private_broadcast_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size) {}
 
 void chpl_comm_impl_barrier(const char *msg) { }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3340,7 +3340,7 @@ void init_broadcast_private(void) {
   //
   //
   // Share the nodes' private broadcast tables around.  These are
-  // needed by chpl_comm_broadcast_private(), below.
+  // needed by chpl_comm_private_broadcast(), below.
   //
   void** pbtMap;
   size_t pbtSize = chpl_rt_unified_private_broadcast_table_len
@@ -3356,7 +3356,7 @@ void init_broadcast_private(void) {
 }
 
 
-void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int32_t id,
+void chpl_rt_comm_private_broadcast_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size) {
   DBG_PRINTF(DBG_IFACE_SETUP, "%s(%d, %zd)", __func__, id, size);
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3354,7 +3354,8 @@ void init_broadcast_private(void) {
 }
 
 
-void chpl_comm_broadcast_private(int id, size_t size) {
+void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
+                                         size_t size) {
   DBG_PRINTF(DBG_IFACE_SETUP, "%s(%d, %zd)", __func__, id, size);
 
   for (int i = 0; i < chpl_numNodes; i++) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -1165,7 +1165,7 @@ void chpl_comm_pre_mem_init(void) {
 
 void chpl_comm_post_mem_init(void) {
   DBG_PRINTF(DBG_IFACE_SETUP, "%s()", __func__);
-  chpl_comm_init_prv_bcast_tab();
+  chpl_rt_comm_init_unified_private_broadcast_table();
   init_broadcast_private();
 
   /*
@@ -3343,13 +3343,15 @@ void init_broadcast_private(void) {
   // needed by chpl_comm_broadcast_private(), below.
   //
   void** pbtMap;
-  size_t pbtSize = chpl_rt_priv_bcast_tab_len
-                   * sizeof(chpl_rt_priv_bcast_tab[0]);
+  size_t pbtSize = chpl_rt_unified_private_broadcast_table_len
+                   * sizeof(chpl_rt_unified_private_broadcast_table[0]);
   CHPL_CALLOC(pbtMap, chpl_numNodes * pbtSize);
-  chpl_comm_ofi_oob_allgather(chpl_rt_priv_bcast_tab, pbtMap, pbtSize);
+  chpl_comm_ofi_oob_allgather(chpl_rt_unified_private_broadcast_table,
+                              pbtMap, pbtSize);
   CHPL_CALLOC(chplPrivBcastTabMap, chpl_numNodes);
+  const size_t len = chpl_rt_unified_private_broadcast_table_len;
   for (int i = 0; i < chpl_numNodes; i++) {
-    chplPrivBcastTabMap[i] = &pbtMap[i * chpl_rt_priv_bcast_tab_len];
+    chplPrivBcastTabMap[i] = &pbtMap[i * len];
   }
 }
 
@@ -3360,7 +3362,7 @@ void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
 
   for (int i = 0; i < chpl_numNodes; i++) {
     if (i != chpl_nodeID) {
-      (void) ofi_put(chpl_rt_priv_bcast_tab[id], i,
+      (void) ofi_put(chpl_rt_unified_private_broadcast_table[id], i,
                      chplPrivBcastTabMap[i][id], size);
     }
   }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -3356,7 +3356,7 @@ void init_broadcast_private(void) {
 }
 
 
-void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
+void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size) {
   DBG_PRINTF(DBG_IFACE_SETUP, "%s(%d, %zd)", __func__, id, size);
 

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3936,11 +3936,11 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
 }
 
 
-void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int32_t id,
+void chpl_rt_comm_private_broadcast_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size) {
   int i;
 
-  DBG_P_LP(DBGF_IFACE, "IFACE chpl_comm_broadcast_private(%d, %zd)", id, size);
+  DBG_P_LP(DBGF_IFACE, "IFACE chpl_comm_private_broadcast(%d, %zd)", id, size);
 
   //
   // TODO: Currently this does a PUT and wait for remote completion to

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3936,8 +3936,8 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
 }
 
 
-void chpl_comm_broadcast_private(int id, size_t size)
-{
+void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
+                                         size_t size) {
   int i;
 
   DBG_P_LP(DBGF_IFACE, "IFACE chpl_comm_broadcast_private(%d, %zd)", id, size);

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -1939,7 +1939,7 @@ void chpl_comm_pre_mem_init(void) { }
 
 void chpl_comm_post_mem_init(void)
 {
-  chpl_comm_init_prv_bcast_tab();
+  chpl_rt_comm_init_unified_private_broadcast_table();
 }
 
 
@@ -3950,8 +3950,8 @@ void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
   //
   for (i = 0; i < chpl_numNodes; i++) {
     if (i != chpl_nodeID) {
-      do_remote_put(chpl_rt_priv_bcast_tab[id], i,
-                    chpl_rt_priv_bcast_tab[id], size,
+      do_remote_put(chpl_rt_unified_private_broadcast_table[id], i,
+                    chpl_rt_unified_private_broadcast_table[id], size,
                     NULL, may_proxy_true);
     }
   }

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3936,7 +3936,7 @@ wide_ptr_t* chpl_rt_comm_broadcast_global_vars_impl(chpl_rt_prginfo* prg) {
 }
 
 
-void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int id,
+void chpl_rt_comm_broadcast_private_impl(chpl_rt_prginfo* prg, int32_t id,
                                          size_t size) {
   int i;
 


### PR DESCRIPTION
This PR adjusts the runtime's private broadcast API in order to better facilitate dynamic loading.

Prior to this effort, the runtime would build what I call a "unified broadcast table" at execution-time. This table is an address table that contains the contents of the broadcast table from the "root Chapel program" combined with some additional RT-exclusive symbol addresses tacked on at the end.

The problem with this approach is that it is not conducive to dynamic loading because the runtime only reasons about a single table. While it might be possible to dynamically resize the table as needed to support multiple Chapel programs, I thought it might be simpler if we just remove the dynamic address table entirely, and let the runtime fetch the address table from the specific Chapel program that it needs (or its own address table).

While I feel confident this "separate table" approach works with gasnet, I haven't spent the time to investigate how it will work with the ofi comm layer. Because I'm not adjusting ofi in this release, I'm still keeping the old "unified broadcast table" around for now. I've renamed it to `chpl_rt_unified_private_broadcast_table`.

In general, I've refactored the symbols used in the private broadcast API and implementation to have a more consistent and legible naming scheme (continuing the theme of clarity over brevity).

The runtime used to name its private broadcasting functions as `...broadcast_private`. I've adjusted this to be `...private_broadcast` so that the terminology is consistent everywhere.

This PR introduces another runtime shim into `ChapelRuntimeInterface.chpl` which the compiler will invoke whenever it needs to broadcast a symbol's value to all locales.

Future work could improve the implementation's robustness w.r.t. potential overflows or take advantage of new routines provided by the GASNet-EX API, for example `gex_Coll_BroadcastNB` as suggested by @bonachea.

TESTING

- [x] `standard`
- [x] `COMM=gasnet`
- [x] `COMM=gasnet`, `COMPILER=gnu`
- [x] Build with `COMM=ofi`
- [x] Build with `gasnet-asan`, run `fastAndIncremental.chpl`

Reviewed by @benharsh, @bonachea. Thanks both!