### PR TITLE
Update Linuxbrew testing to new `homebrew/brew` image

### DIFF
--- a/util/packaging/docker/test/Dockerfile
+++ b/util/packaging/docker/test/Dockerfile
@@ -1,7 +1,7 @@
 # This is a container used to run homebrew-ci
 
 # Get the homebrew ubuntu container
-FROM ghcr.io/homebrew/ubuntu22.04:main
+FROM ghcr.io/homebrew/brew:main
 
 # Redundant to brew_install.bash but imporant for anyone working in this container
 # which can be ran without brew_install.bash

--- a/util/packaging/homebrew/readme.md
+++ b/util/packaging/homebrew/readme.md
@@ -37,7 +37,7 @@ https://github.com/Homebrew/homebrew-core/blob/main/CONTRIBUTING.md
 
 The container is executed using the following instructions:
 ```
-docker run --interactive --tty --rm --pull always homebrew/ubuntu22.04:latest /bin/bash
+docker run --interactive --tty --rm --pull always ghcr.io/homebrew/brew:main /bin/bash
 ```
 
 Formulas can be copied to the container using the following command:


### PR DESCRIPTION
Per the deprecation warnings the old container is now throwing, switch Linuxbrew testing image from `homebrew/ubuntu22.04:main` to `homebrew/brew:main`.

[trivial, not reviewed]

Testing:
- [x] local run of linuxbrew test