### PR TITLE
Adjust module code that was broken under LLVM-14

### DIFF
--- a/modules/internal/ChapelRuntimeInterface.chpl
+++ b/modules/internal/ChapelRuntimeInterface.chpl
@@ -28,10 +28,12 @@ module ChapelRuntimeInterface {
   // The compiler will generate code that calls this procedure in order to
   // deterministically populate the 'chpl_globals_registry' on all locales.
   export proc
-  chpl_registerGlobalVar(idx: c_int, ptrToWidePtr: c_ptr(wide_ptr_t)) {
-    // Extern, but declared by the compiler and lives in program code.
-    extern var chpl_globals_registry: c_ptr(c_ptr(wide_ptr_t));
-    chpl_globals_registry[idx] = ptrToWidePtr;
+  chpl_registerGlobalVar(idx: int(32), ptrToWidePtr: c_ptr(wide_ptr_t)) {
+    param cname = 'chpl_rt_comm_register_global_var';
+    extern cname proc fn(prg: c_ptr(chpl_rt_prginfo),
+                         idx: int(32),
+                         ptr_to_wide_ptr: c_ptr(wide_ptr_t)): void;
+    fn(ptrToPrgInfoHere, idx, ptrToWidePtr);
   }
 
   // These pragmas will be useful for debugging what is going on when a RT

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -338,6 +338,16 @@ chpl_bool chpl_comm_regMemFree(void* p, size_t size) {
   return CHPL_COMM_IMPL_REG_MEM_FREE(p, size);
 }
 
+// Helper to register a global variable to be broadcasted later.
+// TODO: Move this entirely to module code.
+static inline
+void chpl_rt_comm_register_global_var(chpl_rt_prginfo* prg,
+                                      int32_t idx,
+                                      wide_ptr_t* ptr_to_wide_ptr) {
+  CHPL_RT_PRGINFO_DECLARE(prg, chpl_globals_registry);
+  chpl_globals_registry[idx] = ptr_to_wide_ptr;
+}
+
 //
 // This routine is used by the Chapel runtime to broadcast the locations of
 // module-level ("global") variables within a program to all locales so that


### PR DESCRIPTION
This PR tries to fix a nightly test failure related to LLVM-14. I recently moved some runtime code related to registering global variables into the module code. Doing so required an `extern` declaration of `chpl_globals_registry`, but its type was not quite right compared to its internal declaration which caused LLVM-14 to complain. This is only a problem in LLVM-14 because it uses "typed pointers" by default.

TESTING

- [x] `standard`
- [x] `COMM=gasnet`
- [x] `COMM=gasnet`, `COMPILER=gnu`

Reviewed by @benharsh. Thanks!