### PR TITLE
Fix an infinite hang in multi-locale python interop tests

### DIFF
--- a/runtime/src/chpl-launcher-common.c
+++ b/runtime/src/chpl-launcher-common.c
@@ -714,7 +714,7 @@ void printAdditionalHelpEntry(const argDescTuple_t* argTuple,
 extern const char launcher_real_suffix[];
 extern const char launcher_exe_suffix[];    // May be the empty string.
 extern const int launcher_is_mli;
-extern const char launcher_mli_real_name[];
+extern const char* launcher_mli_real_name;
 
 static char* chpl_real_binary_name;
 


### PR DESCRIPTION
This PR fixes a bug that causes a timeout when running multi-locale python interop tests in nightly testing.

Much to my eternal frustration and chagrin, `char* foo` and `char foo[]` are not the same type even if the latter often decays to the former. While moving `launcher_mli_real_name` from a header to a source file, I accidentally changed its type from `char*` to `char []`. The mismatch caused interpretation of the `const char*` to break.

Reviewed (and debugged!) by @benharsh. Thanks!