### PR TITLE
Fix broken and fragile links in CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10829,7 +10829,7 @@ Cray-specific Changes
 
 Documentation
 -------------
-* simplified URLs to use https://chapel-lang/docs/ rather than .../docs/latest/
+* simplified URLs to use https://chapel-lang.org/docs/ rather than .../docs/latest/
 * fixed some typos and broken links in this file
 
 Packaging Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1589,7 +1589,7 @@ Runtime Library Improvements
 Third-Party Software Changes
 ----------------------------
 * added a bundled version of `mimalloc` 2.1.7 as a memory allocator option  
-  (see https://github.com/chapel-lang/chapel/blob/main/third-party/mimalloc/README)
+  (see https://github.com/chapel-lang/chapel/blob/release/2.5/third-party/mimalloc/README)
 * updated the bundled version of Qthreads to 1.22
 * updated the bundled hwloc to version 2.11.2
 
@@ -6677,7 +6677,7 @@ Third-Party Software Changes
 Developer-oriented changes: Process
 -----------------------------------
 * introduced a Code of Conduct for Chapel developers  
-  (see https://github.com/chapel-lang/chapel/blob/main/CODE_OF_CONDUCT.md)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.27/CODE_OF_CONDUCT.md)
 
 Developer-oriented changes: Documentation
 -----------------------------------------
@@ -7777,19 +7777,19 @@ Developer-oriented changes: Naming Changes
 Developer-oriented changes: Documentation
 -----------------------------------------
 * added a draft style guide for standard modules  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/StandardModuleStyle.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/bestPractices/StandardModuleStyle.rst)
 * added notes about how Chapel web documentation is built  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/buildingdocs.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/bestPractices/buildingdocs.rst)
 * added information about how to test PRs in the contributor guidelines  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/ContributorInfo.rst#reviewer-responsibilities)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/bestPractices/ContributorInfo.rst#reviewer-responsibilities)
 * generally cleaned up and streamlined the contributor guidelines  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/ContributorInfo.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/bestPractices/ContributorInfo.rst)
 * improved the layout of documentation generated for the new compiler
 * moved documents in `compilerOverview/` to `implementation/compilerOverview/`  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/implementation/compilerOverview/)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/implementation/compilerOverview/)
 * documented the implementation of interfaces and a proposed new approach  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/implementation/Interfaces.md  
-   and https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/implementation/Interfaces-new.md)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/implementation/Interfaces.md  
+   and https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/implementation/Interfaces-new.md)
 
 Developer-oriented changes: Module changes
 ------------------------------------------
@@ -7988,7 +7988,7 @@ New Features
   (see https://chapel-lang.org/docs/1.24/language/spec/statements.html#the-conditional-statement  
    and https://chapel-lang.org/docs/1.24/language/spec/statements.html#the-while-do-and-do-while-loops)
 * added initial support for constrained generic interfaces  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/chips/2.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.24/doc/rst/developer/chips/2.rst)
 * added support for directly indexing `string` and `bytes` literals  
   (e.g., `var s = "Chapel"[0];` and `var b = b"is great!"[0];` now work)
 * added `domain.orderToIndex(i)` to get the `i`th index in a rectangular domain  
@@ -8238,17 +8238,17 @@ Third-Party Software Changes
 Developer-oriented changes: Process
 -----------------------------------
 * switched from having developers sign CLAs to using DCO-based commits  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/DCO.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.24/doc/rst/developer/bestPractices/DCO.rst)
 
 Developer-oriented changes: Documentation
 -----------------------------------------
 * updated the docs to reflect our use of Discourse rather than mailing lists
 * refreshed the information in our 'GettingStarted' documentation  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/GettingStarted.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.24/doc/rst/developer/bestPractices/GettingStarted.rst)
 * refactored our 'ContributorInfo' documentation w.r.t. DCOs, git tips, etc.  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/ContributorInfo.rst,
