### PR TITLE
Update c2chapel to use pycparser 3.0 and pycparserext 2026.1

### DIFF
--- a/doc/rst/tools/c2chapel/c2chapel.rst
+++ b/doc/rst/tools/c2chapel/c2chapel.rst
@@ -115,12 +115,13 @@ headers by modifying ``tools/c2chapel/utils/custom.h``.
 Troubleshooting
 ~~~~~~~~~~~~~~~
 
-``c2chapel`` does not perfectly parse all C99 files and you may want to parse
-other C files that are not C99 compliant. If you encounter parsing errors, you can try the following:
+``c2chapel`` ought to parse all C99 files and should handle some C11
+files as well; however, our testing is far from complete.  If you
+encounter parsing errors, you can try the following:
 
-* Use the ``--gnu-extensions`` flag to allow GNU extensions in the C99 file.
+* Use the ``--gnu-extensions`` flag to allow GNU extensions in the C file.
 
-* Comment out the offending lines in the C99 file and re-run ``c2chapel``. You
+* Comment out the offending lines in the C file and re-run ``c2chapel``. You
   can use the generated Chapel code to help you determine which lines are
   causing parsing errors.
 
@@ -139,19 +140,7 @@ other C files that are not C99 compliant. If you encounter parsing errors, you c
 Future Work
 -----------
 
-``c2chapel`` does not currently handle the entirety of C99, so some human
-intervention may be required (e.g. commenting out unhandled portions of the
-file). There are also some limitations based on Chapel's extern capability.
-See https://chapel-lang.org/bugs.html for instructions on reporting bugs.
-
 Known issues:
 
 - fake standard headers are incomplete
 - choice between ``ref``/``c_ptr`` for formals is not intuitive or easily controlled
-
-Contributors
-------------
-| Ben Harshbarger [HPE]
-| Nikhil Padmanabhan [Yale University]
-| Ben McDonald [HPE]
-|

--- a/third-party/chpl-venv/c2chapel-requirements.txt
+++ b/third-party/chpl-venv/c2chapel-requirements.txt
@@ -1,3 +1,3 @@
 # tools/c2chapel/Makefile should match so fakeHeaders download matches
-pycparser==2.23
-pycparserext==2024.1
+pycparser==3.0
+pycparserext==2026.1

--- a/tools/c2chapel/Makefile
+++ b/tools/c2chapel/Makefile
@@ -34,13 +34,8 @@ bdir=$(CHPL_BIN_DIR)
 link=$(bdir)/c2chapel
 
 # Note, this version is used only for the fake headers,
-# but it should probably match third-party/chpl-venv/c2chapel-requirements.txt
-# TODO: this should be 2.23 to match the requirements, but that actually breaks
-# the fake headers (which have new fake headers for dirent, socket, and
-# stdatomic.h)
-# leave this as 2.20 for now until we can update c2chapel to handle the new
-# fake headers
-VERSION=2.20
+# and it should match third-party/chpl-venv/c2chapel-requirements.txt
+VERSION=3.00
 TAR=release_v$(VERSION).tar.gz
 
 RELEASE=https://github.com/eliben/pycparser/archive/$(TAR)

--- a/tools/c2chapel/c2chapel.py
+++ b/tools/c2chapel/c2chapel.py
@@ -805,13 +805,16 @@ def findIgnores():
             with open(defs, "r") as fi:
                 for line in fi:
                     if line.startswith("typedef"):
+                        # handle multi-line 'typedef enum {' case by
+                        # skipping to '} ident;'
+                        if line.endswith(" {\n"):
+                            # assume no nesting for simplicity
+                            for line2 in fi:
+                                if line2.startswith("}"):
+                                    line = line2
+                                    break
                         rhs = line.replace(";", "")
-                        rhs = rhs.replace("typedef int ", "")
-                        rhs = rhs.replace("typedef uint32_t ", "")
-                        rhs = rhs.replace("typedef _Bool ", "")
-                        rhs = rhs.replace("typedef void* ", "")
-                        if "typedef struct" in rhs:
-                            rhs = rhs.split()[-1]
+                        rhs = rhs.split()[-1]
 
                         ret.add(rhs.strip())
 

