### PR TITLE
Fix typo in `chpl_llvm.py` flag

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -1705,7 +1705,7 @@ def _main():
         default="",
     )
     parser.add_option(
-        "--llvm-vesion",
+        "--llvm-version",
         dest="action",
         action="store_const",
         const="llvmversion",


### PR DESCRIPTION
Fixes a typo in `chpl_llvm.py` flag to print the llvm version.

As far as I can tell, as of this PR the flag is unused in any infrastructure.

[Reviewed by @arifthpe]