### PR TITLE
See whether `MAKE` is set after `CHPL_MAKE` and use it if so

### DIFF
--- a/util/chplenv/chpl_make.py
+++ b/util/chplenv/chpl_make.py
@@ -10,16 +10,18 @@ from utils import which, memoize
 def get():
     make_val = overrides.get("CHPL_MAKE")
     if not make_val:
-        platform_val = chpl_platform.get()
-        if platform_val.startswith("cygwin") or platform_val == "darwin":
-            make_val = "make"
-        elif platform_val.startswith("linux"):
-            if which("gmake"):
-                make_val = "gmake"
-            else:
+        make_val = overrides.get("MAKE")
+        if not make_val:
+            platform_val = chpl_platform.get()
+            if platform_val.startswith("cygwin") or platform_val == "darwin":
                 make_val = "make"
-        else:
-            make_val = "gmake"
+            elif platform_val.startswith("linux"):
+                if which("gmake"):
+                    make_val = "gmake"
+                else:
+                    make_val = "make"
+            else:
+                make_val = "gmake"
     return make_val
 
 


### PR DESCRIPTION
This follows up on a suggestion made by @bonachea to have `chpl_make.py` look for whether `MAKE` is set and to use that value if it is.  Here, I put it after `CHPL_MAKE` so that we use the most-Chapel-specific setting if there is one, and the setting set by the Makefile environment if not.  My assumption is that if `CHPL_MAKE` is set and we're invoking this script in a recursive context, it and `MAKE` will match at that point anyway; and if it's not, this should resolve the failure mode Dan saw in which his environment's `gmake` is older than the `make` that was used to invoke the build such that they could not share their internal state properly.

Dan also proposed changing the default for Linux to use `make` rather than `gmake`, but I didn't want to attempt that here, in part because I didn't want to mess with the historical logic on a weekend when it seems to have worked for so long, and in part because this approach seems like it may be "good enough."