### PR TITLE
Adjust '.prediff' for GPU test to filter source code line numbers

### DIFF
--- a/test/gpu/native/jacobi/flags-warn-unstable-internal.good
+++ b/test/gpu/native/jacobi/flags-warn-unstable-internal.good
@@ -1,2 +1,2 @@
-$CHPL_HOME/modules/internal/ChapelStandard.chpl:53: warning: The GPU locale interface is unstable and expected to change in the forthcoming releases
-$CHPL_HOME/modules/internal/ChapelLocale.chpl:29: warning: The GPU locale interface is unstable and expected to change in the forthcoming releases
+$CHPL_HOME/modules/internal/ChapelStandard.chpl:nnnn: warning: The GPU locale interface is unstable and expected to change in the forthcoming releases
+$CHPL_HOME/modules/internal/ChapelLocale.chpl:nnnn: warning: The GPU locale interface is unstable and expected to change in the forthcoming releases

--- a/test/gpu/native/jacobi/flags.prediff
+++ b/test/gpu/native/jacobi/flags.prediff
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 TESTNAME=$1
 OUTFILE=$2
@@ -15,3 +15,8 @@ if [[ "$@" == *"--warn-unstable-internal"* ]]; then
   grep "$FILTER_TEXT" "$TMPFILE" > "$OUTFILE"
   rm $TMPFILE
 fi
+
+# Replace lines with 'nnnn'.
+regex='\|CHPL_HOME/modules|s/:[0-9:]*:/:nnnn:/'
+sed -e "$regex" $OUTFILE > $TMPFILE
+mv $TMPFILE $OUTFILE


### PR DESCRIPTION
Fix a nightly test failure by filtering line numbers pointing into standard/internal modules to read `nnnn`.