### PR TITLE
Make debug tests more robust

### DIFF
--- a/test/llvm/debugInfo/lldb/functionCalls.chpl
+++ b/test/llvm/debugInfo/lldb/functionCalls.chpl
@@ -46,6 +46,9 @@ proc main() {
   breakpoint;
 }
 
+// CHECK: breakpoint set -n debuggerBreakHere -N debuggerBreakHere
+// CHECK-NEXT: Breakpoint [[#BREAKPOINT_START:]]
+
 // CHECK: b myFunc
 // CHECK-NEXT: functionCalls`myFunc
 // CHECK-SAME: functionCalls.chpl:2
@@ -79,28 +82,28 @@ proc main() {
 // CHECK-NEXT: functionCalls`getMyClass
 // CHECK-SAME: functionCalls.chpl:38
 
-// CHECK: stop reason = breakpoint 2
-// CHECK: stop reason = breakpoint 3
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+1]]
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+2]]
 // CHECK: p ret
 // CHECK: (int(64)) 6
 
-// CHECK: stop reason = breakpoint 4
-// CHECK: stop reason = breakpoint 5
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+3]]
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+4]]
 // CHECK: p ret
 // CHECK: (string) "Hello from getString!"
 
-// CHECK: stop reason = breakpoint 6
-// CHECK: stop reason = breakpoint 7
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+5]]
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+6]]
 // CHECK: p ret
 // CHECK: (functionCalls::myRec)  (a = 10, b = 3.14
 
-// CHECK: stop reason = breakpoint 8
-// CHECK: stop reason = breakpoint 9
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+7]]
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+8]]
 // CHECK: p ret
 // CHECK: (functionCalls::myRec2)  (a = 20, b = 2.71, c = true)
 
-// CHECK: stop reason = breakpoint 10
-// CHECK: stop reason = breakpoint 11
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+9]]
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+10]]
 // CHECK: p ret
 // CHECK: (owned MyClass) 0x{{[0-9a-f]+}} {
 // CHECK-NEXT: super

--- a/test/llvm/debugInfo/lldb/methodCallsClass.chpl
+++ b/test/llvm/debugInfo/lldb/methodCallsClass.chpl
@@ -28,6 +28,9 @@ proc main() {
   breakpoint;
 }
 
+// CHECK: breakpoint set -n debuggerBreakHere -N debuggerBreakHere
+// CHECK-NEXT: Breakpoint [[#BREAKPOINT_START:]]
+
 // CHECK: b methodCallsClass.chpl:8
 // CHECK-NEXT: methodCallsClass`toString
 // CHECK-SAME: methodCallsClass.chpl:8
@@ -38,12 +41,12 @@ proc main() {
 // CHECK-NEXT: methodCallsClass`setter
 // CHECK-SAME: methodCallsClass.chpl:15
 
-// CHECK: stop reason = breakpoint 3
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+2]]
 // CHECK: p this
 // CHECK-NEXT: (methodCallsClass::myClass *) 0x{{0*[0-9a-fA-F]+}}
 // CHECK: c
 
-// CHECK: stop reason = breakpoint 4
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+3]]
 // CHECK: p *this
 // CHECK-NEXT: (methodCallsClass::myClass) {
 // CHECK-NEXT: super = (cid =
@@ -52,20 +55,20 @@ proc main() {
 // CHECK-NEXT: }
 // CHECK: c
 
-// CHECK: stop reason = breakpoint 2
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+1]]
 // CHECK: p this->a
 // CHECK-NEXT: (int(64)) 10
 // CHECK: p ret
 // CHECK-NEXT: (string) "myClass(10, 2.71)"
 // CHECK: c
 
-// CHECK: stop reason = breakpoint 3
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+2]]
 // CHECK: c
 
-// CHECK: stop reason = breakpoint 4
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+3]]
 // CHECK: c
 
-// CHECK: stop reason = breakpoint 2
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+1]]
 // CHECK: frame var
 // CHECK-NEXT: (methodCallsClass::myClass *) this = 0x{{0*[0-9a-fA-F]+}}
 // CHECK-NEXT: (string) ret = "myClass(20, 0.577)"

--- a/test/llvm/debugInfo/lldb/methodCallsRec.chpl
+++ b/test/llvm/debugInfo/lldb/methodCallsRec.chpl
@@ -24,6 +24,9 @@ proc main() {
   breakpoint;
 }
 
+// CHECK: breakpoint set -n debuggerBreakHere -N debuggerBreakHere
+// CHECK-NEXT: Breakpoint [[#BREAKPOINT_START:]]
+
 // CHECK: b methodCallsRec.chpl:8
 // CHECK-NEXT: methodCallsRec`toString
 // CHECK-SAME: methodCallsRec.chpl:8
@@ -34,17 +37,17 @@ proc main() {
 // CHECK-NEXT: methodCallsRec`setter
 // CHECK-SAME: methodCallsRec.chpl:15
 
-// CHECK: stop reason = breakpoint 3
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+2]]
 // CHECK: p this
 // CHECK-NEXT: (_ref(myRec)) 0x{{0*[0-9a-fA-F]+}} (a = 10, b = 3.14
 // CHECK: c
 
-// CHECK: stop reason = breakpoint 4
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+3]]
 // CHECK: p *this
 // CHECK-NEXT: (methodCallsRec::myRec){{.*}}(a = 10, b = 3.14
 // CHECK: c
 
-// CHECK: stop reason = breakpoint 2
+// CHECK: stop reason = breakpoint [[#BREAKPOINT_START+1]]
 // CHECK: p this->a
 // CHECK-NEXT: (int(64)) 10
 // CHECK: p this.a

--- a/test/llvm/debugInfo/lldb/targetVar.chpl
+++ b/test/llvm/debugInfo/lldb/targetVar.chpl
@@ -1,10 +1,13 @@
+// CHECK: breakpoint set -n debuggerBreakHere -N debuggerBreakHere
+// CHECK-NEXT: Breakpoint [[#BREAKPOINT_START:]]
+
 const myGlobal = 42;
 
 proc foo(myFormal) {
   const localVar = myFormal + 1;
   writeln("printing from foo");
-  // CHECK: stop reason = breakpoint 2
-  // CHECK-NEXT: targetVar.chpl:5
+  // CHECK: stop reason = breakpoint [[#BREAKPOINT_START+1]]
+  // CHECK-NEXT: targetVar.chpl:8
   // CHECK: target var
   // CHECK: (int(64)) myGlobal_chpl = 42
   // CHECK: frame var
@@ -15,8 +18,8 @@ proc foo(myFormal) {
 }
 
 proc bar(myFormal) {
-  // CHECK: stop reason = breakpoint 3
-  // CHECK-NEXT: targetVar.chpl:17
+  // CHECK: stop reason = breakpoint [[#BREAKPOINT_START+2]]
+  // CHECK-NEXT: targetVar.chpl:20
   // CHECK: target var
   // CHECK: (int(64)) myGlobal_chpl = 42
   // CHECK: frame var

--- a/test/llvm/debugInfo/lldb/targetVarCommands.txt
+++ b/test/llvm/debugInfo/lldb/targetVarCommands.txt
@@ -1,4 +1,4 @@
-b targetVar.chpl:5
+b targetVar.chpl:8
 b bar
 r
 target var


### PR DESCRIPTION
Makes a few debug tests more robust to non-default initial state.

Prior to this PR, some of the FileCheck checks were dependent on the breakpoints for `debuggerBreakHere` being the first and only breakpoint set. This PR makes those checks more dynamic.

[Reviewed by @arifthpe]