### PR TITLE
Expand twoLocales prediff to avoid hardcoded constants

### DIFF
--- a/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
+++ b/test/llvm/debugInfo/chpl-parallel-dbg/prediff-for-gasnet-udp
@@ -20,15 +20,15 @@ out_of_order = rb"""\*\*\* GASNET WARNING\(Node \d+\): Detected arrival of out-o
 signal = rb"\*\*\* Caught a fatal signal \(proc \d\): (SIGSEGV\(11\)|SIGABRT\(6\))\n"
 assertion = rb"[^:\n]+:[^\n]+Assertion `qthread_library_initialized' failed\.\n"
 ioctl_broken = rb"\*\*\* GASNET WARNING\(Node 0\): ioctl\(\) is probably broken: bytesAvail=\d+  recvfrom returned=\d+\n"
-extra_prints = b"""*** NOTICE (proc 1): Before reporting bugs, run with GASNET_BACKTRACE=1 in the environment to generate a backtrace.
-*** NOTICE (proc 1): We recommend linking the debug version of GASNet to assist you in resolving this application issue.
+extra_prints = rb"""\*\*\* NOTICE \(proc \d+\): Before reporting bugs, run with GASNET_BACKTRACE=1 in the environment to generate a backtrace\.
+\*\*\* NOTICE \(proc \d+\): We recommend linking the debug version of GASNet to assist you in resolving this application issue\.
 """
 
 output = re.sub(out_of_order, b'', contents, flags=re.MULTILINE)
 output = re.sub(signal, b'', output)
 output = re.sub(assertion, b'', output)
 output = re.sub(ioctl_broken, b'', output)
-output = output.replace(extra_prints, b'')
+output = re.sub(extra_prints, b'', output)
 
 
 with open(file, 'wb') as f:


### PR DESCRIPTION
I should've known!

## Testing
- [x] lines that show up in nightly testing are properly filtered out of `.good` file now

Reviewed by @arifthpe -- thanks!