### PR TITLE
Make c2chapel build failure in `nightly` fatal

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -582,7 +582,7 @@ if ($build == 1) {
 
   if ($c2chapel == 1) {
       print "Making c2chapel\n";
-      mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt c2chapel", "make c2chapel", $emailOnError);
+      mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt c2chapel", "make c2chapel", $exitOnError);
   }
 
   if ($chplcheck == 1) {


### PR DESCRIPTION
Make `util/cron/nightly` exit with error if building `c2chapel` was requested and fails.

[trivial, not reviewed]