### PR TITLE
dlopen: Fix regressions caused by changes to CHPL_CACHE_REMOTE

### DIFF
--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -37,17 +37,17 @@ extern "C" {
 #endif
 
 #if defined(__SANITIZE_ADDRESS__)
-#define CHPL_ASAN 1
+#define CHPL_RT_USING_ASAN 1
 #endif
 
 #if defined(__has_feature)
 #if __has_feature(address_sanitizer)
-#define CHPL_ASAN 1
+#define CHPL_RT_USING_ASAN 1
 #endif
 #endif
 
-#if !defined(CHPL_ASAN)
-#define CHPL_ASAN 0
+#if !defined(CHPL_RT_USING_ASAN)
+#define CHPL_RT_USING_ASAN 0
 #endif
 
 static inline
@@ -57,7 +57,7 @@ void chpl_cache_warn_if_disabled(void)
                           CHPL_CACHE_REMOTE);
 
   if (CHPL_CACHE_REMOTE && !chpl_env_rt_get_bool("CACHE_QUIET", false)) {
-    if (CHPL_ASAN) {
+    if (CHPL_RT_USING_ASAN) {
       chpl_warning("Disabling --cache-remote due to incompatibility with "
                    "AddressSanitizer (quiet with CHPL_RT_CACHE_QUIET=true)", 0, 0);
     } else if (chpl_task_canMigrateThreads()) {
@@ -76,10 +76,9 @@ int chpl_cache_enabled(void)
   // The remote cache is not compatible with ASan, and it uses thread local
   // storage, so if tasks can migrate between threads we lose our ability to
   // correctly fence.
-  return CHPL_CACHE_REMOTE && !CHPL_ASAN && !chpl_task_canMigrateThreads();
+  return CHPL_CACHE_REMOTE && !CHPL_RT_USING_ASAN &&
+         !chpl_task_canMigrateThreads();
 }
-#undef CHPL_ASAN
-
 
 // Initialize the remote data cache layer.
 void chpl_cache_init(void);

--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -29,13 +29,6 @@
 #include "chpl-tasks.h"
 #include "chpl-error.h"
 
-#ifdef HAS_CHPL_CACHE_FNS
-// This is a cache for remote data.
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #if defined(__SANITIZE_ADDRESS__)
 #define CHPL_RT_USING_ASAN 1
 #endif
@@ -48,6 +41,13 @@ extern "C" {
 
 #if !defined(CHPL_RT_USING_ASAN)
 #define CHPL_RT_USING_ASAN 0
+#endif
+
+#ifdef HAS_CHPL_CACHE_FNS
+// This is a cache for remote data.
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 static inline

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -29,7 +29,7 @@
 #include "chpl-wide-ptr-fns.h"
 
 #include "chpl-prefetch.h" // for chpl_prefetch
-#include "chpl-cache.h" // chpl_cache_enabled, chpl_cache_comm_get etc
+#include "chpl-cache.h" // chpl_rt_is_cache_enabled_fast, chpl_cache_comm_get etc
 #include "chpl-gpu.h" // for comm between device and host
 
 // Don't warn about chpl_comm_get e.g. in this file.
@@ -47,6 +47,15 @@ extern "C" {
 
 #define CHPL_COMM_UNKNOWN_ID -1
 
+static ___always_inline int chpl_rt_is_cache_enabled_fast(void) {
+  extern const int CHPL_CACHE_REMOTE;
+
+  // The remote cache is not compatible with ASan, and it uses thread local
+  // storage, so if tasks can migrate between threads we lose our ability to
+  // correctly fence.
+  return CHPL_CACHE_REMOTE && !CHPL_RT_USING_ASAN &&
+         !chpl_task_canMigrateThreads();
+}
 
 static ___always_inline
 void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
@@ -55,7 +64,7 @@ void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
   if (chpl_nodeID == node) {
     memmove(addr, raddr, size);
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
     chpl_cache_comm_get(addr, node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -77,7 +86,7 @@ void chpl_gen_comm_get_from_subloc(void *addr, c_nodeid_t src_node,
     chpl_gpu_comm_get(dst_subloc, addr, src_node, src_subloc, raddr, size,
                       commID, ln, fn);
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
     chpl_cache_comm_get(addr, src_node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -102,7 +111,7 @@ void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
       chpl_prefetch((unsigned char*)raddr + offset);
     }
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
     chpl_cache_comm_prefetch(node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -119,7 +128,7 @@ void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
   if (chpl_nodeID == node) {
     memmove(raddr, addr, size);
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
     chpl_cache_comm_put(addr, node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -142,7 +151,7 @@ void chpl_gen_comm_put_to_subloc(void* addr,
     chpl_gpu_comm_put(dst_node, dst_subloc, raddr, src_subloc, addr, size,
                       commID, ln, fn);
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
       chpl_cache_comm_put(addr, dst_node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -168,7 +177,7 @@ void chpl_gen_comm_get_strd(void *addr, void *dststr, c_nodeid_t node, c_subloci
   if( 0 ) {
 #endif // HAS_GPU_LOCALE
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
     chpl_cache_comm_get_strd(addr, (size_t*)dststr, node, raddr, (size_t*)srcstr, (size_t*)count, strlevels, elemSize, commID, ln, fn);
 #endif
   } else {
@@ -193,7 +202,7 @@ void chpl_gen_comm_put_strd(void *addr, void *dststr, c_nodeid_t node, c_subloci
   if( 0 ) {
 #endif // HAS_GPU_LOCALE
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
     chpl_cache_comm_put_strd(addr, (size_t*)dststr, node, raddr, (size_t*)srcstr, (size_t*)count, strlevels, elemSize, commID, ln, fn);
 #endif
   } else {
@@ -208,7 +217,7 @@ void chpl_gen_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
     chpl_cache_comm_get_unordered(addr, node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -222,7 +231,7 @@ void chpl_gen_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
     chpl_cache_comm_put_unordered(addr, node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -238,7 +247,7 @@ void chpl_gen_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
     chpl_cache_comm_getput_unordered(dstnode, dstaddr, srcnode, srcaddr, size, commID, ln, fn);
 #endif
   } else {
@@ -251,7 +260,7 @@ void chpl_gen_comm_getput_unordered_task_fence(void)
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_cache_enabled() ) {
+  } else if( chpl_rt_is_cache_enabled_fast() ) {
     chpl_cache_comm_getput_unordered_task_fence();
 #endif
   } else {


### PR DESCRIPTION
This PR attempts to fix performance regressions caused by changes to `CHPL_CACHE_REMOTE`.

Previously, `CHPL_CACHE_REMOTE` was declared as an `extern const int` within the runtime code (and used in `chpl-cache.h`). The references to it in the runtime would be resolved when a Chapel program was linked (recall that normally, the runtime is distributed as a static archive and a copy of it is bundled in with every Chapel program).

As of #28869, `CHPL_CACHE_REMOTE` is now accessed via a struct field read instead of being a _const global variable_.

This change is causing a 5-15% drop in performance.

The hot spot is its use in `chpl_cache_enabled()`, which can potentially be invoked per iteration in very tight loops.

My guess is that in the old world, when throwing `--fast`, the (LLVM only?) compiler is doing LTO (link-time optimization) and basically inlining `CHPL_CACHE_REMOTE`. After #28869 it is no longer able to do that and is forced to do a memory read.

The first thing I tried to do was optimize the struct read to avoid function calls on the fast path. The second thing I tried to do was to adjust `chpl_cache_enabled()` to reference a runtime global variable that is computed during runtime setup. Neither had any effect, which makes sense - the cost of both is about the same, which is a memory read, and neither can substitute for basically inlining away the memory read (and branch) completely.

The next step was to figure out all the places where `chpl_cache_enabled()` is called. The majority are in `chpl-comm-compiler-macros.h`, which as far as I can tell is a header (primarily meant for use by the compiler) which contains wrappers around GET/PUT primitives. The macros all basically boil down to:

- If src/dst locale are local, do a mem-move
- If (GPU-based condition) do GPU-based things
- If remote and cache is enabled, use cache (where `chpl_cache_enabled()` would be called)
- Otherwise, do a runtime PUT/GET

## SHORT TERM FIX

I've added a shim in `chpl-comm-compiler-macros.h` that basically does what the old code used to do. It declares `CHPL_CACHE_REMOTE` as an `extern const int` so that it can take advantage of LTO. This restores performance on `16-node-apollo-hdr`.

## LONG TERM FIX

If we want to let the code in this header reference `CHPL_CACHE_REMOTE` directly so that it can take advantage of LTO (which appears to be critical for these functions), then we have to isolate them so that only the compiler can use their current forms and the runtime code cannot invoke them directly.

This is because the runtime is no longer allowed to directly reference (via declaration and linking) constants that are declared per-Chapel-program.

So structurally, all the places in the runtime code that invoke the helpers in this header ought to be changed to effectively do something else. Maybe they can use a runtime-only copy of the code that does the slower thing, which is OK as long as the shims used by the compiler in tight loops are performant.

We might also be able to whip up some macro-based magic to make this a bit less painful. I'll figure something out after the 2.9 release.

TESTING

- [x] Verified regressions are fixed on `16-node-apollo-hdr`
- [x] `standard`
- [x] `COMM=gasnet`
- [x] Built with `COMM=ofi`

Reviewed by @benharsh. Thanks!