### PR TITLE
Move access of 'chpl_finfo' into runtime to avoid LLVM 14 issues

### DIFF
--- a/modules/standard/ChapelIO.chpl
+++ b/modules/standard/ChapelIO.chpl
@@ -443,18 +443,18 @@ module ChapelIO {
   @chpldoc.nodoc
   operator :(x: ?t1, type t2: string) where isProcedureType(t1) {
     if useProcedurePointers then try! {
-      extern record chpl_fn_info {
-        const name: c_ptrConst(c_char);
-      }
+      // In LLVM 14, we encounter bugs when indexing into chpl_finfo directly
+      // from module code, so we use this shim.
+      extern proc chpl_rt_finfo_name(idx: c_int): c_ptrConst(c_char);
+
       extern const chpl_ftableSize: int(64);
       extern proc chpl_get_ftable(): c_ptr(c_ptr(void));
-      extern const chpl_finfo: c_ptrConst(chpl_fn_info);
       const chpl_ftable = chpl_get_ftable();
       const xPtr = x : c_ptr(void);
       var name : string;
       for idx in 0..<chpl_ftableSize {
         if xPtr == chpl_ftable[idx] : c_ptr(void) {
-          name = string.createBorrowingBuffer(chpl_finfo[idx].name);
+          name = string.createBorrowingBuffer(chpl_rt_finfo_name(idx:c_int));
         }
       }
 

--- a/runtime/include/chpl-visual-debug.h
+++ b/runtime/include/chpl-visual-debug.h
@@ -62,6 +62,8 @@ void chpl_vdebug_tagname(const char* tagname, int tagno);
 //  mark the current task as a xxxVdebug() task and all children
 extern void chpl_vdebug_mark(void);
 
+extern const char* chpl_rt_finfo_name(int idx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/src/chpl-visual-debug.c
+++ b/runtime/src/chpl-visual-debug.c
@@ -657,3 +657,9 @@ void cb_task_end (const chpl_task_cb_info_t *info) {
 
   }
 }
+
+const char* chpl_rt_finfo_name(int idx) {
+    chpl_rt_prginfo* prg = CHPL_RT_ROOT_PROGRAM_PLACEHOLDER;
+    CHPL_RT_PRGINFO_DECLARE(prg, chpl_finfo);
+    return chpl_finfo[idx].name;
+}


### PR DESCRIPTION
This is a PR similar to #28913, where we need to avoid accessing a c_ptr in module code to avoid LLVM 14 internal errors.