### PR TITLE
Update mason help to describe --color rather than --no-color

### DIFF
--- a/test/mason/mason-help-tests/masonHelpTests.good
+++ b/test/mason/mason-help-tests/masonHelpTests.good
@@ -8,7 +8,7 @@ Usage:
 Options:
     -h, --help          Display this message
     -V, --version       Print version info and exit
-        --no-color      Do not format text printed on console
+        --color=[mode]  Select color mode ('always', 'never', or 'auto')
 
 Mason commands:
     new         Create a new Mason project

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -158,7 +158,8 @@ proc masonHelp() {
   Options:
       -h, --help          Display this message
       -V, --version       Print version info and exit
-          --no-color      Do not format text printed on console
+          --color=[mode]  Select color mode ('always', 'never', or 'auto')
+
 
   Mason commands:
       new         Create a new Mason project

--- a/tools/mason/MasonHelp.chpl
+++ b/tools/mason/MasonHelp.chpl
@@ -160,7 +160,6 @@ proc masonHelp() {
       -V, --version       Print version info and exit
           --color=[mode]  Select color mode ('always', 'never', or 'auto')
 
-
   Mason commands:
       new         Create a new Mason project
       init        Initialize a Mason project inside an existing directory


### PR DESCRIPTION
This was changed in #28478, but the help output wasn't updated
