### PR TITLE
Make memleaks silencing regex do what it says

### DIFF
--- a/test/library/packages/Python/memleaks/PREDIFF
+++ b/test/library/packages/Python/memleaks/PREDIFF
@@ -9,14 +9,14 @@ OUTFILE=$2
 #       printed if there were no deltas).
 #
 # The lines starting with these words report leak stats.
-cat $OUTFILE | grep "dict" >  $OUTFILE.tmphead
-cat $OUTFILE | grep "list" >> $OUTFILE.tmphead
-cat $OUTFILE | grep "tuple" >> $OUTFILE.tmphead
+cat $OUTFILE | grep "^dict" >  $OUTFILE.tmphead
+cat $OUTFILE | grep "^list" >> $OUTFILE.tmphead
+cat $OUTFILE | grep "^tuple" >> $OUTFILE.tmphead
 
 # cp $OUTFILE.tmphead $OUTFILE.tmphead.step1
 
 # The remaining lines (inverse grep) are just part of the test.
-cat $OUTFILE | grep -v -e "dict" -e "list" -e "tuple" > $OUTFILE.tmptail
+cat $OUTFILE | grep -v -e "^dict" -e "^list" -e "^tuple" > $OUTFILE.tmptail
 # cp $OUTFILE.tmptail $OUTFILE.tmptail.step1
 
 # If the number is preceded by a '+', remove it.


### PR DESCRIPTION
The comment says:

> The lines starting with these words report leak stats.

But then, it greps for lines that contain the word anywhere in their body. I suppose this was masked by the fact that no line contained the word "list" or "dict", but now that the word "tuple" is included, unrelated lines are catching strays and getting reordered. Adjust the regex to expect the words at the start of a line.

## Testing
- [x] `test/library/packages/Python/memleaks`

Reviewed by @arifthpe -- thanks!