### PR TITLE
Performance graph updates for release 2.9

### DIFF
--- a/util/pastPerformance/testReleasesPerformance
+++ b/util/pastPerformance/testReleasesPerformance
@@ -234,6 +234,10 @@ testReleasePerformance
 export CHPL_TEST_PERF_DATE="03/06/26"
 export CHPL_HOME=$chpl_release_home/chapel-2.8.0
 testReleasePerformance
+
+export CHPL_TEST_PERF_DATE="06/12/26"
+export CHPL_HOME=$chpl_release_home/chapel-2.9.0
+testReleasePerformance
 #
 # ADD NEW RELEASES HERE AS THEY ARE CREATED.
 #

--- a/util/test/perf/perfgraph.js
+++ b/util/test/perf/perfgraph.js
@@ -199,6 +199,10 @@ var branchInfo = [
                     "releaseDate": "2026-03-12",
                     "branchDate" : "2026-03-06",
                     "revision": -1},
+                  { "release": "2.9.0",
+                    "releaseDate": "2026-06-18",
+                    "branchDate" : "2026-06-12",
+                    "revision": -1},
                   ];
 
 var indexMap = {};


### PR DESCRIPTION
This adds performance graph data for the 2.9 release.

Corresponding previous update for 2.8: https://github.com/chapel-lang/chapel/pull/28507

To be merged on 2.9 release day, June 18.

[reviewed by @jabraham17 , thanks!]

Testing:
- [x] perf graphs viewed locally has line for release
- [x] used branch date (not release date) in `util/pastPerformance/testReleasesPerformance`
- [x] manually checked against last release's PR