### PR TITLE
Fix homebrew chapel-release.rb commits to reference that file

### DIFF
--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -65,7 +65,7 @@ jobs:
         git checkout -b update-chapel-homebrew-release-${{ env.HASH_SUBSTRING }}
         mv hb_master_chapel.rb util/packaging/homebrew/chapel-release.rb
         git add util/packaging/homebrew/chapel-release.rb
-        git commit -m "Update chapel-main.rb with changes from chapel.rb" --signoff
+        git commit -m "Update chapel-release.rb with changes from chapel.rb" --signoff
         git push --set-upstream origin update-chapel-homebrew-release-${{ env.HASH_SUBSTRING }}
         echo "Homebrew has updated the formula!"
 


### PR DESCRIPTION
The `monitor-homebrew` workflow checks for changes to [the live `chapel.rb` in homebrew-core](https://github.com/Homebrew/homebrew-core/blob/main/Formula/c/chapel.rb) and propagates them to our copy in `util/packaging/homebrew/chapel-release.rb`. However, the commit name it generates says it is updating `chapel-main.rb`; see for example [`54239de` (#28999)](https://github.com/chapel-lang/chapel/pull/28999/changes/54239dee2a795f8d2b1dd90e8a8b76b70e49a2a6). Fix this to say `chapel-release.rb` instead.

[reviewed by @jabraham17 , thanks!]