### PR TITLE
Add undefined behavior testing

### DIFF
--- a/util/cron/common-ubsan.bash
+++ b/util/cron/common-ubsan.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Configure environment for testing AddressSanitizer.
+
+UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+
+export CHPL_TARGET_MEM=cstdlib
+export CHPL_HOST_MEM=cstdlib
+export CHPL_SANITIZE=undefined
+export CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET=yes

--- a/util/cron/common-ubsan.bash
+++ b/util/cron/common-ubsan.bash
@@ -7,4 +7,3 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 export CHPL_TARGET_MEM=cstdlib
 export CHPL_HOST_MEM=cstdlib
 export CHPL_SANITIZE=undefined
-export CHPL_RT_NUM_THREADS_PER_LOCALE_QUIET=yes

--- a/util/cron/common-ubsan.bash
+++ b/util/cron/common-ubsan.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Configure environment for testing AddressSanitizer.
+# Configure environment for testing UndefinedBehaviorSanitizer.
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 

--- a/util/cron/test-ubsan.clang.bash
+++ b/util/cron/test-ubsan.clang.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Test UBSAN-compatible configuration on full suite with UBSAN on linux64.
+
+UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $UTIL_CRON_DIR/common.bash
+source $UTIL_CRON_DIR/common-ubsan.bash
+export CHPL_TARGET_COMPILER=clang
+source $UTIL_CRON_DIR/common-localnode-paratest.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="ubsan.clang"
+
+$UTIL_CRON_DIR/nightly -cron ${nightly_args} $(get_nightly_paratest_args 16)

--- a/util/cron/test-ubsan.clang.bash
+++ b/util/cron/test-ubsan.clang.bash
@@ -6,6 +6,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-ubsan.bash
 export CHPL_TARGET_COMPILER=clang
+export CHPL_HOST_COMPILER=clang
 source $UTIL_CRON_DIR/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="ubsan.clang"

--- a/util/cron/test-ubsan.gnu.bash
+++ b/util/cron/test-ubsan.gnu.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Test UBSAN-compatible configuration on full suite with UBSAN on linux64.
+
+UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $UTIL_CRON_DIR/common.bash
+source $UTIL_CRON_DIR/common-ubsan.bash
+export CHPL_TARGET_COMPILER=gnu
+source $UTIL_CRON_DIR/common-localnode-paratest.bash
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="ubsan.gnu"
+
+$UTIL_CRON_DIR/nightly -cron ${nightly_args} $(get_nightly_paratest_args 16)

--- a/util/cron/test-ubsan.gnu.bash
+++ b/util/cron/test-ubsan.gnu.bash
@@ -6,6 +6,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-ubsan.bash
 export CHPL_TARGET_COMPILER=gnu
+export CHPL_HOST_COMPILER=gnu
 source $UTIL_CRON_DIR/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="ubsan.gnu"


### PR DESCRIPTION
Adds two new test configs to make sure there is no undefined behavior in the Chapel compiler or runtime

[Reviewed by @arifthpe]