### PR TITLE
Fix invocation of dwarfdump from PREDIFF

### DIFF
--- a/test/llvm/debugInfo/dwarfdump/PREDIFF
+++ b/test/llvm/debugInfo/dwarfdump/PREDIFF
@@ -29,13 +29,14 @@ class Verifier:
             return None
 
         try:
-            sp.check_call(
+            sp.run(
                 [
                     self.llvm_dwarfdump,
                     "--debug-info",
                     "--verify",
                     self.dwarfDumpTarget,
                 ],
+                check=True,
                 stdout=sp.PIPE,
                 stderr=sp.STDOUT,
             )


### PR DESCRIPTION
Fix a hanging invocation of `llvm-dwarfdump` in `test/llvm/debugInfo/dwarfdump/PREDIFF`.

After the LLVM 22 upgrade, our Darwin test system was hanging on the dwarfdump invocation from this prediff, but a manual invocation completed quickly. It was invoked from Python with `subprocess.check_call` with `stdout=PIPE`, which [Python docs warn can hang](https://docs.python.org/3/library/subprocess.html#subprocess.check_call) due to filling the pipe buffer without it ever getting consumed. Fix by switching to an invocation of `subprocess.run` with `check=True`, as the docs suggest for cases that need to capture output.

This invocation has been unchanged since it was introduced in https://github.com/jabraham17/chapel/commit/4660ccc2439c53d9f0663119b804338b45ea749e. I suspect the LLVM upgrade made this latent bug have observable behavior by increasing the amount of output from `llvm-dwarfdump` to the point of exceeding the pipe buffer. This isn't 100% confirmation, but we get about 40kb of output from it, and per [this StackOverflow answer](https://unix.stackexchange.com/a/11954) the default macOS pipe buffer size is 16kb.

I grepped in `test` for `check_call` and found this was the only invocation which set `stdout` or `stderr` to `PIPE`, so we don't have this same issue elsewhere.

Resolves https://github.com/Cray/chapel-private/issues/7750.

[reviewed by @DanilaFe , thanks!]

Testing:
- [x] `test/llvm/debugInfo/dwarfdump` on macOS
- [x] `test/llvm/debugInfo/dwarfdump/PREDIFF` correctly fails if invoked on a manually corrupted dump