### PR TITLE
Refresh the Chapel README a bit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Social media:          https://chapel-lang.org/socials/
    :width: 100%
    :class: borderless
 
-   * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.svg
+   * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg
           :target: https://hpsf.io/
           :height: 75px
          
@@ -56,7 +56,7 @@ Social media:          https://chapel-lang.org/socials/
           :height: 75px
           :align: center
 
-     - .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.svg
+     - .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.jpg
           :target: https://www.linuxfoundation.org/
           :height: 75px
           :align: right

--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,7 @@ For more information about Chapel, please refer to the following resources:
    If you are viewing this file locally, we recommend referring to
    doc/README.rst for local references to documentation and resources.
 
-.. class:: align-center
-   
-=====================  ========================================================
+=====================  ======================================
 Project website:       https://chapel-lang.org
 Try Chapel online:     https://chapel-lang.org/tryit/
 Install Chapel:        https://chapel-lang.org/download/
@@ -41,7 +39,7 @@ GitHub repository:     https://github.com/chapel-lang/chapel
 Discussion forums:     https://chapel-lang.org/forums/
 Social media:          https://chapel-lang.org/socials/
 Chapel Community:      https://chapel-lang.org/community/
-=====================  ========================================================
+=====================  ======================================
 
 .. list-table::
    :class: borderless

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,6 @@ Chapel Community:      https://chapel-lang.org/community/
 
 .. list-table::
    :width: 50%
-   :widths: 33 33 33
    :class: borderless
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg

--- a/README.rst
+++ b/README.rst
@@ -46,8 +46,6 @@ Chapel Community:      https://chapel-lang.org/community/
 |
 
 .. list-table::
-   :class: borderless
-   :widths: 33 33 33
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg
           :target: https://hpsf.io/

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ Chapel Community:      https://chapel-lang.org/community/
 =====================  ========================================================
 
 .. list-table::
+   :width: 50%
    :widths: 33 33 33
    :class: borderless
 

--- a/README.rst
+++ b/README.rst
@@ -45,11 +45,27 @@ Social media:          https://chapel-lang.org/socials/
 
 .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.svg
    :target: https://hpsf.io/
-   :width: 240px
-
+   :height: 50px
+   :align: left
 .. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
    :target: https://hpsf.io/projects/chapel/
-   :scale: 50%
-
+   :height: 50px
+   :align: center
 .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.svg
    :target: https://www.linuxfoundation.org/
+   :height: 50px
+   :align: right
+
+
+.. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.svg
+   :target: https://hpsf.io/
+   :width: 30 %
+   :align: middle
+.. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
+   :target: https://hpsf.io/projects/chapel/
+   :width: 10 %
+   :align: middle
+.. image:: https://chapel-lang.org/img/logos/lf-stacked-color.svg
+   :target: https://www.linuxfoundation.org/
+   :width: 30 %
+   :align: middle

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,6 @@ Chapel Community:      https://chapel-lang.org/community/
          
      - .. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
           :target: https://hpsf.io/projects/chapel/
-          :align: middle
 
      - .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.jpg
           :target: https://www.linuxfoundation.org/

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,8 @@ Social media:          https://chapel-lang.org/socials/
 Chapel Community:      https://chapel-lang.org/community/
 =====================  ======================================
 
+|
+
 .. list-table::
    :class: borderless
 

--- a/README.rst
+++ b/README.rst
@@ -43,16 +43,19 @@ Chapel Community:      https://chapel-lang.org/community/
 
 |
 
+|
+
 .. list-table::
    :class: borderless
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg
           :target: https://hpsf.io/
+          :align: middle
          
      - .. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
           :target: https://hpsf.io/projects/chapel/
-          :align: center
+          :align: middle
 
      - .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.jpg
           :target: https://www.linuxfoundation.org/
-          :align: right
+          :align: middle

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Chapel Community:      https://chapel-lang.org/community/
          
      - .. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
           :target: https://hpsf.io/projects/chapel/
+          :align: middle
 
      - .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.jpg
           :target: https://www.linuxfoundation.org/

--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,10 @@ The Chapel Language
 What is Chapel?
 ---------------
 Chapel is a modern programming language designed for productive
-parallel computing at scale. Chapel's design and implementation have
-been undertaken with portability in mind, permitting it to run on the
-CPUS and GPUS of laptops, desktops, commodity clusters, and the cloud,
-in addition to the high-end supercomputers that originally motivated
-it.
+parallel computing at scale.  Its design and implementation have been
+undertaken with portability in mind, permitting it to run on the CPUS
+and GPUS of laptops, desktops, commodity clusters, and the cloud, in
+addition to the high-end supercomputers that Chapel was designed for.
 
 For more information about Chapel, see its website at
 https://chapel-lang.org