--- a/tools/c2chapel/test/invalidC.chpl
+++ b/tools/c2chapel/test/invalidC.chpl
@@ -1,1 +1,1 @@
-Unable to parse file: invalidC.h:2:6: before: foo
+Unable to parse file: invalidC.h:2:1: Invalid function definition

--- a/tools/c2chapel/test/justC.chpl
+++ b/tools/c2chapel/test/justC.chpl
@@ -9,6 +9,8 @@ extern proc main() : c_int;
 
 // c2chapel thinks these typedefs are from the fake headers:
 /*
+extern type DIR = c_ptr(void);
+
 extern type FILE = c_int;
 
 // Opaque struct?
@@ -58,6 +60,8 @@ extern type __gid_t = c_int;
 
 extern type __gnuc_va_list = c_int;
 
+extern type __int128_t = c_int;
+
 extern type __int16_t = c_int;
 
 extern type __int32_t = c_int;
@@ -69,6 +73,8 @@ extern type __int8_t = c_int;
 extern type __int_least16_t = c_int;
 
 extern type __int_least32_t = c_int;
+
+extern type __kernel_sa_family_t = c_ushort;
 
 extern type __loff_t = c_int;
 
@@ -86,6 +92,8 @@ extern type __s8 = c_int;
 
 extern type __sigset_t = c_int;
 
+extern type __socklen_t = __uint32_t;
+
 extern type __tzinfo_type = c_int;
 
 extern type __tzrule_type = c_int;
@@ -99,6 +107,8 @@ extern type __u64 = c_int;
 extern type __u8 = c_int;
 
 extern type __uid_t = c_int;
+
+extern type __uint128_t = c_int;
 
 extern type __uint16_t = c_int;
 
@@ -130,9 +140,91 @@ extern type _ssize_t = c_int;
 
 extern type _types_fd_set = c_int;
 
+extern type atomic_bool = _Bool;
+
+extern type atomic_char = c_char;
+
+extern type atomic_char16_t = uint_least16_t;
+
+extern type atomic_char32_t = uint_least32_t;
+
+extern record atomic_flag {
+  var _Value : atomic_bool;
+}
+
+extern type atomic_int = c_int;
+
+extern type atomic_int_fast16_t = int_fast16_t;
+
+extern type atomic_int_fast32_t = int_fast32_t;
+
+extern type atomic_int_fast64_t = int_fast64_t;
+
+extern type atomic_int_fast8_t = int_fast8_t;
+
+extern type atomic_int_least16_t = int_least16_t;
+
+extern type atomic_int_least32_t = int_least32_t;
+
+extern type atomic_int_least64_t = int_least64_t;
+
+extern type atomic_int_least8_t = int_least8_t;
+
+extern type atomic_intmax_t = intmax_t;
+
+extern type atomic_intptr_t = c_intptr;
+
+extern type atomic_llong = c_longlong;
+
+extern type atomic_long = c_long;
+
+extern type atomic_ptrdiff_t = c_ptrdiff;
+
+extern type atomic_schar = c_schar;
+
+extern type atomic_short = c_short;
+
+extern type atomic_size_t = c_size_t;
+
+extern type atomic_uchar = c_uchar;
+
+extern type atomic_uint = c_uint;
+
+extern type atomic_uint_fast16_t = uint_fast16_t;
+
+extern type atomic_uint_fast32_t = uint_fast32_t;
+
+extern type atomic_uint_fast64_t = uint_fast64_t;
+
+extern type atomic_uint_fast8_t = uint_fast8_t;
+
+extern type atomic_uint_least16_t = uint_least16_t;
+
+extern type atomic_uint_least32_t = uint_least32_t;
+
+extern type atomic_uint_least64_t = uint_least64_t;
+
+extern type atomic_uint_least8_t = uint_least8_t;
+
+extern type atomic_uintmax_t = uintmax_t;
+
+extern type atomic_uintptr_t = c_uintptr;
+
+extern type atomic_ullong = c_ulonglong;
+
+extern type atomic_ulong = c_ulong;
+
+extern type atomic_ushort = c_ushort;
+
+extern type atomic_wchar_t = c_wchar_t;
+
 extern type bool = _Bool;
 
 extern type caddr_t = c_int;
+
+extern type char16_t = c_int;
+
+extern type char32_t = c_int;
 
 extern type clock_t = c_int;
 
@@ -200,6 +292,16 @@ extern type lldiv_t = c_int;
 
 extern type mbstate_t = c_int;
 
+// memory_order enum
+extern type memory_order = c_int;
+extern const memory_order_relaxed :memory_order;
+extern const memory_order_consume :memory_order;
+extern const memory_order_acquire :memory_order;
+extern const memory_order_release :memory_order;
+extern const memory_order_acq_rel :memory_order;
+extern const memory_order_seq_cst :memory_order;
+
+
 extern type mode_t = c_int;
 
 extern type nlink_t = c_int;
@@ -251,6 +353,8 @@ extern type sigjmp_buf = c_int;
 extern type sigset_t = c_int;
 
 extern type size_t = c_int;
+
+extern type socklen_t = __socklen_t;
 
 extern type ssize_t = c_int;
 

--- a/tools/c2chapel/test/sysCTypes.chpl
+++ b/tools/c2chapel/test/sysCTypes.chpl
@@ -34,6 +34,8 @@ extern proc unsignedWidths(a : uint(8), b : uint(16), c : uint(32), d : uint(64)
 
 // c2chapel thinks these typedefs are from the fake headers:
 /*
+extern type DIR = c_ptr(void);
+
 extern type FILE = c_int;
 
 // Opaque struct?
@@ -83,6 +85,8 @@ extern type __gid_t = c_int;
 
 extern type __gnuc_va_list = c_int;
 
+extern type __int128_t = c_int;
+
 extern type __int16_t = c_int;
 
 extern type __int32_t = c_int;
@@ -94,6 +98,8 @@ extern type __int8_t = c_int;
 extern type __int_least16_t = c_int;
 
 extern type __int_least32_t = c_int;
+
+extern type __kernel_sa_family_t = c_ushort;
 
 extern type __loff_t = c_int;
 
@@ -111,6 +117,8 @@ extern type __s8 = c_int;
 
 extern type __sigset_t = c_int;
 
+extern type __socklen_t = __uint32_t;
+
 extern type __tzinfo_type = c_int;
 
 extern type __tzrule_type = c_int;
@@ -124,6 +132,8 @@ extern type __u64 = c_int;
 extern type __u8 = c_int;
 
 extern type __uid_t = c_int;
+
+extern type __uint128_t = c_int;
 
 extern type __uint16_t = c_int;
 
@@ -155,9 +165,91 @@ extern type _ssize_t = c_int;
 
 extern type _types_fd_set = c_int;
 
+extern type atomic_bool = _Bool;
+
+extern type atomic_char = c_char;
+
+extern type atomic_char16_t = uint_least16_t;
+
+extern type atomic_char32_t = uint_least32_t;
+
+extern record atomic_flag {
+  var _Value : atomic_bool;
+}
+
+extern type atomic_int = c_int;
+
+extern type atomic_int_fast16_t = int_fast16_t;
+
+extern type atomic_int_fast32_t = int_fast32_t;
+
+extern type atomic_int_fast64_t = int_fast64_t;
+
+extern type atomic_int_fast8_t = int_fast8_t;
+
+extern type atomic_int_least16_t = int_least16_t;
+
+extern type atomic_int_least32_t = int_least32_t;
+
+extern type atomic_int_least64_t = int_least64_t;
+
+extern type atomic_int_least8_t = int_least8_t;
+
+extern type atomic_intmax_t = intmax_t;
+
+extern type atomic_intptr_t = c_intptr;
+
+extern type atomic_llong = c_longlong;
+
+extern type atomic_long = c_long;
+
+extern type atomic_ptrdiff_t = c_ptrdiff;
+
+extern type atomic_schar = c_schar;
+
+extern type atomic_short = c_short;
+
+extern type atomic_size_t = c_size_t;
+
+extern type atomic_uchar = c_uchar;
+
+extern type atomic_uint = c_uint;
+
+extern type atomic_uint_fast16_t = uint_fast16_t;
+
+extern type atomic_uint_fast32_t = uint_fast32_t;
+
+extern type atomic_uint_fast64_t = uint_fast64_t;
+
+extern type atomic_uint_fast8_t = uint_fast8_t;
+
+extern type atomic_uint_least16_t = uint_least16_t;
+
+extern type atomic_uint_least32_t = uint_least32_t;
+
+extern type atomic_uint_least64_t = uint_least64_t;
+
+extern type atomic_uint_least8_t = uint_least8_t;
+
+extern type atomic_uintmax_t = uintmax_t;
+
+extern type atomic_uintptr_t = c_uintptr;
+
+extern type atomic_ullong = c_ulonglong;
+
+extern type atomic_ulong = c_ulong;
+
+extern type atomic_ushort = c_ushort;
+
+extern type atomic_wchar_t = c_wchar_t;
+
 extern type bool = _Bool;
 
 extern type caddr_t = c_int;
+
+extern type char16_t = c_int;
+
+extern type char32_t = c_int;
 
 extern type clock_t = c_int;
 
@@ -225,6 +317,16 @@ extern type lldiv_t = c_int;
 
 extern type mbstate_t = c_int;
 
+// memory_order enum
+extern type memory_order = c_int;
+extern const memory_order_relaxed :memory_order;
+extern const memory_order_consume :memory_order;
+extern const memory_order_acquire :memory_order;
+extern const memory_order_release :memory_order;
+extern const memory_order_acq_rel :memory_order;
+extern const memory_order_seq_cst :memory_order;
+
+
 extern type mode_t = c_int;
 
 extern type nlink_t = c_int;
@@ -276,6 +378,8 @@ extern type sigjmp_buf = c_int;
 extern type sigset_t = c_int;
 
 extern type size_t = c_int;
+
+extern type socklen_t = __socklen_t;
 
 extern type ssize_t = c_int;
 


### PR DESCRIPTION
This updates c2chapel to use pycparser 3.0 and pycparserext 2026.1 now that the latter has been released.

The simple part of this PR was updating the version numbers in `third-party/chpl-venv/c2chapel-requirements.txt` and `tools/c2chapel/Makefile`.

The more labor-intensive part was remembering that the fake headers are parsed and put into a separate category by `tools/c2chapel/c2chapel.py`, which needed to be updated because the previous logic was rather simplistically implemented (by me, I think) to just look for the typedef patterns that existed in the fake headers at that time, which were fairly predictable.  They've since become a bit more diverse, so here I generalized the logic for the typical one-liner typedef and then added a new tailored special case for a single multi-line enum typedef in the fake headers.

I checked these changes by ensuring that the output generated for `tools/c2chapel/test/sysCTypes.chpl` and `tools/c2chapel/test/justC.chpl` was the same prior to the fake header comment and that all other declarations fell into the fake header section and were strictly additive.

One other unit test needed updating, to reflect the improved error message produced by pycparser 3.0.

I gave the docs a minor refresh to reflect that pycparser 3.0 claims to parse all of C99 and some of C11 and to remove the Contributors list, primarily because it hasn't been maintained, and most of our other tools don't have such sections.

I considered bumping the version number to 0.2.0 due to these changes, but doing so requires all of the unit tests, which wasn't that appealing.  Probably the right thing to do is update the little unit testing script to write out the version number as it runs the tests so that they're not captured in the git repo, but that was more than I felt motivated to take on here.

Resolves #28555