### PR TITLE
Bump lcals timeout to 60 minutes

### DIFF
--- a/test/studies/lcals/LCALSMain.perftimeout
+++ b/test/studies/lcals/LCALSMain.perftimeout
@@ -1,2 +1,2 @@
 # --no-local perf testing takes a while
-3000
+3600


### PR DESCRIPTION
Looks like until this test started failing, we were close to the upper bound of its timeout. Bump the timeout some more.

Reviewed by @arifthpe and @benharsh -- thanks!
