### PR TITLE
dlopen: Refactor 'execute on' functions in runtime/modules

### DIFF
--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -7181,13 +7181,13 @@ void CallExpr::codegenInvokeOnFun() {
   // get(4) is a dummy class type for the argument bundle
 
   if (fn->hasFlag(FLAG_NON_BLOCKING))
-    fname = "chpl_executeOnNB";
+    fname = "chpl_localeModelExecuteOnNb";
 
   else if (fn->hasFlag(FLAG_FAST_ON))
-    fname = "chpl_executeOnFast";
+    fname = "chpl_localeModelExecuteOnFast";
 
   else
-    fname = "chpl_executeOn";
+    fname = "chpl_localeModelExecuteOn";
 
   argBundle  = codegenValue(get(2));
   bundleSize = codegenValue(get(3));

--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -122,6 +122,7 @@ struct DefinitionInfo {
       astr("SharedObject"),
       astr("String"),
       astr("LocaleModelHelpRuntime"),
+      astr("ChapelRuntimeInterface"),
     });
     if (sym_->getModule()->modTag == MOD_INTERNAL) {
       auto modName = sym_->getModule()->name;

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1360,7 +1360,7 @@ static void insertEndCounts()
 // if ( chpl_doDirectExecuteOn( targetLocale ) )
 //     call un-wrapped task function
 // else
-//     proceed as with chpl_executeOn/chpl_executeOnFast
+//     proceed as with chpl_localeModelExecuteOn/chpl_localeModelExecuteOnFast
 //     fid call to wrapper function on a remote local
 //     (possibly just a different sublocale)
 //

--- a/frontend/include/chpl/resolution/all-internal-types-list.h
+++ b/frontend/include/chpl/resolution/all-internal-types-list.h
@@ -64,9 +64,9 @@ START_INTERNAL_MODULE(ChapelLocale)
   INTERNAL_TYPE(ChapelLocale, Locale, _locale, "record _locale {}")
 END_INTERNAL_MODULE(ChapelLocale)
 
-START_INTERNAL_MODULE(LocaleModelHelpRuntime)
-  INTERNAL_TYPE(LocaleModelHelpRuntime, LocaleId, chpl_localeID_t, "record chpl_localeID_t {}")
-END_INTERNAL_MODULE(LocaleModelHelpRuntime)
+START_INTERNAL_MODULE(ChapelRuntimeInterface)
+  INTERNAL_TYPE(ChapelRuntimeInterface, LocaleId, chpl_localeID_t, "record chpl_localeID_t {}")
+END_INTERNAL_MODULE(ChapelRuntimeInterface)
 
 START_INTERNAL_MODULE(OwnedObject)
   INTERNAL_TYPE(OwnedObject, Owned, _owned, "record _owned {}")

--- a/frontend/lib/types/CompositeType.cpp
+++ b/frontend/lib/types/CompositeType.cpp
@@ -202,7 +202,7 @@ const RecordType* CompositeType::getLocaleType(Context* context) {
 }
 
 const RecordType* CompositeType::getLocaleIDType(Context* context) {
-  auto [id, name] = parsing::getLocaleIdTypeFromTopLevelLocaleModelHelpRuntimeModule(context);
+  auto [id, name] = parsing::getLocaleIdTypeFromTopLevelChapelRuntimeInterfaceModule(context);
   return RecordType::get(context, id, name,
                          /* instantiatedFrom */ nullptr,
                          SubstitutionsMap());

--- a/modules/internal/ChapelRuntimeInterface.chpl
+++ b/modules/internal/ChapelRuntimeInterface.chpl
@@ -109,4 +109,54 @@ module ChapelRuntimeInterface {
                          arg_size: c_size_t): void;
     fn(ptrToPrgInfoHere, node, subloc, fid, arg, arg_size);
   }
+
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc chpl_addTask(fid: int, args: chpl_task_bundle_p,
+                    args_size: c_size_t,
+                    subloc_id: int) {
+    param cname = 'chpl_rt_task_add_task';
+    pragma "insert line file info"
+    pragma "always propagate line file info"
+    extern cname proc fn(prg: c_ptr(chpl_rt_prginfo), fid: int,
+                         args: chpl_task_bundle_p,
+                         args_size: c_size_t,
+                         subloc_id: int): void;
+    fn(ptrToPrgInfoHere, fid, args, args_size, subloc_id);
+  }
+
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc chpl_commTaskFtableCall(fid: int, args: chpl_comm_on_bundle_p,
+                               args_size: c_size_t,
+                               subloc_id: int) {
+    param cname = 'chpl_rt_comm_task_ftable_call';
+    pragma "insert line file info"
+    pragma "always propagate line file info"
+    extern cname proc fn(prg: c_ptr(chpl_rt_prginfo), fid: int,
+                         args: chpl_comm_on_bundle_p,
+                         args_size: c_size_t,
+                         subloc_id: int): void;
+    fn(ptrToPrgInfoHere, fid, args, args_size, subloc_id);
+  }
+
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc chpl_ftableCall(fid: int, args: c_ptr(void)) {
+    param cname = 'chpl_rt_ftable_call';
+    // TODO: No need to actually call into the runtime to do this.
+    extern cname proc fn(prg: c_ptr(chpl_rt_prginfo), fid: int,
+                         bundle: c_ptr(void)): void;
+    fn(ptrToPrgInfoHere, fid, args);
+  }
+
+  inline proc chpl_ftableCall(fid: int, args: chpl_comm_on_bundle_p) {
+    const ptr = __primitive('cast', c_ptr(void), args);
+    chpl_ftableCall(fid, ptr);
+  }
+
+  inline proc chpl_ftableCall(fid: int, args: chpl_task_bundle_p) {
+    const ptr = __primitive('cast', c_ptr(void), args);
+    chpl_ftableCall(fid, ptr);
+  }
 }

--- a/modules/internal/ChapelRuntimeInterface.chpl
+++ b/modules/internal/ChapelRuntimeInterface.chpl
@@ -21,6 +21,12 @@
 module ChapelRuntimeInterface {
   use ChapelBase, ChapelProgramRegistration, CTypes;
 
+  // Records with empty bodies are intentionally opaque.
+  extern record chpl_localeID_t {};
+  extern record chpl_comm_on_bundle_t {};
+  extern record chpl_task_bundle_t {};
+  extern type chpl_comm_on_bundle_p;
+  extern type chpl_task_bundle_p;
   extern type wide_ptr_t;
 
   inline proc ptrToPrgInfoHere do return chpl_programInfoHere.asPtr();
@@ -57,5 +63,50 @@ module ChapelRuntimeInterface {
                          idx: int(32),
                          size: c_size_t): void;
     fn(ptrToPrgInfoHere, idx, size);
+  }
+
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc chpl_executeOn(node: int, subloc: int, fid: int,
+                            arg: chpl_comm_on_bundle_p,
+                            arg_size: c_size_t) {
+    param cname = 'chpl_rt_comm_execute_on';
+    pragma "insert line file info"
+    pragma "always propagate line file info"
+    extern cname proc fn(prg: c_ptr(chpl_rt_prginfo), node: int,
+                         subloc: int, fid: int,
+                         arg: chpl_comm_on_bundle_p,
+                         arg_size: c_size_t): void;
+    fn(ptrToPrgInfoHere, node, subloc, fid, arg, arg_size);
+  }
+
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc chpl_executeOnFast(node: int, subloc: int, fid: int,
+                          arg: chpl_comm_on_bundle_p,
+                          arg_size: c_size_t) {
+    param cname = 'chpl_rt_comm_execute_on_fast';
+    pragma "insert line file info"
+    pragma "always propagate line file info"
+    extern cname proc fn(prg: c_ptr(chpl_rt_prginfo), node: int,
+                         subloc: int, fid: int,
+                         arg: chpl_comm_on_bundle_p,
+                         arg_size: c_size_t): void;
+    fn(ptrToPrgInfoHere, node, subloc, fid, arg, arg_size);
+  }
+
+  pragma "insert line file info"
+  pragma "always propagate line file info"
+  proc chpl_executeOnNb(node: int, subloc: int, fid: int,
+                        arg: chpl_comm_on_bundle_p,
+                        arg_size: c_size_t) {
+    param cname = 'chpl_rt_comm_execute_on_nb';
+    pragma "insert line file info"
+    pragma "always propagate line file info"
+    extern cname proc fn(prg: c_ptr(chpl_rt_prginfo), node: int,
+                         subloc: int, fid: int,
+                         arg: chpl_comm_on_bundle_p,
+                         arg_size: c_size_t): void;
+    fn(ptrToPrgInfoHere, node, subloc, fid, arg, arg_size);
   }
 }

