### PR TITLE
Expand the prediff to cover more unexpected GASNet errors

### DIFF
--- a/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
+++ b/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
@@ -19,6 +19,7 @@ out_of_order = rb"""\*\*\* GASNET WARNING\(Node \d+\): Detected arrival of out-o
 # an exit code (6 or 11) and a GASNet notice. Filter them out as well.
 signal = rb"\*\*\* Caught a fatal signal \(proc \d\): (SIGSEGV\(11\)|SIGABRT\(6\))\n"
 assertion = rb"[^:\n]+:[^\n]+Assertion `qthread_library_initialized' failed\.\n"
+ioctl_broken = rb"\*\*\* GASNET WARNING\(Node 0\): ioctl\(\) is probably broken: bytesAvail=\d+  recvfrom returned=\d+\n"
 extra_prints = b"""*** NOTICE (proc 1): Before reporting bugs, run with GASNET_BACKTRACE=1 in the environment to generate a backtrace.
 *** NOTICE (proc 1): We recommend linking the debug version of GASNet to assist you in resolving this application issue.
 """
@@ -26,6 +27,7 @@ extra_prints = b"""*** NOTICE (proc 1): Before reporting bugs, run with GASNET_B
 output = re.sub(out_of_order, b'', contents, flags=re.MULTILINE)
 output = re.sub(signal, b'', output)
 output = re.sub(assertion, b'', output)
+output = re.sub(ioctl_broken, b'', output)
 output = output.replace(extra_prints, b'')
 
 

--- a/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
+++ b/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
@@ -14,7 +14,19 @@ out_of_order = rb"""\*\*\* GASNET WARNING\(Node \d+\): Detected arrival of out-o
  This might \(rarely\) lead to corruption of AMUDP traffic\.
 """
 
+# For some reason, on exit, we occasionally see strange seg faults and
+# assertion failures. These come with an assertion description (optionally),
+# an exit code (6 or 11) and a GASNet notice. Filter them out as well.
+signal = rb"\*\*\* Caught a fatal signal \(proc \d\): (SIGSEGV\(11\)|SIGABRT\(6\))\n"
+assertion = rb"[^:\n]+:[^\n]+Assertion `qthread_library_initialized' failed\.\n"
+extra_prints = b"""*** NOTICE (proc 1): Before reporting bugs, run with GASNET_BACKTRACE=1 in the environment to generate a backtrace.
+*** NOTICE (proc 1): We recommend linking the debug version of GASNet to assist you in resolving this application issue.
+"""
+
 output = re.sub(out_of_order, b'', contents, flags=re.MULTILINE)
+output = re.sub(signal, b'', output)
+output = re.sub(assertion, b'', output)
+output = output.replace(extra_prints, b'')
 
 
 with open(file, 'wb') as f:


### PR DESCRIPTION
These happen sometimes after the debugger is done. We don't really know why, and they're different errors depending on the day. Adjust the prediff to strip these too.

Reviewed by @bradcray -- thanks!

## Testing
- [x] these lines are now removed from the output