### PR TITLE
Fix debug flag compiler tests

### DIFF
--- a/test/compflags/bradc/gdbddash/declint-lldb.prediff
+++ b/test/compflags/bradc/gdbddash/declint-lldb.prediff
@@ -8,7 +8,7 @@ tmpfile=$outfile.raw.tmp
 # some gdbs print out extra stuff.  This filters it out
 #
 mv $outfile $tmpfile
-grep -v "Current executable set to" $tmpfile | grep -v "Executing commands in" | grep -v "settings set" | grep -v "command regex" | grep -v "breakpoint set" | grep -v "breakpoint command" | grep -v 'command script import' | grep -v "Breakpoint 1" | grep -v "target create" | grep -v "command source" > $outfile
+grep -v "Current executable set to" $tmpfile | grep -v "Executing commands in" | grep -v "settings set" | grep -v "command regex" | grep -v "breakpoint set" | grep -v "breakpoint command" | grep -v 'command script import' | grep -v "Breakpoint 1" | grep -v "target create" | grep -v "command source" | grep -iv 'stop hook' > $outfile
 rm $tmpfile
 
 #

--- a/test/compflags/driver/monolithic/debugger/declint-lldb.prediff
+++ b/test/compflags/driver/monolithic/debugger/declint-lldb.prediff
@@ -8,7 +8,7 @@ tmpfile=$outfile.raw.tmp
 # some gdbs print out extra stuff.  This filters it out
 #
 mv $outfile $tmpfile
-grep -v "Current executable set to" $tmpfile | grep -v "Executing commands in" | grep -v "settings set" | grep -v "command regex" | grep -v "breakpoint set" | grep -v "breakpoint command" | grep -v 'command script import' | grep -v "Breakpoint 1" | grep -v "target create" | grep -v "command source" > $outfile
+grep -v "Current executable set to" $tmpfile | grep -v "Executing commands in" | grep -v "settings set" | grep -v "command regex" | grep -v "breakpoint set" | grep -v "breakpoint command" | grep -v 'command script import' | grep -v "Breakpoint 1" | grep -v "target create" | grep -v "command source" | grep -iv "stop hook" > $outfile
 rm $tmpfile
 
 #


### PR DESCRIPTION
Fixes the prediffes for some `--lldb` compiler tests

[Not reviewed - trivial]