### PR TITLE
Add links to the mason package search from the docs

### DIFF
--- a/doc/rst/mason-packages/index.rst
+++ b/doc/rst/mason-packages/index.rst
@@ -8,9 +8,10 @@ Community-developed modules are available as Mason packages on the
 These packages can be downloaded and used through :ref:`mason <readme-mason>`,
 Chapel's package manager.
 
-Browsing available packages is best done through the ``mason`` command line
-tool, via ``mason search``. They can also be found by browsing the Mason
-registry repository.
+The available packages can be found either through the
+`Mason registry <https://chapel-lang.org/packages/>`_ or through the command
+line with ``mason search``.
+
 
 For details on contributing a package to the Mason registry, see the
 documentation on :ref:`submitting a package <submit-a-package>`.

--- a/doc/rst/tools/mason/guide/masonregistry.rst
+++ b/doc/rst/tools/mason/guide/masonregistry.rst
@@ -3,7 +3,10 @@ The Mason Registry
 
 The default Mason registry is a GitHub repository containing a list of versioned manifest files.
 
-View the official Mason registry here: `Mason-Registry <https://github.com/chapel-lang/mason-registry>`_.
+The official registry can be browsed
+`on the Chapel website <https://chapel-lang.org/packages/>`_.
+The actual repository of package entries can be found at
+`Mason-Registry <https://github.com/chapel-lang/mason-registry/>`_.
 
 A registry will be downloaded to ``$MASON_HOME/<name>`` by ``mason update``
 for each registry named in ``$MASON_REGISTRY`` if a registry at that location


### PR DESCRIPTION
Adjusts the mason docs to link to the mason package search

[Reviewed by @DanilaFe]