### PR TITLE
Add an annotation for when the Arkouda performance tests changed problem sizes

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2725,6 +2725,8 @@ arkouda: &arkouda-base
       config: chapcs
   02/10/26:
     - Add runtime warning on divide-by-zero (Bears-R-Us/arkouda#5315)
+  02/18/26:
+    - Change problem sizes for co-locale benchmarks (Bears-R-Us/arkouda#5022)
   02/19/26:
     - Fix performance regressions from divide-by-zero check (Bears-R-Us/arkouda#5416)
   04/19/26:


### PR DESCRIPTION
Engin updated the problem sizes for the Arkouda benchmarks to be per-node rather than per-locale, which changed the performance numbers we plot and return.  This adds an annotation for that change, as it caught me off-guard while reviewing performance changes for Chapel 2.9.
