### PR TITLE
Switch aarch64 test from 8 to 4 cores for new machine

### DIFF
--- a/util/cron/test-linux64-aarch64.bash
+++ b/util/cron/test-linux64-aarch64.bash
@@ -8,4 +8,4 @@ source $UTIL_CRON_DIR/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="linux64-aarch64"
 
-$UTIL_CRON_DIR/nightly -cron $(get_nightly_paratest_args 8)
+$UTIL_CRON_DIR/nightly -cron $(get_nightly_paratest_args 4)


### PR DESCRIPTION
This config now runs on a test machine that has only 4 cores, so reduce degree of parallelism correspondingly.

[trivial, not reviewed]