### PR TITLE
Use smaller problem size for vectorization codegen test

### DIFF
--- a/test/llvm/vectorization/nested_loop.chpl
+++ b/test/llvm/vectorization/nested_loop.chpl
@@ -21,7 +21,5 @@ var D : [1..n,1..n] int(32);
 var E : [1..n,1..n,1..n] int(32);
 var F : [1..n,1..n,1..n] int(32);
 
-var z = [ i in 1..10] i;
-
 loop(A, B, C, D, E, F, n);
 writeln("Sum of A is ", + reduce A);

--- a/test/llvm/vectorization/nested_loop.chpl
+++ b/test/llvm/vectorization/nested_loop.chpl
@@ -1,5 +1,5 @@
 
-proc loop (A, B, C, D, E, F, n) {
+proc loop (ref A, const B, ref C, D, ref E, const F, n) {
   foreach i in 1..n {
     A[i] = 3*B[i];
     foreach j in 1..n {
@@ -12,14 +12,16 @@ proc loop (A, B, C, D, E, F, n) {
   }
 }
 
-config const n = 1000;
+config const n = 256;
 
- var A : [1..n] int(32);
- var B : [1..n] int(32);
- var C : [1..n,1..n] int(32);
- var D : [1..n,1..n] int(32);
- var E : [1..n,1..n,1..n] int(32);
- var F : [1..n,1..n,1..n] int(32);
+var A : [1..n] int(32);
+var B : [1..n] int(32);
+var C : [1..n,1..n] int(32);
+var D : [1..n,1..n] int(32);
+var E : [1..n,1..n,1..n] int(32);
+var F : [1..n,1..n,1..n] int(32);
+
+var z = [ i in 1..10] i;
 
 loop(A, B, C, D, E, F, n);
 writeln("Sum of A is ", + reduce A);


### PR DESCRIPTION
Switches a test to use a much smaller problem size.

This test is for checking we properly vectorize certain patterns, which is done statically based on the generated code (so the loop trip count really doesn't matter). The previous problem size was way too big (10+ gigs), and a new test machine with a smaller memory was timing out while running it.

I also fixed some other issues with the test I noticied

[Not reviewed - trivial]