### PR TITLE
Fix writeBits test failures

### DIFF
--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -1510,7 +1510,7 @@ qioerr qio_channel_write_bits(const int threadsafe, qio_channel_t* restrict ch, 
     // Can we just put it into bitbuffer?
     if( tmp_live + nbits <= (int) (8*sizeof(qio_bitbuffer_t)) ) {
       //printf("WRITE BITS LOCAL WRITING %llx %i %llx %i\n", (long long int) tmp_bits, tmp_live, (long long int) v, nbits);
-      tmp_bits = CHPL_SAFE_LSHIFT(tmp_bits, nbits, 8*sizeof(qio_bitbuffer_t)) | v;
+      tmp_bits = CHPL_SAFE_LSHIFT(tmp_bits, nbits, (int)(8*sizeof(qio_bitbuffer_t))) | v;
       tmp_live += nbits;
       ch->bit_buffer = tmp_bits;
       ch->bit_buffer_bits = tmp_live;
@@ -1600,7 +1600,7 @@ qioerr qio_channel_read_bits(const int threadsafe, qio_channel_t* restrict ch, u
     if( nbits <= tmp_live ) {
       //printf("READ BITS LOCAL\n");
       *v = tmp_bits >> (8*sizeof(qio_bitbuffer_t) - nbits);
-      tmp_bits = CHPL_SAFE_LSHIFT(tmp_bits, nbits, 8*sizeof(qio_bitbuffer_t));
+      tmp_bits = CHPL_SAFE_LSHIFT(tmp_bits, nbits, (int)(8*sizeof(qio_bitbuffer_t)));
       tmp_live -= nbits;
       ch->bit_buffer = tmp_bits;
       ch->bit_buffer_bits = tmp_live;

--- a/test/io/jade/CLEANFILES
+++ b/test/io/jade/CLEANFILES
@@ -1,0 +1,1 @@
+test.bin

--- a/test/io/jade/readWriteBits-stress.chpl
+++ b/test/io/jade/readWriteBits-stress.chpl
@@ -5,10 +5,10 @@ use Random;
 
 config const n = 10_000_000;
 config const repeat = 20;
-config const filename = "out.bin";
+config const filename = "test.bin";
 
 for 1..repeat {
-  var f = open("out.bin", ioMode.cwr);
+  var f = open(filename, ioMode.cwr);
   var writes: [1..n] (uint(64), int(64));
   {
     var w = f.writer(serializer=new binarySerializer(), locking=false);

--- a/test/io/jade/readWriteBits-stress.execopts
+++ b/test/io/jade/readWriteBits-stress.execopts
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import os
+
+small = "--n=100_000"
+skips = [
+    ("--baseline", "COMPOPTS"),
+    ("--memLeaks", "EXECOPTS"),
+    ("--memLeaksLog", "EXECOPTS"),
+    ("address", "CHPL_SANITIZE_EXE"),
+    ("on", "CHPL_TEST_VGRND_EXE"),
+]
+if any(flag in os.getenv(env, "") for flag, env in skips):
+    print(small)
+else:
+    print(" ")


### PR DESCRIPTION
Fixes a few writeBits test failures.

* fixed signed int comparison which fails with `-Werror`
* fixed dummy file getting left behind
* fixed too large of a problem size timing out on slow tests

[Reviewed by @benharsh]