@@ -37,15 +36,13 @@ Install Chapel:        https://chapel-lang.org/download/
 Sample computations:   https://chapel-lang.org/docs/examples/
 Chapel documentation:  https://chapel-lang.org/docs/
 GitHub repository:     https://github.com/chapel-lang/chapel
-Reporting bugs:        https://github.com/chapel-lang/chapel/issues
 Discussion forums:     https://chapel-lang.org/forums/
-Community resources:   https://chapel-lang.org/community/
 Social media:          https://chapel-lang.org/socials/
+Chapel Community:      https://chapel-lang.org/community/
 =====================  ========================================================
 
 .. list-table::
    :width: 100%
-   :widths: 25 25 25
    :class: borderless
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ What is Chapel?
 ---------------
 Chapel is a modern programming language designed for productive
 parallel computing at scale.  Its design and implementation have been
-undertaken with portability in mind, permitting it to run on the CPUS
-and GPUS of laptops, desktops, commodity clusters, and the cloud, in
+undertaken with portability in mind, permitting it to run on the CPUs
+and GPUs of laptops, desktops, commodity clusters, and the cloud, in
 addition to the high-end supercomputers that Chapel was designed for.
 
 For more information about Chapel, see its website at
@@ -47,14 +47,11 @@ Chapel Community:      https://chapel-lang.org/community/
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg
           :target: https://hpsf.io/
-          :height: 75px
          
      - .. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
           :target: https://hpsf.io/projects/chapel/
-          :height: 75px
           :align: center
 
      - .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.jpg
           :target: https://www.linuxfoundation.org/
-          :height: 75px
           :align: right

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,8 @@ For more information about Chapel, please refer to the following resources:
    If you are viewing this file locally, we recommend referring to
    doc/README.rst for local references to documentation and resources.
 
+.. class:: align-center
+   
 =====================  ========================================================
 Project website:       https://chapel-lang.org
 Try Chapel online:     https://chapel-lang.org/tryit/
@@ -42,7 +44,6 @@ Chapel Community:      https://chapel-lang.org/community/
 =====================  ========================================================
 
 .. list-table::
-   :width: 50%
    :class: borderless
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg

--- a/README.rst
+++ b/README.rst
@@ -44,5 +44,12 @@ Social media:          https://chapel-lang.org/socials/
 =====================  ========================================================
 
 .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.svg
+   :target: https://hpsf.io/
+   :width: 240px
+
 .. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
+   :target: https://hpsf.io/projects/chapel/
+   :scale: 50%
+
 .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.svg
+   :target: https://www.linuxfoundation.org/

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ Social media:          https://chapel-lang.org/socials/
 
 .. list-table::
    :width: 100%
+   :widths: 33% 33% 33%
    :class: borderless
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg

--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,13 @@ What is Chapel?
 ---------------
 Chapel is a modern programming language designed for productive
 parallel computing at scale. Chapel's design and implementation have
-been undertaken with portability in mind, permitting Chapel to run on
-multicore desktops and laptops, commodity clusters, and the cloud, in
-addition to the high-end supercomputers for which it was originally
-undertaken.
+been undertaken with portability in mind, permitting it to run on the
+CPUS and GPUS of laptops, desktops, commodity clusters, and the cloud,
+in addition to the high-end supercomputers that originally motivated
+it.
+
+For more information about Chapel, see its website at
+https://chapel-lang.org
 
 License
 -------
@@ -28,17 +31,18 @@ For more information about Chapel, please refer to the following resources:
    doc/README.rst for local references to documentation and resources.
 
 =====================  ========================================================
-Project homepage:      https://chapel-lang.org
-Installing Chapel:     https://chapel-lang.org/download/
-Building from source:  https://chapel-lang.org/docs/usingchapel/QUICKSTART.html
+Project website:       https://chapel-lang.org
+Try Chapel online:     https://chapel-lang.org/tryit/
+Install Chapel:        https://chapel-lang.org/download/
 Sample computations:   https://chapel-lang.org/docs/examples/
-Learning Chapel:       https://chapel-lang.org/learn/
-Reporting bugs:        https://chapel-lang.org/bugs.html
 Chapel documentation:  https://chapel-lang.org/docs/
