### PR TITLE
Remove no longer necessary settings (and docs) about setting useProcedurePointers

### DIFF
--- a/modules/packages/DynamicLoading.chpl
+++ b/modules/packages/DynamicLoading.chpl
@@ -27,10 +27,6 @@ Support for dynamic loading in Chapel.
 
 .. note::
 
-  To ``use`` this module, the experimental procedure pointer feature
-  must be activated. Do this by setting the ``config param`` named
-  ``useProcedurePointers`` to ``true``.
-
 This module provides the ability to load a binary at runtime. Procedures
 contained in a dynamically loaded binary can be retrieved and called on
 any locale without compile-time knowledge of their names or locations.

--- a/modules/packages/DynamicLoading.chpl
+++ b/modules/packages/DynamicLoading.chpl
@@ -25,8 +25,6 @@
 /*
 Support for dynamic loading in Chapel.
 
-.. note::
-
 This module provides the ability to load a binary at runtime. Procedures
 contained in a dynamically loaded binary can be retrieved and called on
 any locale without compile-time knowledge of their names or locations.

--- a/test/dynamic-loading/COMPOPTS
+++ b/test/dynamic-loading/COMPOPTS
@@ -1,1 +1,1 @@
--suseProcedurePointers=true --verify
+--verify

--- a/test/functions/fcf/pointers/COMPOPTS
+++ b/test/functions/fcf/pointers/COMPOPTS
@@ -1,1 +1,1 @@
--suseProcedurePointers=true --verify
+--verify

--- a/test/library/packages/DynamicLoading/COMPOPTS
+++ b/test/library/packages/DynamicLoading/COMPOPTS
@@ -1,1 +1,1 @@
---verify -suseProcedurePointers=true
+--verify

--- a/test/library/packages/DynamicLoading/doc-examples/COMPOPTS
+++ b/test/library/packages/DynamicLoading/doc-examples/COMPOPTS
@@ -1,1 +1,1 @@
---verify -suseProcedurePointers=true
+--verify

--- a/test/library/packages/DynamicLoading/doc-examples/ModuleDocTest.chpl
+++ b/test/library/packages/DynamicLoading/doc-examples/ModuleDocTest.chpl
@@ -3,8 +3,6 @@
 //
 
 /* START_EXAMPLE_0 */
-//
-
 use DynamicLoading;
 
 // A binary may or may not exist at this path.

--- a/test/library/packages/DynamicLoading/doc-examples/ModuleDocTest.chpl
+++ b/test/library/packages/DynamicLoading/doc-examples/ModuleDocTest.chpl
@@ -3,7 +3,6 @@
 //
 
 /* START_EXAMPLE_0 */
-// Compile with: 'chpl Test.chpl -suseProcedurePointers=true'
 //
 
 use DynamicLoading;

--- a/test/library/packages/DynamicLoading/simpleChplLib/COMPOPTS
+++ b/test/library/packages/DynamicLoading/simpleChplLib/COMPOPTS
@@ -1,1 +1,0 @@
--suseProcedurePointers=true


### PR DESCRIPTION
Now that procedure pointers are enabled by default and working, we don't need to explicitly set it to true in our test system.  More importantly, documentation that refers to the necessity of setting it can be removed.  This PR does both of those things.