### PR TITLE
Add more testing of mason

### DIFF
--- a/util/cron/test-asan.bash
+++ b/util/cron/test-asan.bash
@@ -9,4 +9,4 @@ source $UTIL_CRON_DIR/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="asan"
 
-$UTIL_CRON_DIR/nightly -cron ${nightly_args} $(get_nightly_paratest_args 16)
+$UTIL_CRON_DIR/nightly -cron -mason ${nightly_args} $(get_nightly_paratest_args 16)

--- a/util/cron/test-c-backend.bash
+++ b/util/cron/test-c-backend.bash
@@ -12,6 +12,6 @@ nightly_args="${nightly_args} $(set +x ; get_nightly_paratest_args 8) -asserts"
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="c-backend"
 
-log_info START nightly -cron ${nightly_args}
-$UTIL_CRON_DIR/nightly -cron ${nightly_args}
+log_info START nightly -cron -mason ${nightly_args}
+$UTIL_CRON_DIR/nightly -cron -mason ${nightly_args}
 log_info nightly EXIT status $?

--- a/util/cron/test-darwin.bash
+++ b/util/cron/test-darwin.bash
@@ -9,4 +9,4 @@ source $UTIL_CRON_DIR/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="darwin"
 
-$UTIL_CRON_DIR/nightly -cron -blog $(get_nightly_paratest_args 4)
+$UTIL_CRON_DIR/nightly -cron -mason -blog $(get_nightly_paratest_args 4)

--- a/util/cron/test-ubsan.clang.bash
+++ b/util/cron/test-ubsan.clang.bash
@@ -11,4 +11,4 @@ source $UTIL_CRON_DIR/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="ubsan.clang"
 
-$UTIL_CRON_DIR/nightly -cron ${nightly_args} $(get_nightly_paratest_args 16)
+$UTIL_CRON_DIR/nightly -cron -mason ${nightly_args} $(get_nightly_paratest_args 16)

--- a/util/cron/test-ubsan.gnu.bash
+++ b/util/cron/test-ubsan.gnu.bash
@@ -11,4 +11,4 @@ source $UTIL_CRON_DIR/common-localnode-paratest.bash
 
 export CHPL_NIGHTLY_TEST_CONFIG_NAME="ubsan.gnu"
 
-$UTIL_CRON_DIR/nightly -cron ${nightly_args} $(get_nightly_paratest_args 16)
+$UTIL_CRON_DIR/nightly -cron -mason ${nightly_args} $(get_nightly_paratest_args 16)


### PR DESCRIPTION
Adds more testing of mason by building it in more test configs.

This is applied to a few configs that I think will add value and aren't dependent on start_test compopts like `--verify` (which the mason build system won't respect anyways)
* C backend testing
* darwin portability testing
* asan/ubsan testing

[Reviewed by @benharsh]