### PR TITLE
Make sure to add "extern C" block around program-only declarations

### DIFF
--- a/runtime/include/chpl-prginfo-program-only-decls.h
+++ b/runtime/include/chpl-prginfo-program-only-decls.h
@@ -27,6 +27,10 @@
 // DO NOT INCLUDE THIS HEADER WITHIN RUNTIME CODE!
 //
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //
 // This header fixes issues with '--incremental' compilation.
 //
@@ -78,5 +82,9 @@ extern const c_string chpl_filenameTable[];
 extern const int chpl_filenameTableSize;
 extern void* const chpl_private_broadcast_table[];
 extern const int chpl_private_broadcast_table_len;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
This PR fixes nightly testing errors for ROCM7 gpu testing. Add an `extern "C"` block around a set of program-only symbol declarations (that really should have been declared as such in the first place).

TESTING

- [x] `standard`
- [x] Build on `hpe-cray-ex` `CHPL_LOCALE_MODEL=gpu` w/ `ROCM7`
- [x] `COMM=gasnet`
- [x] `gasnet-asan` w/ `fastAndIncremental.chpl`

Reviewed by @bradcray. Thanks much!