### PR TITLE
Remove unnecessary -lyaml from compopts

### DIFF
--- a/test/library/packages/Yaml/COMPOPTS
+++ b/test/library/packages/Yaml/COMPOPTS
@@ -5,4 +5,8 @@ normal_args=""
 ccflags=$(pkg-config --cflags yaml-0.1)
 ldflags=$(pkg-config --libs yaml-0.1)
 
+# The YAML module itself should be passing '-lyaml' via 'require'
+# on macOS we get warnings about duplicate libraries, so remove it here
+ldflags=${ldflags//-lyaml/}
+
 echo "${ccflags:+--ccflags '$ccflags'} ${ldflags:+--ldflags '$ldflags'} ${normal_args}"


### PR DESCRIPTION
The YAML module itself already throws ``-lyaml`` via its ``require`` statement. On macOS we were seeing warnings about duplicate libraries that caused ``start_test`` to fail due to the extra output.