### PR TITLE
Belatedly, add a mention of the lcm() procedure to the editions docs

### DIFF
--- a/doc/rst/technotes/editions.rst
+++ b/doc/rst/technotes/editions.rst
@@ -169,6 +169,9 @@ remain in the preview until they are deemed sufficiently complete.
   real`` values taken to ``param real`` or ``integral`` exponents and
   considered stable.
 
+- The `Math` module defines a new ``lcm()`` procedure that supports
+  computing least common multiples of integral values.
+
 - Default comparison operators on records (``==``, ``!=``, ``<``,
   ``<=``, ``>``, ``>=``) are defined as module code accepting two
   generic arguments of type ``record`` rather than being inserted by


### PR DESCRIPTION
Jade caught that I'd failed to list lcm() among other preview edition features for 2.9, so making up for that here.