### PR TITLE
Fix broken python multilocale interop tests in nightly testing

### DIFF
--- a/compiler/passes/buildDefaultFunctions.cpp
+++ b/compiler/passes/buildDefaultFunctions.cpp
@@ -912,10 +912,12 @@ static void buildChplEntryPoints() {
   chpl_gen_main->insertAtTail(new CallExpr(PRIM_SET_DYNAMIC_END_COUNT, endCount));
   chpl_gen_main->insertAtTail(new CallExpr("chpl_preUserCodeSync"));
 
+  // We always generate this function, but it may not always be called.
+  auto initCmdModsFn = buildInitProgramCommandLineModulesFn();
+
   // We have to initialize the main module explicitly.
   // It will initialize all the modules it uses, recursively.
   if (!fClientServerLibrary) {
-    auto initCmdModsFn = buildInitProgramCommandLineModulesFn();
     chpl_gen_main->insertAtTail(new CallExpr(initCmdModsFn));
 
   } else {


### PR DESCRIPTION
This PR fixes broken multilocale interop tests in nightly testing by always generating a function which initializes program command line modules (even if it is not always called). This fixes an error from the backend at codegen.

TESTING

- [x] `standard`
- [x] `COMM=gasnet`
- [x] `interop/python`, `COMM=gasnet`, w/ python-interop deps

Reviewed by @benharsh. Thanks!