### PR TITLE
Add ArrayType/DomainType methods to chapel-py

### DIFF
--- a/frontend/include/chpl/types/DomainType.h
+++ b/frontend/include/chpl/types/DomainType.h
@@ -52,6 +52,7 @@ class DomainType final : public CompositeType {
      Subdomain,
      Unknown
    };
+   static const char* kindToString(Kind k);
 
  private:
   // TODO: distributions

--- a/frontend/lib/types/DomainType.cpp
+++ b/frontend/lib/types/DomainType.cpp
@@ -37,6 +37,18 @@ const ID DomainType::stridesId = ID(UniqueString(), 2, 0);
 const ID DomainType::parSafeId = ID(UniqueString(), 1, 0);
 const ID DomainType::parentDomainId = ID(UniqueString(), 0, 0);
 
+const char* DomainType::kindToString(Kind k) {
+  switch (k) {
+    case Kind::Rectangular: return "Rectangular";
+    case Kind::Associative: return "Associative";
+    case Kind::Sparse: return "Sparse";
+    case Kind::Subdomain: return "Subdomain";
+    case Kind::Unknown: return "Unknown";
+  }
+  CHPL_ASSERT(false && "all domain kinds should be handled");
+  return "";
+}
+
 const RuntimeType* DomainType::runtimeType(Context* context) const {
   // generic domains do not have a runtime type
   if (kind() == DomainType::Kind::Unknown) return nullptr;

--- a/tools/chapel-py/src/method-tables/type-methods.h
+++ b/tools/chapel-py/src/method-tables/type-methods.h
@@ -46,6 +46,38 @@ CLASS_BEGIN(CompositeType)
                return node->name())
 CLASS_END(CompositeType)
 
+CLASS_BEGIN(ArrayType)
+  PLAIN_GETTER(ArrayType, domain_type, "Get the domain type of this ArrayType",
+               Nilable<const chpl::types::DomainType*>,
+               auto ty = node->domainType().type();
+               if (!ty || !ty->isDomainType()) return {};
+               return ty->toDomainType())
+  PLAIN_GETTER(ArrayType, elt_type, "Get the element type of this ArrayType",
+               Nilable<const chpl::types::Type*>,
+               auto ty = node->eltType().type();
+               if (!ty) return {};
+               return ty)
+CLASS_END(ArrayType)
+
+CLASS_BEGIN(DomainType)
+ PLAIN_GETTER(DomainType, kind, "Get the kind of this DomainType (e.g. rectangular, associative, etc.)",
+              const char*,
+              return chpl::types::DomainType::kindToString(node->kind()))
+  PLAIN_GETTER(DomainType, rank, "Get the rank of this DomainType as an integer",
+               int,
+               return node->rankInt())
+  PLAIN_GETTER(DomainType, idx_type, "Get the index type of this DomainType",
+                Nilable<const chpl::types::Type*>,
+                auto ty = node->idxType().type();
+                if (!ty) return {};
+                return ty)
+  PLAIN_GETTER(DomainType, strides, "Get the param that represents the strides of this DomainType, if it exists",
+               Nilable<const chpl::types::Param*>,
+               auto ty = node->strides().param();
+               if (!ty) return {};
+               return ty)
+CLASS_END(DomainType)
+
 CLASS_BEGIN(EnumType)
   PLAIN_GETTER(EnumType, name, "Get name of this EnumType",
                chpl::UniqueString,


### PR DESCRIPTION
Adds new methods to access a subset of the fields/information stored in the ArrayType/DomainType frontend classes from chapel-py.

As of now, these are unused. I added them in a local experiment that didn't end up panning out, but wanted to check them in as they may be useful in the future

[Reviewed by @benharsh]