--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -92,5 +92,4 @@ module ChapelStandard {
   use ChapelDynamicLoading;
   use ChapelProgramEntrypoints;
   use ChapelProgramRegistration;
-
 }

--- a/modules/internal/ChapelStandard.chpl
+++ b/modules/internal/ChapelStandard.chpl
@@ -50,6 +50,7 @@ module ChapelStandard {
   public use ChapelReduce;
   public use ChapelSyncvar;
   public use ChapelTaskDataHelp;
+  public use ChapelRuntimeInterface;
   public use LocaleModel;
   public use ChapelLocale;
   public use ChapelPrivatization;
@@ -91,5 +92,5 @@ module ChapelStandard {
   use ChapelDynamicLoading;
   use ChapelProgramEntrypoints;
   use ChapelProgramRegistration;
-  use ChapelRuntimeInterface;
+
 }

--- a/modules/internal/LocaleModelHelpFlat.chpl
+++ b/modules/internal/LocaleModelHelpFlat.chpl
@@ -28,6 +28,7 @@ module LocaleModelHelpFlat {
   use CTypes;
   use ChapelBase;
   use ChapelLocale;
+  use ChapelRuntimeInterface;
 
   //////////////////////////////////////////
   //
@@ -46,8 +47,7 @@ module LocaleModelHelpFlat {
   //         chpl_executeOn / chpl_executeOnFast
   //
   export
-  proc chpl_doDirectExecuteOn(in loc: chpl_localeID_t // target locale
-                             ):bool {
+  proc chpl_doDirectExecuteOn(in loc: chpl_localeID_t): bool {
     const node = chpl_nodeFromLocaleID(loc);
     return (node == chpl_nodeID);
   }
@@ -57,11 +57,10 @@ module LocaleModelHelpFlat {
   //
   pragma "insert line file info"
   export
-  proc chpl_executeOn(in loc: chpl_localeID_t, // target locale
-                      fn: int,              // on-body function idx
-                      args: chpl_comm_on_bundle_p,     // function args
-                      args_size: c_size_t     // args size
-                     ) {
+  proc chpl_localeModelExecuteOn(in loc: chpl_localeID_t,
+                                 fn: int,
+                                 args: chpl_comm_on_bundle_p,
+                                 args_size: c_size_t) {
     const node = chpl_nodeFromLocaleID(loc);
     if (node == chpl_nodeID) {
       // don't call the runtime execute_on function if we can stay local
@@ -72,8 +71,8 @@ module LocaleModelHelpFlat {
     } else {
       var tls = chpl_task_getInfoChapel();
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
-      chpl_comm_execute_on(node, chpl_sublocFromLocaleID(loc),
-                           fn, args, args_size);
+      chpl_executeOn(node, chpl_sublocFromLocaleID(loc),
+                     fn, args, args_size);
     }
   }
 
@@ -83,11 +82,10 @@ module LocaleModelHelpFlat {
   //
   pragma "insert line file info"
   export
-  proc chpl_executeOnFast(in loc: chpl_localeID_t, // target locale
-                          fn: int,              // on-body function idx
-                          args: chpl_comm_on_bundle_p,     // function args
-                          args_size: c_size_t     // args size
-                         ) {
+  proc chpl_localeModelExecuteOnFast(in loc: chpl_localeID_t,
+                                     fn: int,
+                                     args: chpl_comm_on_bundle_p,
+                                     args_size: c_size_t) {
     const node = chpl_nodeFromLocaleID(loc);
     if (node == chpl_nodeID) {
       // don't call the runtime fast execute_on function if we can stay local
@@ -95,8 +93,8 @@ module LocaleModelHelpFlat {
     } else {
       var tls = chpl_task_getInfoChapel();
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
-      chpl_comm_execute_on_fast(node, chpl_sublocFromLocaleID(loc),
-                                fn, args, args_size);
+      chpl_executeOnFast(node, chpl_sublocFromLocaleID(loc),
+                         fn, args, args_size);
     }
   }
 
@@ -105,11 +103,10 @@ module LocaleModelHelpFlat {
   //
   pragma "insert line file info"
   export
-  proc chpl_executeOnNB(in loc: chpl_localeID_t, // target locale
-                        fn: int,              // on-body function idx
-                        args: chpl_comm_on_bundle_p,     // function args
-                        args_size: c_size_t     // args size
-                       ) {
+  proc chpl_localeModelExecuteOnNb(in loc: chpl_localeID_t,
+                                   fn: int,
+                                   args: chpl_comm_on_bundle_p,
+                                   args_size: c_size_t) {
     //
     // If we're in serial mode, we should use blocking rather than
     // non-blocking "on" in order to serialize the execute_ons.
@@ -128,9 +125,9 @@ module LocaleModelHelpFlat {
     } else {
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
       if isSerial {
-        chpl_comm_execute_on(node, c_sublocid_none, fn, args, args_size);
+        chpl_executeOn(node, c_sublocid_none, fn, args, args_size);
       } else {
-        chpl_comm_execute_on_nb(node, c_sublocid_none, fn, args, args_size);
+        chpl_executeOnNb(node, c_sublocid_none, fn, args, args_size);
       }
     }
   }

--- a/modules/internal/LocaleModelHelpFlat.chpl
+++ b/modules/internal/LocaleModelHelpFlat.chpl
@@ -67,7 +67,7 @@ module LocaleModelHelpFlat {
       // one day, we could rely on this always being handled
       // by the compiler's use of doDirectExecuteOn, but for now
       // the compiler calls this version in some cases.
-      chpl_ftable_call(fn, args);
+      chpl_ftableCall(fn, args);
     } else {
       var tls = chpl_task_getInfoChapel();
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
@@ -89,7 +89,7 @@ module LocaleModelHelpFlat {
     const node = chpl_nodeFromLocaleID(loc);
     if (node == chpl_nodeID) {
       // don't call the runtime fast execute_on function if we can stay local
-      chpl_ftable_call(fn, args);
+      chpl_ftableCall(fn, args);
     } else {
       var tls = chpl_task_getInfoChapel();
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
@@ -117,10 +117,10 @@ module LocaleModelHelpFlat {
     if (node == chpl_nodeID) {
       // don't call the runtime nb execute_on function if we can stay local
       if isSerial {
-        chpl_ftable_call(fn, args);
+        chpl_ftableCall(fn, args);
       } else {
         chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
-        chpl_comm_taskCallFTable(fn, args, args_size, c_sublocid_none);
+        chpl_commTaskFtableCall(fn, args, args_size, c_sublocid_none);
       }
     } else {
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);

--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -26,6 +26,7 @@ module LocaleModelHelpGPU {
   use CTypes;
   use ChapelBase;
   use ChapelLocale;
+  use ChapelRuntimeInterface;
 
   @chpldoc.nodoc
   config param debugGPULocale = false;
@@ -62,8 +63,7 @@ module LocaleModelHelpGPU {
   //         chpl_executeOn / chpl_executeOnFast
   //
   pragma "always resolve function"
-  proc chpl_doDirectExecuteOn(in loc: chpl_localeID_t // target locale
-                             ):bool {
+  proc chpl_doDirectExecuteOn(in loc: chpl_localeID_t): bool {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
 
@@ -84,11 +84,11 @@ module LocaleModelHelpGPU {
   //
   pragma "insert line file info"
   pragma "always resolve function"
-  proc chpl_executeOn(in loc: chpl_localeID_t, // target locale
-                      fn: int,              // on-body function idx
-                      args: chpl_comm_on_bundle_p,     // function args
-                      args_size: c_size_t     // args size
-                     ) {
+  proc chpl_localeModelExecuteOn(
+                        in loc: chpl_localeID_t,      // target locale
+                        fn: int,                      // on-body function idx
+                        args: chpl_comm_on_bundle_p,  // function args
+                        args_size: c_size_t) {        // args size
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
 
@@ -104,7 +104,7 @@ module LocaleModelHelpGPU {
     if dnode != chpl_nodeID {
       var tls = chpl_task_getInfoChapel();
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
-      chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);
+      chpl_executeOn(dnode, dsubloc, fn, args, args_size);
     } else {
       // run directly on this node
       var origSubloc = chpl_task_getRequestedSubloc();
@@ -125,17 +125,16 @@ module LocaleModelHelpGPU {
   //
   pragma "insert line file info"
   pragma "always resolve function"
-  proc chpl_executeOnFast(in loc: chpl_localeID_t, // target locale
-                          fn: int,              // on-body function idx
-                          args: chpl_comm_on_bundle_p,     // function args
-                          args_size: c_size_t     // args size
-                         ) {
+  proc chpl_localeModelExecuteOnFast(in loc: chpl_localeID_t,
+                                     fn: int,
+                                     args: chpl_comm_on_bundle_p,
+                                     args_size: c_size_t) {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
     if dnode != chpl_nodeID {
       var tls = chpl_task_getInfoChapel();
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
-      chpl_comm_execute_on_fast(dnode, dsubloc, fn, args, args_size);
+      chpl_executeOnFast(dnode, dsubloc, fn, args, args_size);
     } else {
       var origSubloc = chpl_task_getRequestedSubloc();
       if (dsubloc==origSubloc) {
@@ -154,14 +153,13 @@ module LocaleModelHelpGPU {
   //
   pragma "insert line file info"
   pragma "always resolve function"
-  proc chpl_executeOnNB(in loc: chpl_localeID_t, // target locale
-                        fn: int,              // on-body function idx
-                        args: chpl_comm_on_bundle_p,     // function args
-                        args_size: c_size_t     // args size
-                       ) {
+  proc chpl_localeModelExecuteOnNb(in loc: chpl_localeID_t,
+                                   fn: int,
+                                   args: chpl_comm_on_bundle_p,
+                                   args_size: c_size_t) {
     //
     // If we're in serial mode, we should use blocking rather than
-    // non-blocking "on" in order to serialize the execute_ons.
+    // non-blocking "on" in order to serialize the executeOns.
     //
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
@@ -177,9 +175,9 @@ module LocaleModelHelpGPU {
     } else {
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
       if isSerial {
-        chpl_comm_execute_on(dnode, dsubloc, fn, args, args_size);
+        chpl_executeOn(dnode, dsubloc, fn, args, args_size);
       } else {
-        chpl_comm_execute_on_nb(dnode, dsubloc, fn, args, args_size);
+        chpl_executeOnNb(dnode, dsubloc, fn, args, args_size);
       }
     }
   }

--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -109,11 +109,11 @@ module LocaleModelHelpGPU {
       // run directly on this node
       var origSubloc = chpl_task_getRequestedSubloc();
       if (dsubloc==origSubloc) {
-        chpl_ftable_call(fn, args);
+        chpl_ftableCall(fn, args);
       } else {
         // move to a different sublocale
         chpl_task_setSubloc(dsubloc);
-        chpl_ftable_call(fn, args);
+        chpl_ftableCall(fn, args);
         chpl_task_setSubloc(origSubloc);
       }
     }
@@ -138,11 +138,11 @@ module LocaleModelHelpGPU {
     } else {
       var origSubloc = chpl_task_getRequestedSubloc();
       if (dsubloc==origSubloc) {
-        chpl_ftable_call(fn, args);
+        chpl_ftableCall(fn, args);
       } else {
         // move to a different sublocale
         chpl_task_setSubloc(dsubloc);
-        chpl_ftable_call(fn, args);
+        chpl_ftableCall(fn, args);
         chpl_task_setSubloc(origSubloc);
       }
     }
@@ -167,10 +167,10 @@ module LocaleModelHelpGPU {
     var isSerial = chpl_task_data_getSerial(tls);
     if dnode == chpl_nodeID {
       if isSerial {
-        chpl_ftable_call(fn, args);
+        chpl_ftableCall(fn, args);
       } else {
         chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);
-        chpl_comm_taskCallFTable(fn, args, args_size, dsubloc);
+        chpl_commTaskFtableCall(fn, args, args_size, dsubloc);
       }
     } else {
       chpl_task_data_setup(chpl_comm_on_bundle_task_bundle(args), tls);

--- a/modules/internal/LocaleModelHelpGPU.chpl
+++ b/modules/internal/LocaleModelHelpGPU.chpl
@@ -84,7 +84,7 @@ module LocaleModelHelpGPU {
   //
   pragma "insert line file info"
   pragma "always resolve function"
-  proc chpl_localeModelExecuteOn(
+  export proc chpl_localeModelExecuteOn(
                         in loc: chpl_localeID_t,      // target locale
                         fn: int,                      // on-body function idx
                         args: chpl_comm_on_bundle_p,  // function args
@@ -125,10 +125,10 @@ module LocaleModelHelpGPU {
   //
   pragma "insert line file info"
   pragma "always resolve function"
-  proc chpl_localeModelExecuteOnFast(in loc: chpl_localeID_t,
-                                     fn: int,
-                                     args: chpl_comm_on_bundle_p,
-                                     args_size: c_size_t) {
+  export proc chpl_localeModelExecuteOnFast(in loc: chpl_localeID_t,
+                                            fn: int,
+                                            args: chpl_comm_on_bundle_p,
+                                            args_size: c_size_t) {
     const dnode =  chpl_nodeFromLocaleID(loc);
     const dsubloc =  chpl_sublocFromLocaleID(loc);
     if dnode != chpl_nodeID {
@@ -153,10 +153,10 @@ module LocaleModelHelpGPU {
   //
   pragma "insert line file info"
   pragma "always resolve function"
-  proc chpl_localeModelExecuteOnNb(in loc: chpl_localeID_t,
-                                   fn: int,
-                                   args: chpl_comm_on_bundle_p,
-                                   args_size: c_size_t) {
+  export proc chpl_localeModelExecuteOnNb(in loc: chpl_localeID_t,
+                                          fn: int,
+                                          args: chpl_comm_on_bundle_p,
+                                          args_size: c_size_t) {
     //
     // If we're in serial mode, we should use blocking rather than
     // non-blocking "on" in order to serialize the executeOns.

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -28,30 +28,7 @@
 // duplication. If necessary, a locale model using this file
 // should feel free to reimplement them in some other way.
 module LocaleModelHelpRuntime {
-  private use ChapelStandard, CTypes;
-
-  // The chpl_localeID_t type is used internally.  It should not be exposed to
-  // the user.  The runtime defines the actual type, as well as a functional
-  // interface for assembling and disassembling chpl_localeID_t values.  This
-  // module then provides the interface the compiler-emitted code uses to do
-  // the same.
-
-  extern record chpl_localeID_t {
-    // We need to know that this is a record type in order to pass it to and
-    // return it from runtime functions properly, but we don't need or want
-    // to see its contents.
-  };
-
-  // runtime stuff about argument bundles
-  extern record chpl_comm_on_bundle_t {
-  };
-
-  extern record chpl_task_bundle_t {
-  };
-
-  extern type chpl_comm_on_bundle_p;
-
-  extern type chpl_task_bundle_p;
+  private use ChapelStandard, CTypes, ChapelRuntimeInterface;
 
   pragma "fn synchronization free"
   extern proc chpl_comm_on_bundle_task_bundle(bundle:chpl_comm_on_bundle_p):chpl_task_bundle_p;
@@ -97,18 +74,10 @@ module LocaleModelHelpRuntime {
   // runtime interface
   //
   pragma "insert line file info"
-  extern proc chpl_comm_execute_on(loc_id: int, subloc_id: int, fn: int,
-                                   args: chpl_comm_on_bundle_p, arg_size: c_size_t);
-  pragma "insert line file info"
-  extern proc chpl_comm_execute_on_fast(loc_id: int, subloc_id: int, fn: int,
-                                        args: chpl_comm_on_bundle_p, args_size: c_size_t);
-  pragma "insert line file info"
-  extern proc chpl_comm_execute_on_nb(loc_id: int, subloc_id: int, fn: int,
-                                      args: chpl_comm_on_bundle_p, args_size: c_size_t);
-  pragma "insert line file info"
-    extern proc chpl_comm_taskCallFTable(fn: int,
-                                         args: chpl_comm_on_bundle_p, args_size: c_size_t,
-                                         subloc_id: int): void;
+  extern proc chpl_comm_taskCallFTable(fn: int,
+                                       args: chpl_comm_on_bundle_p,
+                                       args_size: c_size_t,
+                                       subloc_id: int): void;
   extern proc chpl_ftable_call(fn: int, args: chpl_comm_on_bundle_p): void;
   extern proc chpl_ftable_call(fn: int, args: chpl_task_bundle_p): void;
 

--- a/modules/internal/LocaleModelHelpRuntime.chpl
+++ b/modules/internal/LocaleModelHelpRuntime.chpl
@@ -67,32 +67,8 @@ module LocaleModelHelpRuntime {
 
   //////////////////////////////////////////
   //
-  // support for "on" statements
-  //
-
-  //
-  // runtime interface
-  //
-  pragma "insert line file info"
-  extern proc chpl_comm_taskCallFTable(fn: int,
-                                       args: chpl_comm_on_bundle_p,
-                                       args_size: c_size_t,
-                                       subloc_id: int): void;
-  extern proc chpl_ftable_call(fn: int, args: chpl_comm_on_bundle_p): void;
-  extern proc chpl_ftable_call(fn: int, args: chpl_task_bundle_p): void;
-
-  //////////////////////////////////////////
-  //
   // support for tasking statements: begin, cobegin, coforall
   //
-
-  //
-  // runtime interface
-  //
-  pragma "insert line file info"
-  extern proc chpl_task_addTask(fn: int,
-                                args: chpl_task_bundle_p, args_size: c_size_t,
-                                subloc_id: int);
 
   //
   // Add a task for a begin statement.
@@ -107,10 +83,10 @@ module LocaleModelHelpRuntime {
     var tls = chpl_task_getInfoChapel();
     var isSerial = chpl_task_data_getSerial(tls);
     if isSerial {
-      chpl_ftable_call(fn, args);
+      chpl_ftableCall(fn, args);
     } else {
       chpl_task_data_setup(args, tls);
-      chpl_task_addTask(fn, args, args_size, subloc_id);
+      chpl_addTask(fn, args, args_size, subloc_id);
     }
   }
 
@@ -131,10 +107,10 @@ module LocaleModelHelpRuntime {
       chpl_task_data_setNextCoStmtSerial(tls, false);
     }
     if isSerial {
-      chpl_ftable_call(fn, args);
+      chpl_ftableCall(fn, args);
     } else {
       chpl_task_data_setup(args, tls);
-      chpl_task_addTask(fn, args, args_size, subloc_id);
+      chpl_addTask(fn, args, args_size, subloc_id);
      }
   }
 

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -122,6 +122,36 @@ void* chpl_rt_comm_fetch_broadcast_table(chpl_rt_prginfo* prg,
                                          chpl_rt_prg_id prg_id,
                                          size_t* out_table_len);
 
+// Per comm layer implementation.
+void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg,
+                                  c_nodeid_t node,
+                                  c_sublocid_t subloc,
+                                  chpl_fn_int_t fid,
+                                  chpl_comm_on_bundle_t *arg,
+                                  size_t arg_size,
+                                  int ln,
+                                  int32_t fn);
+
+// Per comm layer implementation.
+void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg,
+                                       c_nodeid_t node,
+                                       c_sublocid_t subloc,
+                                       chpl_fn_int_t fid,
+                                       chpl_comm_on_bundle_t *arg,
+                                       size_t arg_size,
+                                       int ln,
+                                       int32_t fn);
+
+// Per comm layer implementation.
+void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg,
+                                     c_nodeid_t node,
+                                     c_sublocid_t subloc,
+                                     chpl_fn_int_t fid,
+                                     chpl_comm_on_bundle_t *arg,
+                                     size_t arg_size,
+                                     int ln,
+                                     int32_t fn);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -92,20 +92,18 @@ chpl_task_bundle_t* chpl_comm_on_bundle_task_bundle(chpl_comm_on_bundle_t* a)
 // we have function table indices rather than function pointers.
 //
 static inline
-void chpl_comm_taskCallFTable(chpl_fn_int_t fid,      // ftable[] entry to call
-                              chpl_comm_on_bundle_t* arg,// function arg
-                              size_t arg_size,        // length of arg in bytes
-                              c_sublocid_t subloc,    // desired sublocale
-                              int lineno,             // source line
-                              int32_t filename) {     // source filename
+void chpl_rt_comm_task_ftable_call(
+                      chpl_rt_prginfo* prg,
+                      chpl_fn_int_t fid,            // ftable[] entry to call
+                      chpl_comm_on_bundle_t* arg,   // function arg
+                      size_t arg_size,              // length of arg in bytes
+                      c_sublocid_t subloc,          // desired sublocale
+                      int lineno,                   // source line
+                      int32_t filename) {           // source filename
     arg->kind = CHPL_ARG_BUNDLE_KIND_COMM;
-    chpl_task_taskCallFTable(fid,
-                             arg, arg_size,
-                             subloc,
-                             lineno, filename);
+    chpl_rt_task_task_ftable_call(prg, fid, arg, arg_size, subloc,
+                                  lineno, filename);
 }
-
-
 
 // Do a GET in a nonblocking fashion, returning a handle which can be used to
 // wait for the GET to complete. The destination buffer must not be modified

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -74,6 +74,7 @@ typedef struct {
   chpl_arg_bundle_kind_t kind;  // 'kind' indicator must be first in any bundle
   chpl_comm_bundleData_t comm;  // for comm layer wrappers
   chpl_task_bundle_t task_bundle;
+  chpl_rt_prg_id prg_id;
   uint64_t payload[0];
 } chpl_comm_on_bundle_t;
 

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -513,28 +513,37 @@ void chpl_comm_getput_unordered_task_fence(void);
 // notes:
 //   multiple executeOns to the same locale should be handled concurrently
 //
-void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
-                          chpl_fn_int_t fid,
-                          chpl_comm_on_bundle_t *arg, size_t arg_size,
-                          int ln, int32_t fn);
+void chpl_rt_comm_execute_on(chpl_rt_prginfo* prg, c_nodeid_t node,
+                             c_sublocid_t subloc,
+                             chpl_fn_int_t fid,
+                             chpl_comm_on_bundle_t *arg,
+                             size_t arg_size,
+                             int ln,
+                             int32_t fn);
 
 //
 // non-blocking execute_on
 // arg can be reused immediately after this call completes.
 //
-void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
-                             chpl_fn_int_t fid,
-                             chpl_comm_on_bundle_t *arg, size_t arg_size,
-                             int ln, int32_t fn);
+void chpl_rt_comm_execute_on_nb(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                c_sublocid_t subloc,
+                                chpl_fn_int_t fid,
+                                chpl_comm_on_bundle_t *arg,
+                                size_t arg_size,
+                                int ln,
+                                int32_t fn);
 
 //
 // fast execute_on (i.e., run in handler)
 // arg can be reused immediately after this call completes.
 //
-void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
-                               chpl_fn_int_t fid,
-                               chpl_comm_on_bundle_t *arg, size_t arg_size,
-                               int ln, int32_t fn);
+void chpl_rt_comm_execute_on_fast(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                  c_sublocid_t subloc,
+                                  chpl_fn_int_t fid,
+                                  chpl_comm_on_bundle_t *arg,
+                                  size_t arg_size,
+                                  int ln,
+                                  int32_t fn);
 
 //
 // Ensure that the communication layer makes progress if there are any

--- a/runtime/include/chpl-gen-includes.h
+++ b/runtime/include/chpl-gen-includes.h
@@ -44,12 +44,11 @@ extern "C" {
 // one argument.
 //
 static inline
-void chpl_ftable_call(chpl_fn_int_t fid, void* bundle)
-{
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
+void chpl_rt_ftable_call(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
+                         void* bundle) {
+  CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
   (*chpl_ftable[fid])(bundle);
 }
-
 
 // used for converting between the Chapel idea of a locale ID: chpl_localeID_t
 // and the runtime idea of a locale ID: c_localeid_t.

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -27,6 +27,7 @@
 #include "chplcgfns.h"
 #include "chpltypes.h"
 #include "chpl-comm-task-decls.h"
+#include "chpl-prginfo.h"
 #include "chpl-tasks-impl.h"
 
 #ifdef __cplusplus
@@ -75,6 +76,7 @@ typedef struct chpl_task_bundle {
   chpl_bool is_executeOn;
   int lineno;
   int filename;
+  chpl_rt_prginfo* prg;
   c_sublocid_t requestedSubloc;
   chpl_fn_int_t requested_fid;
   chpl_fn_p requested_fn;

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -174,7 +174,7 @@ void chpl_task_callMain(void (*chpl_main)(void));
 
 
 //
-// Task creation.  chpl_task_addTask adds a new task to the pool of
+// Task creation. 'chpl_rt_task_add_task' adds a new task to the pool of
 // runnable candidate tasks.  It is called by Chapel tasking support
 // functions in the internal modules, which are in turn called by the
 // compiler-emitted code for all task-parallel constructs.  Tasking
@@ -184,7 +184,8 @@ void chpl_task_callMain(void (*chpl_main)(void));
 // Note that the tasking layer must generally copy the arguments
 // as it cannot assume anything about the lifetime of that memory.
 //
-void chpl_task_addTask(
+void chpl_rt_task_add_task(
+         chpl_rt_prginfo*,
          chpl_fn_int_t,      // function to call for task
          chpl_task_bundle_t*,// argument to the function
          size_t,             // length of the argument
@@ -201,12 +202,13 @@ void chpl_task_addTask(
 // Note that the tasking layer must generally copy the arguments
 // as it cannot assume anything about the lifetime of that memory.
 //
-void chpl_task_taskCallFTable(chpl_fn_int_t fid,      // ftable[] entry to call
-                              void* arg,              // function arg
-                              size_t arg_size,        // length of arg
-                              c_sublocid_t subloc,    // desired sublocale
-                              int lineno,             // source line
-                              int32_t filename);      // source filename
+void chpl_rt_task_task_ftable_call(chpl_rt_prginfo* prg,
+                                   chpl_fn_int_t fid,   // ftable[] entry
+                                   void* arg,           // function arg
+                                   size_t arg_size,     // length of arg
+                                   c_sublocid_t subloc, // desired sublocale
+                                   int lineno,          // source line
+                                   int32_t filename);   // source filename
 
 // In some cases, we are not worried about the "function number" (fid)
 

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -185,6 +185,39 @@ void* chpl_rt_comm_fetch_broadcast_table(chpl_rt_prginfo* prg,
   return ret;
 }
 
+void chpl_rt_comm_execute_on(chpl_rt_prginfo* prg, c_nodeid_t node,
+                             c_sublocid_t subloc,
+                             chpl_fn_int_t fid,
+                             chpl_comm_on_bundle_t *arg,
+                             size_t arg_size,
+                             int ln,
+                             int32_t fn) {
+  chpl_rt_comm_execute_on_impl(prg, node, subloc, fid, arg,
+                               arg_size, ln, fn);
+}
+
+void chpl_rt_comm_execute_on_nb(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                c_sublocid_t subloc,
+                                chpl_fn_int_t fid,
+                                chpl_comm_on_bundle_t *arg,
+                                size_t arg_size,
+                                int ln,
+                                int32_t fn) {
+  chpl_rt_comm_execute_on_nb_impl(prg, node, subloc, fid, arg,
+                                  arg_size, ln, fn);
+}
+
+void chpl_rt_comm_execute_on_fast(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                  c_sublocid_t subloc,
+                                  chpl_fn_int_t fid,
+                                  chpl_comm_on_bundle_t *arg,
+                                  size_t arg_size,
+                                  int ln,
+                                  int32_t fn) {
+  chpl_rt_comm_execute_on_fast_impl(prg, node, subloc, fid, arg,
+                                    arg_size, ln, fn);
+}
+
 static pthread_once_t maxHeapSize_once = PTHREAD_ONCE_INIT;
 static ssize_t maxHeapSize;
 

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -28,7 +28,10 @@
 #include "chpl-comm.h"
 #include "chpl-comm-compiler-macros.h"
 #include "chpl-comm-diags.h"
+#include "chpl-comm-callbacks.h"
+#include "chpl-comm-callbacks-internal.h"
 #include "chpl-comm-internal.h"
+#include "chpl-linefile-support.h"
 #include "chpl-gpu-diags.h"
 #include "chpl-env.h"
 #include "chpl-mem.h"
@@ -184,6 +187,25 @@ void* chpl_rt_comm_fetch_broadcast_table(chpl_rt_prginfo* prg,
 
   return ret;
 }
+static void execute_on_family_common_setup(chpl_rt_prginfo* prg,
+                                           c_nodeid_t node,
+                                           c_sublocid_t subloc,
+                                           chpl_fn_int_t fid,
+                                           chpl_comm_on_bundle_t *arg,
+                                           size_t arg_size,
+                                           int ln,
+                                           int32_t fn) {
+  chpl_task_bundle_t* tb = &arg->task_bundle;
+
+  // This is needed so that we can translate program info across locales.
+  arg->prg_id = prg->id;
+
+  // Local pointer is probably not needed, but just set it anyway.
+  tb->prg = prg;
+
+  // Also set the 'arg->kind'. It can be overridden by a comm-layer if needed.
+  arg->kind = CHPL_ARG_BUNDLE_KIND_COMM;
+}
 
 void chpl_rt_comm_execute_on(chpl_rt_prginfo* prg, c_nodeid_t node,
                              c_sublocid_t subloc,
@@ -192,6 +214,19 @@ void chpl_rt_comm_execute_on(chpl_rt_prginfo* prg, c_nodeid_t node,
                              size_t arg_size,
                              int ln,
                              int32_t fn) {
+  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
+    chpl_comm_cb_info_t cb_data =
+      {chpl_comm_cb_event_kind_executeOn, chpl_nodeID, node,
+       .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
+    chpl_comm_do_callbacks (&cb_data);
+  }
+
+  chpl_comm_diags_verbose_executeOn("", node, ln, fn);
+  chpl_comm_diags_incr(execute_on);
+
+  execute_on_family_common_setup(prg, node, subloc, fid, arg,
+                                 arg_size, ln, fn);
+
   chpl_rt_comm_execute_on_impl(prg, node, subloc, fid, arg,
                                arg_size, ln, fn);
 }
@@ -199,10 +234,23 @@ void chpl_rt_comm_execute_on(chpl_rt_prginfo* prg, c_nodeid_t node,
 void chpl_rt_comm_execute_on_nb(chpl_rt_prginfo* prg, c_nodeid_t node,
                                 c_sublocid_t subloc,
                                 chpl_fn_int_t fid,
-                                chpl_comm_on_bundle_t *arg,
+                                chpl_comm_on_bundle_t* arg,
                                 size_t arg_size,
                                 int ln,
                                 int32_t fn) {
+  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_nb)) {
+    chpl_comm_cb_info_t cb_data =
+      {chpl_comm_cb_event_kind_executeOn_nb, chpl_nodeID, node,
+       .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
+    chpl_comm_do_callbacks (&cb_data);
+  }
+
+  chpl_comm_diags_verbose_executeOn("non-blocking", node, ln, fn);
+  chpl_comm_diags_incr(execute_on_nb);
+
+  execute_on_family_common_setup(prg, node, subloc, fid, arg,
+                                 arg_size, ln, fn);
+
   chpl_rt_comm_execute_on_nb_impl(prg, node, subloc, fid, arg,
                                   arg_size, ln, fn);
 }
@@ -214,6 +262,19 @@ void chpl_rt_comm_execute_on_fast(chpl_rt_prginfo* prg, c_nodeid_t node,
                                   size_t arg_size,
                                   int ln,
                                   int32_t fn) {
+  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {
+    chpl_comm_cb_info_t cb_data =
+      {chpl_comm_cb_event_kind_executeOn_fast, chpl_nodeID, node,
+       .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
+    chpl_comm_do_callbacks (&cb_data);
+  }
+
+  chpl_comm_diags_verbose_executeOn("fast", node, ln, fn);
+  chpl_comm_diags_incr(execute_on_fast);
+
+  execute_on_family_common_setup(prg, node, subloc, fid, arg,
+                                 arg_size, ln, fn);
+
   chpl_rt_comm_execute_on_fast_impl(prg, node, subloc, fid, arg,
                                     arg_size, ln, fn);
 }

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1839,17 +1839,6 @@ void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
     assert(0);
     chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, fid, arg);
   } else {
-    // Communications callback support
-    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
-      chpl_comm_cb_info_t cb_data =
-        {chpl_comm_cb_event_kind_executeOn, chpl_nodeID, node,
-         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
-      chpl_comm_do_callbacks (&cb_data);
-    }
-
-    chpl_comm_diags_verbose_executeOn("", node, ln, fn);
-    chpl_comm_diags_incr(execute_on);
-
     execute_on_common(node, subloc, fid, arg, arg_size,
                      /*fast*/ false, /*blocking*/ true);
   }
@@ -1865,17 +1854,6 @@ void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
   if (chpl_nodeID == node) {
     assert(0); // locale model code should prevent this...
   } else {
-    // Communications callback support
-    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_nb)) {
-      chpl_comm_cb_info_t cb_data =
-        {chpl_comm_cb_event_kind_executeOn_nb, chpl_nodeID, node,
-         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
-      chpl_comm_do_callbacks (&cb_data);
-    }
-
-    chpl_comm_diags_verbose_executeOn("non-blocking", node, ln, fn);
-    chpl_comm_diags_incr(execute_on_nb);
-
     execute_on_common(node, subloc, fid, arg, arg_size,
                       /*fast*/ false, /*blocking*/ false);
   }
@@ -1893,17 +1871,6 @@ void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
     assert(0);
     chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, fid, arg);
   } else {
-    // Communications callback support
-    if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {
-      chpl_comm_cb_info_t cb_data =
-        {chpl_comm_cb_event_kind_executeOn_fast, chpl_nodeID, node,
-         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
-      chpl_comm_do_callbacks (&cb_data);
-    }
-
-    chpl_comm_diags_verbose_executeOn("fast", node, ln, fn);
-    chpl_comm_diags_incr(execute_on_fast);
-
     execute_on_common(node, subloc, fid, arg, arg_size,
                       /*fast*/ true, /*blocking*/ true);
   }

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1825,10 +1825,13 @@ void  execute_on_common(c_nodeid_t node, c_sublocid_t subloc,
 
 ////GASNET - introduce locale-int size
 ////GASNET - is caller in chpl_comm_on_bundle_t redundant? active message can determine this.
-void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
-                           chpl_fn_int_t fid,
-                           chpl_comm_on_bundle_t *arg, size_t arg_size,
-                           int ln, int32_t fn) {
+void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                  c_sublocid_t subloc,
+                                  chpl_fn_int_t fid,
+                                  chpl_comm_on_bundle_t *arg,
+                                  size_t arg_size,
+                                  int ln,
+                                  int32_t fn) {
   if (chpl_nodeID == node) {
     assert(0);
     chpl_ftable_call(fid, arg);
@@ -1849,11 +1852,13 @@ void  chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
   }
 }
 
-void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
-                              chpl_fn_int_t fid,
-                              chpl_comm_on_bundle_t *arg, size_t arg_size,
-                              int ln, int32_t fn) {
-
+void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                     c_sublocid_t subloc,
+                                     chpl_fn_int_t fid,
+                                     chpl_comm_on_bundle_t *arg,
+                                     size_t arg_size,
+                                     int ln,
+                                     int32_t fn) {
   if (chpl_nodeID == node) {
     assert(0); // locale model code should prevent this...
   } else {
@@ -1874,10 +1879,13 @@ void  chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
 }
 
 // GASNET - should only be called for "small" functions
-void  chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
-                                chpl_fn_int_t fid,
-                                chpl_comm_on_bundle_t *arg, size_t arg_size,
-                                int ln, int32_t fn) {
+void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                       c_sublocid_t subloc,
+                                       chpl_fn_int_t fid,
+                                       chpl_comm_on_bundle_t *arg,
+                                       size_t arg_size,
+                                       int ln,
+                                       int32_t fn) {
   if (chpl_nodeID == node) {
     assert(0);
     chpl_ftable_call(fid, arg);

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -276,7 +276,8 @@ static void AM_fork_fast(gasnet_token_t token, void* buf, size_t nbytes) {
   chpl_comm_on_bundle_t *f = buf;
 
   // Run the function
-  chpl_ftable_call(f->task_bundle.requested_fid, f);
+  chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                      f->task_bundle.requested_fid, f);
 
   // Signal that the handler has completed if that was requested.
   if (f->comm.ack)
@@ -334,7 +335,7 @@ static void AM_fork_fast_small(gasnet_token_t token, void* buf, size_t nbytes) {
   setup_small_fork_task(&task, f, nbytes);
 
   // Run the function
-  chpl_ftable_call(f->fid, bptr);
+  chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, f->fid, bptr);
 
   // Signal that the handler has completed if that was requested.
   if (f->ack)
@@ -344,7 +345,8 @@ static void AM_fork_fast_small(gasnet_token_t token, void* buf, size_t nbytes) {
 
 
 static void fork_wrapper(chpl_comm_on_bundle_t *f) {
-  chpl_ftable_call(f->task_bundle.requested_fid, f);
+  chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                      f->task_bundle.requested_fid, f);
 
   GASNET_Safe(gasnet_AMRequestShort2(f->comm.caller, SIGNAL,
                                      Arg0(f->comm.ack), Arg1(f->comm.ack)));
@@ -399,7 +401,7 @@ static void fork_large_wrapper(large_fork_task_t* f) {
                 CHPL_COMM_UNKNOWN_ID, 0, CHPL_FILE_IDX_FORK_LARGE);
 
   // Call the on body function
-  chpl_ftable_call(fid, arg);
+  chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, fid, arg);
 
   // Signal completion
   GASNET_Safe(gasnet_AMRequestShort2(caller, SIGNAL, Arg0(ack), Arg1(ack)));
@@ -426,7 +428,8 @@ static void AM_fork_large(gasnet_token_t token, void* buf, size_t nbytes) {
 }
 
 static void fork_nb_wrapper(chpl_comm_on_bundle_t *f) {
-  chpl_ftable_call(f->task_bundle.requested_fid, f);
+  chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                      f->task_bundle.requested_fid, f);
 }
 
 static void AM_fork_nb(gasnet_token_t  token,
@@ -484,7 +487,7 @@ static void fork_nb_large_wrapper(large_fork_task_t* f) {
                                      Arg1(arg_on_caller)));
 
   // Call the user function
-  chpl_ftable_call(fid, arg);
+  chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, fid, arg);
 
   // Free the bundle we just allocated
   chpl_mem_free(arg, 0, 0);
@@ -1834,7 +1837,7 @@ void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                   int32_t fn) {
   if (chpl_nodeID == node) {
     assert(0);
-    chpl_ftable_call(fid, arg);
+    chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, fid, arg);
   } else {
     // Communications callback support
     if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
@@ -1888,7 +1891,7 @@ void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                        int32_t fn) {
   if (chpl_nodeID == node) {
     assert(0);
-    chpl_ftable_call(fid, arg);
+    chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, fid, arg);
   } else {
     // Communications callback support
     if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -330,19 +330,24 @@ typedef struct {
   char          arg[0];       // variable-sized data here
 } fork_t;
 
-void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
-                          chpl_fn_int_t fid,
-                          chpl_comm_on_bundle_t *arg, size_t arg_size,
-                          int ln, int32_t fn) {
+void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                  c_sublocid_t subloc,
+                                  chpl_fn_int_t fid,
+                                  chpl_comm_on_bundle_t *arg,
+                                  size_t arg_size,
+                                  int ln,
+                                  int32_t fn) {
   assert(node==0);
-
   chpl_ftable_call(fid, arg);
 }
 
-void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
-                             chpl_fn_int_t fid,
-                             chpl_comm_on_bundle_t *arg, size_t arg_size,
-                             int ln, int32_t fn) {
+void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                     c_sublocid_t subloc,
+                                     chpl_fn_int_t fid,
+                                     chpl_comm_on_bundle_t *arg,
+                                     size_t arg_size,
+                                     int ln,
+                                     int32_t fn) {
   assert(node==0);
   CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
 
@@ -351,13 +356,15 @@ void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
                            subloc, chpl_nullTaskID);
 }
 
-// Same as chpl_comm_execute_on()
-void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
-                               chpl_fn_int_t fid,
-                               chpl_comm_on_bundle_t *arg, size_t arg_size,
-                               int ln, int32_t fn) {
+void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                       c_sublocid_t subloc,
+                                       chpl_fn_int_t fid,
+                                       chpl_comm_on_bundle_t *arg,
+                                       size_t arg_size,
+                                       int ln,
+                                       int32_t fn) {
+  // Same as chpl_rt_comm_execute_on_impl()
   assert(node==0);
-
   chpl_ftable_call(fid, arg);
 }
 

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -338,7 +338,7 @@ void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                   int ln,
                                   int32_t fn) {
   assert(node==0);
-  chpl_ftable_call(fid, arg);
+  chpl_rt_ftable_call(prg, fid, arg);
 }
 
 void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
@@ -349,7 +349,7 @@ void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                      int ln,
                                      int32_t fn) {
   assert(node==0);
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
+  CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
 
   chpl_task_startMovedTask(fid, chpl_ftable[fid],
                            chpl_comm_on_bundle_task_bundle(arg), arg_size,
@@ -365,7 +365,7 @@ void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                        int32_t fn) {
   // Same as chpl_rt_comm_execute_on_impl()
   assert(node==0);
-  chpl_ftable_call(fid, arg);
+  chpl_rt_ftable_call(prg, fid, arg);
 }
 
 void chpl_comm_ensure_progress(void) { }

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -5280,7 +5280,7 @@ void amWrapExecOnBody(void* p) {
 
   chpl_comm_bundleData_t* comm = &((chpl_comm_on_bundle_t*) p)->comm;
 
-  chpl_ftable_call(comm->fid, p);
+  chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, comm->fid, p);
   forceMemFxVisAllNodes_noTcip(true /*checkPuts*/, true /*checkAmos*/);
   DBG_PRINTF(DBG_AM | DBG_AM_RECV, "%s", am_reqDoneStr(p));
   if (comm->pAmDone != NULL) {
@@ -5342,7 +5342,8 @@ void amWrapExecOnLrgBody(struct amRequest_execOnLrg_t* xol) {
   //
   // Now we can finally call the body function.
   //
-  chpl_ftable_call(bundle->comm.fid, bundle);
+  chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, bundle->comm.fid,
+                      bundle);
   forceMemFxVisAllNodes_noTcip(true /*checkPuts*/, true /*checkAmos*/);
   DBG_PRINTF(DBG_AM | DBG_AM_RECV, "%s", am_reqDoneStr((amRequest_t*) xol));
   if (comm->pAmDone != NULL) {

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -4230,17 +4230,6 @@ void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
              (int) node, (int) subloc, (int) fid, arg, argSize);
 
   CHK_TRUE(node != chpl_nodeID); // handled by the locale model
-
-  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
-    chpl_comm_cb_info_t cb_data =
-      {chpl_comm_cb_event_kind_executeOn, chpl_nodeID, node,
-       .iu.executeOn={subloc, fid, arg, argSize, ln, fn}};
-    chpl_comm_do_callbacks (&cb_data);
-  }
-
-  chpl_comm_diags_verbose_executeOn("", node, ln, fn);
-  chpl_comm_diags_incr(execute_on);
-
   amRequestExecOn(node, subloc, fid, arg, argSize, false, true);
 }
 
@@ -4257,17 +4246,6 @@ void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
              (int) node, (int) subloc, (int) fid, arg, argSize);
 
   CHK_TRUE(node != chpl_nodeID); // handled by the locale model
-
-  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_nb)) {
-    chpl_comm_cb_info_t cb_data =
-      {chpl_comm_cb_event_kind_executeOn_nb, chpl_nodeID, node,
-       .iu.executeOn={subloc, fid, arg, argSize, ln, fn}};
-    chpl_comm_do_callbacks (&cb_data);
-  }
-
-  chpl_comm_diags_verbose_executeOn("non-blocking", node, ln, fn);
-  chpl_comm_diags_incr(execute_on_nb);
-
   amRequestExecOn(node, subloc, fid, arg, argSize, false, false);
 }
 
@@ -4284,17 +4262,6 @@ void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
              (int) node, (int) subloc, (int) fid, arg, argSize);
 
   CHK_TRUE(node != chpl_nodeID); // handled by the locale model
-
-  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {
-    chpl_comm_cb_info_t cb_data =
-      {chpl_comm_cb_event_kind_executeOn_fast, chpl_nodeID, node,
-       .iu.executeOn={subloc, fid, arg, argSize, ln, fn}};
-    chpl_comm_do_callbacks (&cb_data);
-  }
-
-  chpl_comm_diags_verbose_executeOn("fast", node, ln, fn);
-  chpl_comm_diags_incr(execute_on_fast);
-
   amRequestExecOn(node, subloc, fid, arg, argSize, true, true);
 }
 

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -4218,10 +4218,13 @@ static void amRequestCommon(c_nodeid_t, amRequest_t*, size_t,
 static void amWaitForDone(amDone_t*);
 
 
-void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
-                          chpl_fn_int_t fid,
-                          chpl_comm_on_bundle_t *arg, size_t argSize,
-                          int ln, int32_t fn) {
+void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                  c_sublocid_t subloc,
+                                  chpl_fn_int_t fid,
+                                  chpl_comm_on_bundle_t *arg,
+                                  size_t argSize,
+                                  int ln,
+                                  int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%d, %d, %d, %p, %zd)", __func__,
              (int) node, (int) subloc, (int) fid, arg, argSize);
@@ -4242,10 +4245,13 @@ void chpl_comm_execute_on(c_nodeid_t node, c_sublocid_t subloc,
 }
 
 
-void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
-                             chpl_fn_int_t fid,
-                             chpl_comm_on_bundle_t *arg, size_t argSize,
-                             int ln, int32_t fn) {
+void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                     c_sublocid_t subloc,
+                                     chpl_fn_int_t fid,
+                                     chpl_comm_on_bundle_t *arg,
+                                     size_t argSize,
+                                     int ln,
+                                     int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%d, %d, %d, %p, %zd)", __func__,
              (int) node, (int) subloc, (int) fid, arg, argSize);
@@ -4266,10 +4272,13 @@ void chpl_comm_execute_on_nb(c_nodeid_t node, c_sublocid_t subloc,
 }
 
 
-void chpl_comm_execute_on_fast(c_nodeid_t node, c_sublocid_t subloc,
-                               chpl_fn_int_t fid,
-                               chpl_comm_on_bundle_t *arg, size_t argSize,
-                               int ln, int32_t fn) {
+void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
+                                       c_sublocid_t subloc,
+                                       chpl_fn_int_t fid,
+                                       chpl_comm_on_bundle_t *arg,
+                                       size_t argSize,
+                                       int ln,
+                                       int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%d, %d, %d, %p, %zd)", __func__,
              (int) node, (int) subloc, (int) fid, arg, argSize);

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -4198,7 +4198,8 @@ void rf_handler(gni_cq_entry_t* ev)
       chpl_comm_on_bundle_t* f_c = (chpl_comm_on_bundle_t*) f;
 
       if (f_c->comm.fast) {
-        chpl_ftable_call(f_c->comm.fid, f);
+        chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
+                            f_c->comm.fid, f);
         indicate_done2(f_c->comm.caller, (rf_done_t*) f_c->comm.rf_done);
         // doesn't call release_req_buf, because that
         // is handled on the sender side for fast forks
@@ -4313,7 +4314,7 @@ static
 void fork_call_wrapper_blocking(chpl_comm_on_bundle_t* f)
 {
   // Call the on body
-  chpl_ftable_call(f->comm.fid, f);
+  chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, f->comm.fid, f);
   indicate_done2(f->comm.caller, (rf_done_t*) f->comm.rf_done);
 }
 
@@ -4355,7 +4356,8 @@ void fork_call_wrapper_large(fork_large_call_info_t* lc)
   }
 
   // Call the on body
-  chpl_ftable_call(bundle->comm.fid, bundle);
+  chpl_rt_ftable_call(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, bundle->comm.fid,
+                      bundle);
 
   // Free the bundle we just allocated.
   chpl_mem_free(bundle, 0, 0);

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6966,18 +6966,6 @@ void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t locale,
            (int) locale, (int) subloc, (int) fid, arg, arg_size);
 
   assert(locale != chpl_nodeID); // locale model code should prevent this ...
-
-  // Communications callback support
-  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
-      chpl_comm_cb_info_t cb_data =
-        {chpl_comm_cb_event_kind_executeOn, chpl_nodeID, locale,
-         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
-      chpl_comm_do_callbacks (&cb_data);
-  }
-
-  chpl_comm_diags_verbose_executeOn("", locale, ln, fn);
-  chpl_comm_diags_incr(execute_on);
-
   PERFSTATS_INC(fork_call_cnt);
   fork_call_common(locale, subloc, fid, arg, arg_size, false, true);
 }
@@ -6995,18 +6983,6 @@ void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t locale,
            (int) locale, (int) subloc, (int) fid, arg, arg_size);
 
   assert(locale != chpl_nodeID); // locale model code should prevent this ...
-
-  // Communications callback support
-  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_nb)) {
-      chpl_comm_cb_info_t cb_data =
-        {chpl_comm_cb_event_kind_executeOn_nb, chpl_nodeID, locale,
-         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
-      chpl_comm_do_callbacks (&cb_data);
-  }
-
-  chpl_comm_diags_verbose_executeOn("non-blocking", locale, ln, fn);
-  chpl_comm_diags_incr(execute_on_nb);
-
   PERFSTATS_INC(fork_call_nb_cnt);
   fork_call_common(locale, subloc, fid, arg, arg_size, false, false);
 }
@@ -7024,17 +7000,6 @@ void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t locale,
            (int) locale, (int) subloc, (int) fid, arg, arg_size);
 
   assert(locale != chpl_nodeID); // locale model code should prevent this ...
-
-  // Communications callback support
-  if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {
-      chpl_comm_cb_info_t cb_data =
-        {chpl_comm_cb_event_kind_executeOn_fast, chpl_nodeID, locale,
-         .iu.executeOn={subloc, fid, arg, arg_size, ln, fn}};
-      chpl_comm_do_callbacks (&cb_data);
-  }
-
-  chpl_comm_diags_verbose_executeOn("fast", locale, ln, fn);
-  chpl_comm_diags_incr(execute_on_fast);
 
   //
   // Note: the rf_handler() logic assumes that fast implies blocking.

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -6952,11 +6952,13 @@ void do_nic_amo(void* opnd1, void* opnd2, c_nodeid_t locale,
 }
 
 
-void chpl_comm_execute_on(c_nodeid_t locale, c_sublocid_t subloc,
-                          chpl_fn_int_t fid,
-                          chpl_comm_on_bundle_t* arg, size_t arg_size,
-                          int ln, int32_t fn)
-{
+void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t locale,
+                                  c_sublocid_t subloc,
+                                  chpl_fn_int_t fid,
+                                  chpl_comm_on_bundle_t* arg,
+                                  size_t arg_size,
+                                  int ln,
+                                  int32_t fn) {
   DBG_P_LP(DBGF_IFACE|DBGF_RF,
            "IFACE chpl_comm_execute_on(%d:%d, ftable[%d](%p, %zd))",
            (int) locale, (int) subloc, (int) fid, arg, arg_size);
@@ -6979,11 +6981,13 @@ void chpl_comm_execute_on(c_nodeid_t locale, c_sublocid_t subloc,
 }
 
 
-void chpl_comm_execute_on_nb(c_nodeid_t locale, c_sublocid_t subloc,
-                             chpl_fn_int_t fid,
-                             chpl_comm_on_bundle_t* arg, size_t arg_size,
-                             int ln, int32_t fn)
-{
+void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t locale,
+                                     c_sublocid_t subloc,
+                                     chpl_fn_int_t fid,
+                                     chpl_comm_on_bundle_t* arg,
+                                     size_t arg_size,
+                                     int ln,
+                                     int32_t fn) {
   DBG_P_LP(DBGF_IFACE|DBGF_RF,
            "IFACE chpl_comm_execute_on_nb(%d:%d, ftable[%d](%p, %zd))",
            (int) locale, (int) subloc, (int) fid, arg, arg_size);
@@ -7006,11 +7010,13 @@ void chpl_comm_execute_on_nb(c_nodeid_t locale, c_sublocid_t subloc,
 }
 
 
-void chpl_comm_execute_on_fast(c_nodeid_t locale, c_sublocid_t subloc,
-                               chpl_fn_int_t fid,
-                               chpl_comm_on_bundle_t* arg, size_t arg_size,
-                               int ln, int32_t fn)
-{
+void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t locale,
+                                       c_sublocid_t subloc,
+                                       chpl_fn_int_t fid,
+                                       chpl_comm_on_bundle_t* arg,
+                                       size_t arg_size,
+                                       int ln,
+                                       int32_t fn) {
   DBG_P_LP(DBGF_IFACE|DBGF_RF,
            "IFACE chpl_comm_execute_on_fast(%d:%d, ftable[%d](%p, %zd))",
            (int) locale, (int) subloc, (int) fid, arg, arg_size);

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -490,10 +490,12 @@ void dequeue_task(task_pool_p ptask) {
 }
 
 
-void chpl_task_addTask(chpl_fn_int_t fid,
-                       chpl_task_bundle_t* arg, size_t arg_size,
-                       c_sublocid_t subloc,
-                       int lineno, int32_t filename) {
+void chpl_rt_task_add_task(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
+                           chpl_task_bundle_t* arg,
+                           size_t arg_size,
+                           c_sublocid_t subloc,
+                           int lineno,
+                           int32_t filename) {
   assert(subloc == c_sublocid_none);
 
   arg->kind = CHPL_ARG_BUNDLE_KIND_TASK;
@@ -501,7 +503,7 @@ void chpl_task_addTask(chpl_fn_int_t fid,
   // begin critical section
   chpl_thread_mutexLock(&threading_lock);
 
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
+  CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
 
   (void) add_to_task_pool(fid, chpl_ftable[fid], arg, arg_size,
                           false, lineno, filename);
@@ -511,11 +513,13 @@ void chpl_task_addTask(chpl_fn_int_t fid,
 }
 
 
-void chpl_task_taskCallFTable(chpl_fn_int_t fid,
-                        void* arg, size_t arg_size,
-                        c_sublocid_t subloc,
-                        int lineno, int32_t filename) {
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
+void chpl_rt_task_task_ftable_call(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
+                                   void* arg,
+                                   size_t arg_size,
+                                   c_sublocid_t subloc,
+                                   int lineno,
+                                   int32_t filename) {
+  CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
   taskCallBody(fid, chpl_ftable[fid], arg, arg_size, subloc, lineno, filename);
 }
 

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -999,14 +999,13 @@ int chpl_task_createCommTask(chpl_fn_p fn,
     return rc;
 }
 
-void chpl_task_addTask(chpl_fn_int_t       fid,
-                       chpl_task_bundle_t *arg,
-                       size_t              arg_size,
-                       c_sublocid_t        full_subloc,
-                       int                 lineno,
-                       int32_t             filename)
-{
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
+void chpl_rt_task_add_task(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
+                           chpl_task_bundle_t *arg,
+                           size_t arg_size,
+                           c_sublocid_t full_subloc,
+                           int lineno,
+                           int32_t filename) {
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
 
     chpl_fn_p requested_fn = chpl_ftable[fid];
 
@@ -1074,14 +1073,14 @@ static inline void taskCallBody(chpl_fn_int_t fid, chpl_fn_p fp,
     }
 }
 
-void chpl_task_taskCallFTable(chpl_fn_int_t fid,
-                              void *arg, size_t arg_size,
-                              c_sublocid_t subloc,
-                              int lineno, int32_t filename)
-{
+void chpl_rt_task_task_ftable_call(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
+                                   void *arg,
+                                   size_t arg_size,
+                                   c_sublocid_t subloc,
+                                   int lineno,
+                                   int32_t filename) {
     PROFILE_INCR(profile_task_taskCallFTable,1);
-
-    CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, chpl_ftable);
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
     taskCallBody(fid, chpl_ftable[fid], arg, arg_size, subloc, lineno, filename);
 }
 

--- a/test/compflags/ferguson/print-module-resolution.good
+++ b/test/compflags/ferguson/print-module-resolution.good
@@ -90,6 +90,12 @@ ChapelSyncvar
   from print-module-resolution.ChapelStandard.ChapelSyncvar
 ChapelTaskDataHelp
   from print-module-resolution.ChapelStandard.ChapelTaskDataHelp
+ChapelSetProgramInfoDataEntries
+  from print-module-resolution.ChapelStandard.ChapelRuntimeInterface.ChapelProgramRegistration.ChapelSetProgramInfoDataEntries
+ChapelProgramRegistration
+  from print-module-resolution.ChapelStandard.ChapelRuntimeInterface.ChapelProgramRegistration
+ChapelRuntimeInterface
+  from print-module-resolution.ChapelStandard.ChapelRuntimeInterface
 ChapelIOSerialize
   from print-module-resolution.ChapelStandard.LocaleModel.LocaleModelHelpFlat.LocaleModelHelpSetup.ChapelLocale.ChapelIOSerialize
 ChapelNumLocales
@@ -240,14 +246,8 @@ stopInitCommDiags
   from print-module-resolution.ChapelStandard.stopInitCommDiags
 ChapelDynamicLoading
   from print-module-resolution.ChapelStandard.ChapelDynamicLoading
-ChapelSetProgramInfoDataEntries
-  from print-module-resolution.ChapelStandard.ChapelProgramEntrypoints.ChapelProgramRegistration.ChapelSetProgramInfoDataEntries
-ChapelProgramRegistration
-  from print-module-resolution.ChapelStandard.ChapelProgramEntrypoints.ChapelProgramRegistration
 ChapelProgramEntrypoints
   from print-module-resolution.ChapelStandard.ChapelProgramEntrypoints
-ChapelRuntimeInterface
-  from print-module-resolution.ChapelStandard.ChapelRuntimeInterface
 ChapelStandard
   from print-module-resolution.ChapelStandard
 print-module-resolution

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -14,6 +14,9 @@ Initializing Modules:
      ChapelDebugPrint
       ChapelIOStringifyHelper
     ChapelTaskDataHelp
+    ChapelRuntimeInterface
+     ChapelProgramRegistration
+      ChapelSetProgramInfoDataEntries
     LocaleModel
      LocaleModelHelpFlat
       LocaleModelHelpSetup
@@ -66,9 +69,6 @@ Initializing Modules:
     ChapelStaticVars
     ChapelDynamicLoading
     ChapelProgramEntrypoints
-     ChapelProgramRegistration
-      ChapelSetProgramInfoDataEntries
-    ChapelRuntimeInterface
     AlignedTSupport
    printModuleInitOrder
     moduleInitTest


### PR DESCRIPTION
This PR makes more adjustments to the runtime and module code to support dynamic loading. It adjusts the "execute on" family of functions as well as a few other functions related to the spawning of tasks and invoking "ftable" functions.

It adjusts more runtime function names to have the `chpl_rt_` prefix. For the "execute on" family, it adds an additional per-comm-layer `_impl` layer. It lifts duplicated code for firing comm callbacks out of the comm layers and puts them in the common entrypoints.

In the module code, the `chpl_executeOn` handlers in the `LocaleModel...` modules have been renamed to `chpl_localeModelExecuteOn...`. Then, `chpl_executeOn...` shims were added to `ChapelRuntimeInterface` which call the runtime functions.

TESTING

- [x] `standard`
- [x] `COMM=gasnet`
- [x] `COMM=gasnet`, `COMPILER=gnu`
- [x] `release/examples` with `CHPL_GPU=cpu`
- [x] Build with `gasnet-asan` and `fastAndIncremental.chpl`
- [x] `release/examples` with `COMM=ofi`

Reviewed by @benharsh. Thanks!