### PR TITLE
Prediff out all digits of Python memleak tests

### DIFF
--- a/test/library/packages/Python/memleaks/PREDIFF
+++ b/test/library/packages/Python/memleaks/PREDIFF
@@ -27,11 +27,9 @@ mv $OUTFILE.scratch $OUTFILE.tmphead
 cat $OUTFILE.tmphead | sed -e 's/[[:space:]]*$//g' > $OUTFILE.scratch
 mv $OUTFILE.scratch $OUTFILE.tmphead
 
-# Next, replace all but the first digit of every number with 'x'. Using
-# 'perl' here saved me a crazy headache trying to do this with 'sed'.
-# TODO: If the variance in leaks is such that the first digit changes, then
-#       just replace the whole line with 'x' (also easier to write...).
-cat $OUTFILE.tmphead | perl -pe 's/([0-9])([0-9]+)/$1 . "x" x length($2)/ge' > $OUTFILE.scratch
+# Next, replace all digits of every number with 'x'. Using 'perl' here saved me
+# a crazy headache trying to do this with 'sed'.
+cat $OUTFILE.tmphead | perl -pe 's/([0-9]+)/"x" x length($1)/ge' > $OUTFILE.scratch
 mv $OUTFILE.scratch $OUTFILE.tmphead
 
 # Sort.

--- a/test/library/packages/Python/memleaks/basicTypes.good
+++ b/test/library/packages/Python/memleaks/basicTypes.good
@@ -1,2 +1,2 @@
-dict     2xxx
-list      7xx
+dict     xxxx
+list      xxx

--- a/test/library/packages/Python/memleaks/iterate.good
+++ b/test/library/packages/Python/memleaks/iterate.good
@@ -1,5 +1,5 @@
-dict     2xxx
-list      7xx
+dict     xxxx
+list      xxx
 yielding Values from tuple
 1
 2

--- a/test/library/packages/Python/memleaks/lambdas.good
+++ b/test/library/packages/Python/memleaks/lambdas.good
@@ -1,5 +1,5 @@
-dict     2xxx
-list      7xx
+dict     xxxx
+list      xxx
 [1, 1]
 [hi, hi]
 [[1, 2, 3], [1, 2, 3]]

--- a/test/library/packages/Python/memleaks/maps.3.14.5.darwin.good
+++ b/test/library/packages/Python/memleaks/maps.3.14.5.darwin.good
@@ -1,5 +1,5 @@
-dict     2xxx
-list      7xx
+dict     xxxx
+list      xxx
 d size 3
 d size after deleting second 2
 d size after swap 3

--- a/test/library/packages/Python/memleaks/maps.3.14.5.good
+++ b/test/library/packages/Python/memleaks/maps.3.14.5.good
@@ -1,6 +1,6 @@
-dict      2xxx
-list       7xx
-tuple     1xxx
+dict      xxxx
+list       xxx
+tuple     xxxx
 d size 3
 d size after deleting second 2
 d size after swap 3

--- a/test/library/packages/Python/memleaks/maps.good
+++ b/test/library/packages/Python/memleaks/maps.good
@@ -1,5 +1,5 @@
-dict     2xxx
-list      7xx
+dict     xxxx
+list      xxx
 d size 3
 d size after deleting second 2
 d size after swap 3


### PR DESCRIPTION
Adjust the Python memleak testing PREDIFF to "x" out all digits of the memleak numbers (counts? bytes?), not just all but the first.

As the TODO in this file suggests, the variance in this testing across systems is large enough that we observed even the first digit varying (currently just for `list`s), so apply the suggested change.

[reviewed by @DanilaFe , thanks!]

Testing:
- [x] `test/library/packages/Python/memleaks/`