### PR TITLE
Make sure debugger test always quits

### DIFF
--- a/test/library/standard/Debugger/breakOnHaltCommands.txt
+++ b/test/library/standard/Debugger/breakOnHaltCommands.txt
@@ -1,2 +1,3 @@
+settings set auto-confirm true
 r
 quit


### PR DESCRIPTION
Fixes an issue where this debugger test could hang.

This was caused by the debugger waiting for confirmation on "quit" and fixed by always confirming commands

[Reviewed by @]