### PR TITLE
Automatically add Anna as an assignee on Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 15
+    assignees:
+      - "arifthpe"


### PR DESCRIPTION
Automatically assign Dependabot Github Action version update PRs to me, so a human gets a notification and can go hit merge when these pop up.

Docs for this feature: https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/customizing-dependabot-prs#automatically-adding-assignees

[trivial, not reviewed]