### PR TITLE
Adjust test for dynamic loading to use a platform-agnostic extension

### DIFF
--- a/test/dynamic-loading/DemoLoadChapelLibrary.chpl
+++ b/test/dynamic-loading/DemoLoadChapelLibrary.chpl
@@ -1,7 +1,11 @@
 use DynamicLoading;
 
+// Provides the correct extension based on platform, e.g., '.dylib' or '.so'.
+use ChapelLibraryTestCommon only chapelLibraryExtension;
+
 proc main() {
-  var lib = binary.load("./lib/libDemoChapelLibrary.so");
+  const path = "./lib/libDemoChapelLibrary." + chapelLibraryExtension;
+  var lib = binary.load(path);
   type testType = proc(): void;
   const testProc = try! lib.retrieve("test1", testType);
   testProc();


### PR DESCRIPTION
I added a simple demo for dynamic loading of Chapel programs and forgot to use a platform-agnostic extension when writing the test. Fix that here.