-   https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/DCO.rst,  
-   and https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/git.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.24/doc/rst/developer/bestPractices/ContributorInfo.rst,
+   https://github.com/chapel-lang/chapel/blob/release/1.24/doc/rst/developer/bestPractices/DCO.rst,  
+   and https://github.com/chapel-lang/chapel/blob/release/1.24/doc/rst/developer/bestPractices/git.rst)
 * switched to a non-Cray version of the Chapel logo in the project's README
 * created an improved and independently-maintained pygments highlighter  
   (see https://github.com/chapel-lang/sphinxcontrib-chapeldomain)
@@ -9787,7 +9787,7 @@ Launchers
 Testing System
 --------------
 * added support for running multilocale C tests via `start_test`  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/TestSystem.rst#comparing-to-a-c-version)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.20/doc/rst/developer/bestPractices/TestSystem.rst#comparing-to-a-c-version)
 
 Developer-oriented changes: Module changes
 ------------------------------------------
@@ -10430,7 +10430,7 @@ Feature Improvements
   (see 'Function Visibility in Generic Functions' in the 'Generics' chapter)
 * made `in` arguments more consistent with variable initialization  
   (see 'Argument Intents' in the language specification's 'Procedures' chapter)  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/chips/13.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.18/doc/rst/developer/chips/13.rst)
 * added support for casts from `c_void_ptr` to `c_ptr`
 
 Removed Features
@@ -10764,10 +10764,10 @@ Developer-oriented changes: Compiler improvements/changes
 Developer-oriented changes: Documentation improvements
 ------------------------------------------------------
 * revamped the test system documentation to better serve new developers  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/TestSystem.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.18/doc/rst/developer/bestPractices/TestSystem.rst)
 * added a `check_path` script to find bad filepath references in repository
 * documented the launcher interface  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/adding-a-launcher.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.18/doc/rst/developer/adding-a-launcher.rst)
 * removed `404 error` output after successful documentation build
 * removed `git clean` suggestion after failed documentation build
 
@@ -10904,7 +10904,7 @@ New Tools / Tool Changes
 Semantic Changes / Changes to Chapel Language
 ---------------------------------------------
 * `in` intents now behave more like variable initialization  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/chips/13.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.17/doc/rst/developer/chips/13.rst)
 * ranges are now passed by `const in` intent by default  
   (see 'The Default Intent' in the 'Procedures' chapter of the specification)
 * disallowed implicit coercions for type arguments with a formal type specifier  
@@ -11281,12 +11281,12 @@ Developer-oriented changes: Compiler improvements/changes
 Developer-oriented changes: Documentation improvements
 ------------------------------------------------------
 * updated CONTRIBUTING.md content, to reduce redundancy with other docs  
