### PR TITLE
Add note about visitOne with generic functions

### DIFF
--- a/modules/internal/ChapelUnion.chpl
+++ b/modules/internal/ChapelUnion.chpl
@@ -148,7 +148,7 @@ module ChapelUnion {
 
     The function should be generic and work with any of the field types in the
     union, or the code will not compile.
-    
+
     .. note::
 
        A generic first class function can currently only be defined as a functor

--- a/modules/internal/ChapelUnion.chpl
+++ b/modules/internal/ChapelUnion.chpl
@@ -148,6 +148,20 @@ module ChapelUnion {
 
     The function should be generic and work with any of the field types in the
     union, or the code will not compile.
+    
+    .. note::
+
+       A generic first class function can currently only be defined as a functor
+       (a callable object).
+
+       For example,
+
+       .. code-block:: chapel
+
+          record functor {
+            proc this(x) do writeln("the active field has type ", x.type:string);
+          }
+          myUnion.visitOne(new functor());
   */
   proc (union).visitOne(ref func) {
     import Reflection;

--- a/modules/internal/ChapelUnion.chpl
+++ b/modules/internal/ChapelUnion.chpl
@@ -146,22 +146,17 @@ module ChapelUnion {
     A version of :proc:`~ChapelUnion.union.visit` that takes a single function
     and calls it with the active field in the union.
 
-    The function should be generic and work with any of the field types in the
-    union, or the code will not compile.
+    The function should be a callable object (functor) and work with any of the
+    field types in the union, or the code will not compile.
 
-    .. note::
+    For example,
 
-       A generic first class function can currently only be defined as a functor
-       (a callable object).
+    .. code-block:: chapel
 
-       For example,
-
-       .. code-block:: chapel
-
-          record functor {
-            proc this(x) do writeln("the active field has type ", x.type:string);
-          }
-          myUnion.visitOne(new functor());
+       record functor {
+         proc this(x) do writeln("the active field has type ", x.type:string);
+       }
+       myUnion.visitOne(new functor());
   */
   proc (union).visitOne(ref func) {
     import Reflection;


### PR DESCRIPTION
Add a note about using visitOne with generic functions, since the only way to pass a generic function is with a functor.

[Reviewed by @bradcray]