### PR TITLE
Switch Curl test to Chapel website test page

### DIFF
--- a/test/library/packages/URL/doc-examples/example_read_url.chpl
+++ b/test/library/packages/URL/doc-examples/example_read_url.chpl
@@ -4,7 +4,7 @@
 
 /* START_EXAMPLE */
 use URL;
-var urlreader = openUrlReader("http://example.com");
+var urlreader = openUrlReader("https://chapel-lang.org/test-page.html");
 var str: bytes;
 // Output each line read from the URL to stdout
 while urlreader.readLine(str) {

--- a/test/library/packages/URL/doc-examples/example_read_url.good
+++ b/test/library/packages/URL/doc-examples/example_read_url.good
@@ -1,1 +1,11 @@
-<!doctype html><html lang="en"><head><title>Example Domain</title><meta name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href="https://iana.org/domains/example">Learn more</a></p></div></body></html>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Test page</title>
+</head>
+<body>
+  <h1>Example page for Chapel networking tests</h1>
+  <p>Hello, world!</p>
+</body>
+</html>
+


### PR DESCRIPTION
Switch the URL that `test/library/packages/URL/doc-examples/example_read_url.chpl` pulls and checks the content of from example.com to https://chapel-lang.org/test-page.html.

The Chapel website page was added in https://github.com/chapel-lang/chapel-www/pull/129 for this purpose.

[reviewed by @bradcray , thanks!]

Testing:
- [x] `test/library/packages/URL/doc-examples/example_read_url.chpl`