### PR TITLE
Do not use a slice to avoid confusing debugger

### DIFF
--- a/modules/internal/ChapelDynamicLoading.chpl
+++ b/modules/internal/ChapelDynamicLoading.chpl
@@ -1039,10 +1039,12 @@ module ChapelDynamicLoading {
 
         // While holding the LOCALE-0 lock, set on all other locales.
         if requestedUniqueIdx && numLocales > 1 {
-          coforall loc in Locales[1..] do on loc {
-            local do manage chpl_localPtrCache.guard.write() as m {
-              const ptr = lookupPtrFromLocalFtable(idx);
-              m.add(ptr, ret);
+          coforall loc in Locales do on loc {
+            if loc.id != 0 {
+              local do manage chpl_localPtrCache.guard.write() as m {
+                const ptr = lookupPtrFromLocalFtable(idx);
+                m.add(ptr, ret);
+              }
             }
           }
         }

--- a/test/modules/sungeun/init/printModuleInitOrder.good
+++ b/test/modules/sungeun/init/printModuleInitOrder.good
@@ -24,7 +24,6 @@ Initializing Modules:
         ChapelNumLocales
        DefaultRectangular
         ChapelArray
-         ArrayViewSlice
          ChapelPrivatization
          ChapelDomain
           FormattedIO

--- a/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
+++ b/test/optimizations/deadCodeElimination/elliot/countDeadModules.good
@@ -1,1 +1,1 @@
-Removed 39 dead modules.
+Removed 40 dead modules.


### PR DESCRIPTION
For some unknown reason, slicing the Locales array here confuses the debugger enough such that we are unable to correctly interact with arrays. My best guess is that this is because the slice and non-slice types have the same string representation, and some mapping function needs to be updated.

Testing:
- [x] local paratest
- [x] gasnet paratest

