### PR TITLE
Fix checking `tupleEltIdx` `optional` across implementations

### DIFF
--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -4810,7 +4810,7 @@ Expr* TConverter::convertGroupedAssign(
 
     // Get the corresponding associated action
     auto action = re->associatedActions()[i];
-    INT_ASSERT(action.tupleEltIdx().has_value());
+    INT_ASSERT(action.tupleEltIdx());
     INT_ASSERT(*action.tupleEltIdx() == i);
     INT_ASSERT(action.action() == AssociatedAction::ASSIGN);
 


### PR DESCRIPTION
Replace a call to `has_value` on the `AssociatedAction::tupleEltIdx` `chpl::optional` (which only exists if it refers to `std::optional`) with an implicit cast to bool, so it also works if backed by `llvm::optional`.

Follow up to https://github.com/chapel-lang/chapel/pull/28918.

[trivial, not reviewed]

Testing:
- [x] paratest
- [x] compiles against LLVM 14