### PR TITLE
Fix LLDB jumping up stack upon `debuggerBreakHere` breakpoint

### DIFF
--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -36,7 +36,7 @@ class DebuggerBreakHereStopHook:
         isBreakOnDebuggerBreakHere = (
             breakFunc
             and breakFunc.IsValid()
-            and breakFunc.GetName().startswith("debuggerBreakHere")
+            and breakFunc.GetName() == "debuggerBreakHere"
         )
 
         if not (isNamedDebuggerBreakHere or isBreakOnDebuggerBreakHere):

--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -36,7 +36,7 @@ class DebuggerBreakHereStopHook:
         isBreakOnDebuggerBreakHere = (
             breakFunc
             and breakFunc.IsValid()
-            and breakFunc.GetName().startswith("debuggerBreakHere(")
+            and breakFunc.GetName().startswith("debuggerBreakHere")
         )
 
         if not (isNamedDebuggerBreakHere or isBreakOnDebuggerBreakHere):

--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -36,7 +36,8 @@ class DebuggerBreakHereStopHook:
         isBreakOnDebuggerBreakHere = (
             breakFunc
             and breakFunc.IsValid()
-            and breakFunc.GetName().startswith("debuggerBreakHere")
+            and (breakFunc.GetName() == "debuggerBreakHere"
+                 or breakFunc.GetName().startswith("debuggerBreakHere("))
         )
 
         if not (isNamedDebuggerBreakHere or isBreakOnDebuggerBreakHere):
@@ -46,7 +47,8 @@ class DebuggerBreakHereStopHook:
 
         curFrame = thread.GetSelectedFrame()
         fn = curFrame.GetFunction()
-        if fn and fn.name.startswith("debuggerBreakHere"):
+        if fn and (fn.name == "debuggerBreakHere"
+                   or fn.name.startswith("debuggerBreakHere(")):
             thread.SetSelectedFrame(2)
         return True
 

--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -36,8 +36,10 @@ class DebuggerBreakHereStopHook:
         isBreakOnDebuggerBreakHere = (
             breakFunc
             and breakFunc.IsValid()
-            and (breakFunc.GetName() == "debuggerBreakHere"
-                 or breakFunc.GetName().startswith("debuggerBreakHere("))
+            and (
+                breakFunc.GetName() == "debuggerBreakHere"
+                or breakFunc.GetName().startswith("debuggerBreakHere(")
+            )
         )
 
         if not (isNamedDebuggerBreakHere or isBreakOnDebuggerBreakHere):
@@ -47,8 +49,10 @@ class DebuggerBreakHereStopHook:
 
         curFrame = thread.GetSelectedFrame()
         fn = curFrame.GetFunction()
-        if fn and (fn.name == "debuggerBreakHere"
-                   or fn.name.startswith("debuggerBreakHere(")):
+        if fn and (
+            fn.name == "debuggerBreakHere"
+            or fn.name.startswith("debuggerBreakHere(")
+        ):
             thread.SetSelectedFrame(2)
         return True
 

--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -46,7 +46,7 @@ class DebuggerBreakHereStopHook:
 
         curFrame = thread.GetSelectedFrame()
         fn = curFrame.GetFunction()
-        if fn and fn.name.startswith("debuggerBreakHere("):
+        if fn and fn.name == "debuggerBreakHere":
             thread.SetSelectedFrame(2)
         return True
 

--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -36,7 +36,7 @@ class DebuggerBreakHereStopHook:
         isBreakOnDebuggerBreakHere = (
             breakFunc
             and breakFunc.IsValid()
-            and breakFunc.GetName() == "debuggerBreakHere"
+            and breakFunc.GetName().startswith("debuggerBreakHere")
         )
 
         if not (isNamedDebuggerBreakHere or isBreakOnDebuggerBreakHere):
@@ -46,7 +46,7 @@ class DebuggerBreakHereStopHook:
 
         curFrame = thread.GetSelectedFrame()
         fn = curFrame.GetFunction()
-        if fn and fn.name == "debuggerBreakHere":
+        if fn and fn.name.startswith("debuggerBreakHere"):
             thread.SetSelectedFrame(2)
         return True
 


### PR DESCRIPTION
Fix the intended functionality of `--lldb` (on compiled Chapel programs) to move above the `debuggerBreakHere` stack frame upon hitting its breakpoint.

This was broken in [`a6d8985` (#28840)](https://github.com/chapel-lang/chapel/pull/28840/changes/a6d898595c3cce7281e9a3a0ff7bb5789b7d0785). It appears that the `SBFunction`'s name is `debuggerBreakHere`, so our check that it starts with `debuggerBreakHere(` fails. Confusingly, this same check works correctly for the `debuggerBreakHere` hook for _compiler_ code, which received the same change in [`379637a` (#28892)](https://github.com/chapel-lang/chapel/pull/28892/changes/379637a5a896ffbc63ec6997272ec9ffdb468df8); I chalk this up to a difference between C++ and Chapel executables that I don't understand.

Checking for an exact match against `"debuggerBreakHere"` works on my machine with LLVM 22, but given `startswith("debuggerBreakHere(")` worked previously, compromise by matching on either. This avoid breaking older LLVMs, or risking matching a user function that starts with `debuggerBreakHere`.

[reviewed by @benharsh , thanks!]

Testing:
- [x] `test/library/standard/Debugger/`
- [x] no new failures in `test/llvm/debugInfo/`
  - the following fail on my local machine even on `main`:
    ```
    [Error matching program output for llvm/debugInfo/lldb/functionCalls]
	[Error matching program output for llvm/debugInfo/lldb/methodCallsClass]
	[Error matching program output for llvm/debugInfo/lldb/methodCallsRec]
	```