-GitHub:                https://github.com/chapel-lang/chapel
-Discussion forums:     https://chapel.discourse.group
-Gitter chat room:      https://gitter.im/chapel-lang/chapel
-Stack Overflow:        http://stackoverflow.com/questions/tagged/chapel
-X (Twitter):           https://x.com/ChapelLanguage
-Facebook:              https://www.facebook.com/ChapelLanguage
+GitHub repository:     https://github.com/chapel-lang/chapel
+Reporting bugs:        https://github.com/chapel-lang/chapel/issues
+Discussion forums:     https://chapel-lang.org/forums/
+Community resources:   https://chapel-lang.org/community/
+Social media:          https://chapel-lang.org/socials/
 =====================  ========================================================
+
+.. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.svg
+.. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
+.. image:: https://chapel-lang.org/img/logos/lf-stacked-color.svg

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Social media:          https://chapel-lang.org/socials/
 
 .. list-table::
    :width: 100%
-   :widths: 33% 33% 33%
+   :widths: 25 25 25
    :class: borderless
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg

--- a/README.rst
+++ b/README.rst
@@ -43,13 +43,20 @@ Community resources:   https://chapel-lang.org/community/
 Social media:          https://chapel-lang.org/socials/
 =====================  ========================================================
 
-.. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.svg
-   :target: https://hpsf.io/
-   :height: 75px
-   :align: left
-.. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
-   :target: https://hpsf.io/projects/chapel/
-   :height: 75px
-.. image:: https://chapel-lang.org/img/logos/lf-stacked-color.svg
-   :target: https://www.linuxfoundation.org/
-   :height: 75px
+.. list-table::
+   :width: 100%
+   :class: borderless
+
+   * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.svg
+          :target: https://hpsf.io/
+          :height: 75px
+         
+     - .. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
+          :target: https://hpsf.io/projects/chapel/
+          :height: 75px
+          :align: center
+
+     - .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.svg
+          :target: https://www.linuxfoundation.org/
+          :height: 75px
+          :align: right

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Chapel Community:      https://chapel-lang.org/community/
 
 .. list-table::
    :class: borderless
+   :widths: 33 33 33
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg
           :target: https://hpsf.io/

--- a/README.rst
+++ b/README.rst
@@ -50,12 +50,9 @@ Chapel Community:      https://chapel-lang.org/community/
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg
           :target: https://hpsf.io/
-          :align: middle
          
      - .. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
           :target: https://hpsf.io/projects/chapel/
-          :align: middle
 
      - .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.jpg
           :target: https://www.linuxfoundation.org/
-          :align: middle

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@ License
 -------
 Chapel is developed and released under the terms of the Apache 2.0
 license, though it also makes use of third-party packages under their
-own licensing terms.  See the `<LICENSE>`_ file in this directory for
-details.
+own licensing terms.  See https://chapel-lang.org/license/ or the
+`<LICENSE>`_ file in this directory for details.
 
 Resources
 ---------

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Chapel Community:      https://chapel-lang.org/community/
 =====================  ========================================================
 
 .. list-table::
-   :width: 100%
+   :widths: 33 33 33
    :class: borderless
 
    * - .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.jpg

--- a/README.rst
+++ b/README.rst
@@ -45,27 +45,11 @@ Social media:          https://chapel-lang.org/socials/
 
 .. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.svg
    :target: https://hpsf.io/
-   :height: 50px
+   :height: 75px
    :align: left
 .. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
    :target: https://hpsf.io/projects/chapel/
-   :height: 50px
-   :align: center
+   :height: 75px
 .. image:: https://chapel-lang.org/img/logos/lf-stacked-color.svg
    :target: https://www.linuxfoundation.org/
-   :height: 50px
-   :align: right
-
-
-.. image:: https://chapel-lang.org/img/logos/HPSF_horizontal-tagline-color.svg
-   :target: https://hpsf.io/
-   :width: 30 %
-   :align: middle
-.. image:: https://chapel-lang.org/img/logos/HPSF_Project_Badge_Established.png
-   :target: https://hpsf.io/projects/chapel/
-   :width: 10 %
-   :align: middle
-.. image:: https://chapel-lang.org/img/logos/lf-stacked-color.svg
-   :target: https://www.linuxfoundation.org/
-   :width: 30 %
-   :align: middle
+   :height: 75px


### PR DESCRIPTION
This refresh is motivated by a few things:
* a long-term intention/request to add HPSF-related logos to the README
* my mistake at putting the incorrect website URL into our OS4LS LOI and realizing that directing people to the website toward the top of our README would be a good practice anyway
* looking at the summary with fresh eyes
* new webpages that are better maintained than some of the more specific links we had here
