### PR TITLE
dlopen: Make sure `--no-builtin-runtime` exits early without `CHPL_LIB_PIC=pic`

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -2129,6 +2129,20 @@ static void checkClientServerLibrary() {
   fLibraryCompile = true;
 }
 
+static void checkNoBuiltinRuntime() {
+  // Runtime is "builtin" to program, nothing to do.
+  if (fBuiltinRuntime) return;
+
+  // Otherwise, we need "CHPL_LIB_PIC=pic".
+  bool isPic = !strcmp(CHPL_LIB_PIC, "pic");
+  if (!isPic) {
+    USR_FATAL("The '--no-builtin-runtime' flag requires position-independent "
+              "code. Rebuild Chapel with 'CHPL_LIB_PIC=pic'");
+  }
+
+  // TODO: Make sure the dynamic library file actually exists?
+}
+
 static void setMaxCIdentLen() {
   bool gotPGI = !strcmp(CHPL_TARGET_COMPILER, "pgi")
              || !strcmp(CHPL_TARGET_COMPILER, "cray-prgenv-pgi");
@@ -2543,6 +2557,8 @@ static void postprocess_args() {
   postTaskTracking();
 
   checkClientServerLibrary();
+
+  checkNoBuiltinRuntime();
 
   checkMacOsxLinkStyle();
 

--- a/test/dynamic-loading/ErrorNoLibPic.chpl
+++ b/test/dynamic-loading/ErrorNoLibPic.chpl
@@ -1,0 +1,2 @@
+// Not an empty source file.
+;

--- a/test/dynamic-loading/ErrorNoLibPic.compopts
+++ b/test/dynamic-loading/ErrorNoLibPic.compopts
@@ -1,0 +1,1 @@
+--no-builtin-runtime

--- a/test/dynamic-loading/ErrorNoLibPic.good
+++ b/test/dynamic-loading/ErrorNoLibPic.good
@@ -1,0 +1,1 @@
+error: The '--no-builtin-runtime' flag requires position-independent code. Rebuild Chapel with 'CHPL_LIB_PIC=pic'

--- a/test/dynamic-loading/ErrorNoLibPic.skipif
+++ b/test/dynamic-loading/ErrorNoLibPic.skipif
@@ -1,0 +1,1 @@
+CHPL_LIB_PIC == pic


### PR DESCRIPTION
This PR adjusts the compiler to exit early if the `--no-builtin-runtime` flag is thrown but the Chapel installation is not built to generate position-independent code (via `CHPL_LIB_PIC=pic`). Prior to this PR, users would see an obscure linking error about not being able to find `-lchpl`.

FUTURE WORK

While this PR introduces an error message that is _certainly_ better than an obscure linker error, we could go a step further. The key observation here is that all `--no-builtin-runtime` really requires is for a `CHPL_LIB_PIC=pic` variant of the current Chapel installation to _exist_.

If such a PIC variant exists, then we can just link against the shared runtime built for the PIC variant, while keeping the rest of the variables in the current compilation session unchanged (e.g., we don't need to go so far as to implicitly set `--lib-pic=pic`, which would affect the code we're generating). This is in contrast to this PR, which requires you to set `CHPL_LIB_PIC=pic` which affects both the runtime used _and_ the Chapel code generated in the current session.

TESTING

- [x] `standard`

Reviewed by @bradcray. Thanks!