### PR TITLE
dlopen: Adjust "execute on" family to store 'fid' in initial "on bundle"

### DIFF
--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -131,7 +131,8 @@ void chpl_rt_comm_bundle_ftable_call(chpl_comm_on_bundle_t* bundle) {
 
   // Now just call the entry using the program's ftable.
   CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
-  (*chpl_ftable[fid])(bundle);
+  const chpl_fn_p on_fn = chpl_ftable[fid];
+  on_fn(bundle);
 }
 
 // Do a GET in a nonblocking fashion, returning a handle which can be used to

--- a/runtime/include/chpl-gen-includes.h
+++ b/runtime/include/chpl-gen-includes.h
@@ -47,7 +47,8 @@ static inline
 void chpl_rt_ftable_call(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
                          void* bundle) {
   CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
-  (*chpl_ftable[fid])(bundle);
+  const chpl_fn_p on_fn = chpl_ftable[fid];
+  on_fn(bundle);
 }
 
 // used for converting between the Chapel idea of a locale ID: chpl_localeID_t

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -192,20 +192,25 @@ static void execute_on_family_common_setup(chpl_rt_prginfo* prg,
                                            c_nodeid_t node,
                                            c_sublocid_t subloc,
                                            chpl_fn_int_t fid,
-                                           chpl_comm_on_bundle_t *arg,
+                                           chpl_comm_on_bundle_t* on_bundle,
                                            size_t arg_size,
                                            int ln,
                                            int32_t fn) {
-  chpl_task_bundle_t* tb = &arg->task_bundle;
+  chpl_task_bundle_t* task_bundle = &on_bundle->task_bundle;
 
-  // This is needed so that we can translate program info across locales.
-  arg->prg_id = prg->id;
-
-  // Local pointer is probably not needed, but just set it anyway.
-  tb->prg = prg;
-
-  // Also set the 'arg->kind'. It can be overridden by a comm-layer if needed.
-  arg->kind = CHPL_ARG_BUNDLE_KIND_COMM;
+  // Set things in the on/task bundles before passing off to the comm layer.
+  //
+  // TODO: Why do we pass the 'fid'/'arg_size'/'ln'/'fn' args separately
+  //       from the "on bundle" rather than just storing them inside the
+  //       bundle's fields? That doesn't make any sense to me, and it also
+  //       can cause problems within the tasking layer where I'm trying to
+  //       move towards invoking per-program ftable functions using the
+  //       "on bundle" directly rather than disparate fields grabbed from
+  //       a packet header passed to e.g., a GASNet AM.
+  on_bundle->prg_id             = prg->id;
+  task_bundle->prg              = prg;
+  task_bundle->requested_fid    = fid;
+  on_bundle->kind               = CHPL_ARG_BUNDLE_KIND_COMM;
 }
 
 void chpl_rt_comm_execute_on(chpl_rt_prginfo* prg, c_nodeid_t node,

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -473,6 +473,12 @@ static void fork_nb_large_wrapper(large_fork_task_t* f) {
                                      Arg0(arg_on_caller),
                                      Arg1(arg_on_caller)));
 
+  // NOTE: These must match. Currently we 'GET' the entire "on bundle" from
+  //       the remote and then execute the ftable call using it. If we ever
+  //       decide to e.g., fetch only the bundle data and not the whole
+  //       bundle, then this will break (thus the assert).
+  assert(arg->task_bundle.requested_fid == lg->hdr.fid);
+
   // Call the user function
   chpl_rt_comm_bundle_ftable_call(arg);
 


### PR DESCRIPTION
This PR should fix a nightly test failure. It handles a case in the GASNet comm layer where in `fork_nb_large_wrapper`, we do a 'GET' on a remote "on bundle" and then execute an ftable call using the bundle. However, the `fid` was not set on the "on bundle" before the active message was fired.

While here, adjust calls to ftable function pointers to stop using weird syntax.

TESTING

- [x] `standard`
- [x] `COMM=gasnet`
- [x] `COMM=gasnet`, `COMPILER=gnu`
- [x] Build with `COMM=ofi`

Reviewed by @benharsh. Thanks!