-  (see https://github.com/chapel-lang/chapel/blob/main/.github/CONTRIBUTING.md)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.17/.github/CONTRIBUTING.md)
 * updated GitHub issue template to request users to note blocking issues  
-  (see https://github.com/chapel-lang/chapel/blob/main/.github/ISSUE_TEMPLATE.md)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.17/.github/ISSUE_TEMPLATE.md)
 * modified ContributorInfo.rst and TestSystem.rst for clarity
 * document new future file format option  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/bestPractices/TestSystem.rst#futures-a-mechanism-for-tracking-bugs-feature-requests-etc)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.17/doc/rst/developer/bestPractices/TestSystem.rst#futures-a-mechanism-for-tracking-bugs-feature-requests-etc)
 
 Developer-oriented changes: Module improvements
 -----------------------------------------------
@@ -11785,13 +11785,13 @@ New Features
 ------------
 * dramatically improved support for initializers  
   (see https://chapel-lang.org/docs/1.15/technotes/initializers.html  
-   and https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/chips/10.rst)
+   and https://github.com/chapel-lang/chapel/blob/release/1.15/doc/rst/developer/chips/10.rst)
 * added prototype support for error-handling in Chapel  
   (see https://chapel-lang.org/docs/1.15/technotes/errorHandling.html  
-   and https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/chips/8.rst)
+   and https://github.com/chapel-lang/chapel/blob/release/1.15/doc/rst/developer/chips/8.rst)
 * added support for deinit() as a replacement for class/record destructors  
   (see "Class Deinitializer" and "Record Deinitializer" sections in the spec  
-   and https://github.com/chapel-lang/chapel/blob/main/doc/rst/developer/chips/10.rst)
+   and https://github.com/chapel-lang/chapel/blob/release/1.15/doc/rst/developer/chips/10.rst)
 * added support for 'forwarding' methods to fields of classes and records  
   (see https://chapel-lang.org/docs/1.15/technotes/forwarding.html)
 * made 'void' a first-class type in the language and a way to fold variables  
@@ -11951,7 +11951,7 @@ Documentation
   (see https://chapel-lang.org/docs/1.15/usingchapel/QUICKSTART.html)
 * reorganized the doc/ directory in the release tarball  
   (see $CHPL_HOME/doc/README.md  
-   or https://github.com/chapel-lang/chapel/blob/main/doc/README.rst)
+   or https://github.com/chapel-lang/chapel/blob/release/1.15/doc/README.rst)
 * removed $CHPL_HOME/STATUS in favor of GitHub issues
 * updated bugs.rst to refer users to GitHub issues  
   (see https://chapel-lang.org/docs/1.15/usingchapel/bugs.html)
@@ -12313,7 +12313,7 @@ New Features
 * added the ability to create serial iterators for types  
   (see 'The Method Receiver and the 'this' Argument' in the language spec)
 * added early prototype support for class/record initializers (constructors)  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/chips/10.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.14/doc/chips/10.rst)
 
 Feature Improvements
 --------------------
@@ -13172,7 +13172,7 @@ Highlights
 * significantly revamped and improved correctness and performance testing system
 * improved how internal error messages are displayed to users
 * added Chapel Improvement Proposals (CHIPs) framework for proposing changes  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/chips/1.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.12/doc/chips/1.rst)
 * made more bug fixes than any release since version 1.1  
   (see "Bug Fixes" section below)
 * addressed portability issues for a number of platforms and compilers
@@ -13180,7 +13180,7 @@ Highlights
 Process Improvements
 --------------------
 * added Chapel Improvement Proposals (CHIPs) framework for proposed changes  
-  (see https://github.com/chapel-lang/chapel/blob/main/doc/chips/1.rst)
+  (see https://github.com/chapel-lang/chapel/blob/release/1.12/doc/chips/1.rst)
 
 Environment/Configuration Changes
 ---------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7777,13 +7777,13 @@ Developer-oriented changes: Naming Changes
 Developer-oriented changes: Documentation
 -----------------------------------------
 * added a draft style guide for standard modules  
-  (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/bestPractices/StandardModuleStyle.rst)
+  (see https://chapel-lang.org/docs/1.25/developer/bestPractices/StandardModuleStyle.html)
 * added notes about how Chapel web documentation is built  
-  (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/bestPractices/buildingdocs.rst)
+  (see https://chapel-lang.org/docs/1.25/developer/bestPractices/buildingdocs.html)
 * added information about how to test PRs in the contributor guidelines  
-  (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/bestPractices/ContributorInfo.rst#reviewer-responsibilities)
+  (see https://chapel-lang.org/docs/1.25/developer/bestPractices/ContributorInfo.html#reviewer-responsibilities)
 * generally cleaned up and streamlined the contributor guidelines  
-  (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/bestPractices/ContributorInfo.rst)
+  (see https://chapel-lang.org/docs/1.25/developer/bestPractices/ContributorInfo.html)
 * improved the layout of documentation generated for the new compiler
 * moved documents in `compilerOverview/` to `implementation/compilerOverview/`  
   (see https://github.com/chapel-lang/chapel/blob/release/1.25/doc/rst/developer/implementation/compilerOverview/)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10829,7 +10829,7 @@ Cray-specific Changes
 
 Documentation
 -------------
-* simplified URLs to use https://chapel-lang.org/docs/ rather than .../docs/latest/
+* changed URLs to use https://chapel-lang.org/docs/ rather than .../docs/latest/
 * fixed some typos and broken links in this file
 
 Packaging Changes


### PR DESCRIPTION
Update the following links in CHANGES.md:
- link to blobs on `main` under `https://github.com/chapel-lang/chapel/blob/main/` -> link to blob on release branch
  - many of these are broken
  - some are not broken, but could break in the future if we [re]move the referenced file, and in any case this is more faithful to what we referenced at time of writing
- one instance of `https://chapel-lang/docs/` -> `https://chapel-lang.org/docs/`
  - minor wording change to item to maintain line length limit
- some links to release-versioned blobs in the GitHub repo -> release-versioned docs
  - only found 4 instances that had corresponding docs page in their version

[reviewed by @bradcray , thanks!]

Testing:
- [x] [`brok`](https://github.com/smallhadroncollider/brok) finds no broken links except historical URLs we want to keep