### PR TITLE
Allow common inlays to show in more cases

### DIFF
--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -892,7 +892,7 @@ class ChapelLanguageServer(LanguageServer):
         # * If there's only one, we can't distinguish "common" from
         #   "just in this one". We still compute the common inlays in that case,
         #   because its still generally useful and confusing to not show them.
-        #   if more instatnations are added later, the inlays will be updated to
+        #   if more instantiations are added later, the inlays will be updated to
         #   either show or not show based on whether the new instantiation
         #   matches the existing one.
         insts = list(fi.context.instantiations(fn.unique_id()))
@@ -959,7 +959,7 @@ class ChapelLanguageServer(LanguageServer):
         # * If there's only one, we can't distinguish "common" from
         #   "just in this one". We still compute the common inlays in that case,
         #   because its still generally useful and confusing to not show them.
-        #   if more instatnations are added later, the inlays will be updated to
+        #   if more instantiations are added later, the inlays will be updated to
         #   either show or not show based on whether the new instantiation
         #   matches the existing one.
         insts = list(fi.context.instantiations(parent_fn.unique_id()))

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1628,6 +1628,9 @@ def run_lsp():
             if instantiation is not None:
                 continue
 
+            # TODO: common inlays do not work with "Show Instantiation (Default Rectangular)"
+            # TODO: common inlays should be extended to params as well as types
+            #       both for types of params and values of params
             # Get inalys gathered if all instantiations show the same hint.
             inlays.extend(ls.get_common_decl_inlays(decl, fi))
             inlays.extend(ls.get_common_fn_inlays(decl, fi))

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -890,6 +890,15 @@ class ChapelLanguageServer(LanguageServer):
         if len(insts) == 0:
             return []
 
+        # if there are instantiations and its a generic inlay, we should not show common inlays
+        if (
+            len(insts) >= 1
+            and len(existing_inlays) == 1
+            and existing_inlays[0].data
+            and existing_inlays[0].data.get("is_generic")
+        ):
+            return []
+
         type_strs = set()
         for i, _ in insts:
             # If any one of the instantiations is purely provided by
@@ -1622,18 +1631,20 @@ def run_lsp():
 
         for decl in decls:
             instantiation = fi.get_inst_segment_at_position(decl.rng.start)
-            inlays.extend(ls.get_decl_inlays(decl, instantiation))
-            inlays.extend(ls.get_fn_inlays(decl, fi, instantiation))
+            decl_inlays = ls.get_decl_inlays(decl, instantiation)
+            fn_inlays = ls.get_fn_inlays(decl, fi, instantiation)
+            inlays.extend(decl_inlays)
+            inlays.extend(fn_inlays)
 
             if instantiation is not None:
                 continue
 
-            # TODO: common inlays do not work with "Show Instantiation (Default Rectangular)"
             # TODO: common inlays should be extended to params as well as types
             #       both for types of params and values of params
-            # Get inalys gathered if all instantiations show the same hint.
-            inlays.extend(ls.get_common_decl_inlays(decl, fi))
-            inlays.extend(ls.get_common_fn_inlays(decl, fi))
+            common_decl_inlays = ls.get_common_decl_inlays(decl, fi)
+            common_fn_inlays = ls.get_common_fn_inlays(decl, fi, fn_inlays)
+            inlays.extend(common_decl_inlays)
+            inlays.extend(common_fn_inlays)
 
         for call in calls:
             call_range = location_to_range(call.location())

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -800,6 +800,7 @@ class ChapelLanguageServer(LanguageServer):
         self,
         fn: chapel.Function,
         type_str: str,
+        data: Optional[Any] = None,
     ) -> InlayHint:
         """
         Build the InlayHint for a function return type
@@ -829,6 +830,7 @@ class ChapelLanguageServer(LanguageServer):
                 InlayHintLabelPart(padding),
             ],
             text_edits=text_edits,
+            data=data,
         )
 
     def get_fn_inlays(
@@ -853,14 +855,20 @@ class ChapelLanguageServer(LanguageServer):
             return []
 
         type_str = self._fn_return_type_str(fn, sig)
+        is_generic = False
         if type_str is None and self.generic_return_type_inlays:
             type_str = self._try_generic_fn_return_type_str(
                 fn, fi.context.context
             )
+            is_generic = type_str is not None
         if type_str is None:
             return []
 
-        return [self._fn_inlay_from_type_str(fn, type_str)]
+        return [
+            self._fn_inlay_from_type_str(
+                fn, type_str, data={"is_generic": is_generic}
+            )
+        ]
 
     def get_common_fn_inlays(
         self,

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -881,9 +881,13 @@ class ChapelLanguageServer(LanguageServer):
 
         # * If there are no instantiations, nothing to show.
         # * If there's only one, we can't distinguish "common" from
-        #   "just in this one", so don't show anything.
+        #   "just in this one". We still compute the common inlays in that case,
+        #   because its still generally useful and confusing to not show them.
+        #   if more instatnations are added later, the inlays will be updated to
+        #   either show or not show based on whether the new instantiation
+        #   matches the existing one.
         insts = list(fi.context.instantiations(fn.unique_id()))
-        if len(insts) < 2:
+        if len(insts) == 0:
             return []
 
         type_strs = set()
@@ -935,9 +939,13 @@ class ChapelLanguageServer(LanguageServer):
 
         # * If there are no instantiations, nothing to show.
         # * If there's only one, we can't distinguish "common" from
-        #   "just in this one", so don't show anything.
+        #   "just in this one". We still compute the common inlays in that case,
+        #   because its still generally useful and confusing to not show them.
+        #   if more instatnations are added later, the inlays will be updated to
+        #   either show or not show based on whether the new instantiation
+        #   matches the existing one.
         insts = list(fi.context.instantiations(parent_fn.unique_id()))
-        if len(insts) < 2:
+        if len(insts) == 0:
             return inlays
 
         decl_qts = []

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -866,6 +866,7 @@ class ChapelLanguageServer(LanguageServer):
         self,
         decl: NodeAndRange,
         fi: FileInfo,
+        existing_inlays: List[InlayHint],
     ) -> List[InlayHint]:
 
         if (

--- a/tools/chpl-language-server/test/return_type_inlays.py
+++ b/tools/chpl-language-server/test/return_type_inlays.py
@@ -535,6 +535,7 @@ async def test_fn_type_inlay_type(client: LanguageClient):
         A=proc_file,
     )
 
+
 @pytest.mark.asyncio
 async def test_fn_type_inlay_header_variants(client: LanguageClient):
     """

--- a/tools/chpl-language-server/test/return_type_inlays.py
+++ b/tools/chpl-language-server/test/return_type_inlays.py
@@ -510,7 +510,7 @@ async def test_fn_type_inlay_per_instantiation(client: LanguageClient):
 
 
 @pytest.mark.asyncio
-async def test_fn_type_inlay_type(client: LanguageClient):
+async def test_fn_type_inlay_type_proc(client: LanguageClient):
     """
     For functions whose return type depends on the instantiation (i.e.,
     is not common), ensure that clicking a particular instantiation shows
@@ -524,9 +524,9 @@ async def test_fn_type_inlay_type(client: LanguageClient):
     # 3 lenses: "Show Generic" + 2 instantiations
     proc_lens = (pos((0, 5)), 3)
 
-    proc_generic_inlays: EXPECTED_INLAYS = [(pos((0, 19)), ": x", None)]
-    proc_int_inlays: EXPECTED_INLAYS = [(pos((0, 19)), ": int(64)", None)]
-    proc_real_inlays: EXPECTED_INLAYS = [(pos((0, 19)), ": real(64)", None)]
+    proc_generic_inlays: EXPECTED_INLAYS = [(pos((0, 29)), ": x", None)]
+    proc_int_inlays: EXPECTED_INLAYS = [(pos((0, 29)), ": int(64)", None)]
+    proc_real_inlays: EXPECTED_INLAYS = [(pos((0, 29)), ": real(64)", None)]
 
     await click_lenses_and_check_inlays(
         client,

--- a/tools/chpl-language-server/test/return_type_inlays.py
+++ b/tools/chpl-language-server/test/return_type_inlays.py
@@ -475,11 +475,11 @@ async def test_fn_type_inlay_per_instantiation(client: LanguageClient):
     iter_real_inlays: EXPECTED_INLAYS = [(pos((0, 13)), ": real(64)", None)]
 
     proc_generic_inlays_single: EXPECTED_INLAYS = [
-        (pos((0, 12)), ": string", None)
+        (pos((0, 12)), ": x.type", None)
     ]
     proc_str_inlays_single: EXPECTED_INLAYS = [(pos((0, 12)), ": string", None)]
     iter_generic_inlays_single: EXPECTED_INLAYS = [
-        (pos((0, 13)), ": string", None)
+        (pos((0, 13)), ": x.type", None)
     ]
     iter_str_inlays_single: EXPECTED_INLAYS = [(pos((0, 13)), ": string", None)]
 

--- a/tools/chpl-language-server/test/return_type_inlays.py
+++ b/tools/chpl-language-server/test/return_type_inlays.py
@@ -474,9 +474,13 @@ async def test_fn_type_inlay_per_instantiation(client: LanguageClient):
     iter_int_inlays: EXPECTED_INLAYS = [(pos((0, 13)), ": int(64)", None)]
     iter_real_inlays: EXPECTED_INLAYS = [(pos((0, 13)), ": real(64)", None)]
 
-    proc_generic_inlays_single: EXPECTED_INLAYS = [(pos((0, 12)), ": string", None)]
+    proc_generic_inlays_single: EXPECTED_INLAYS = [
+        (pos((0, 12)), ": string", None)
+    ]
     proc_str_inlays_single: EXPECTED_INLAYS = [(pos((0, 12)), ": string", None)]
-    iter_generic_inlays_single: EXPECTED_INLAYS = [(pos((0, 13)), ": string", None)]
+    iter_generic_inlays_single: EXPECTED_INLAYS = [
+        (pos((0, 13)), ": string", None)
+    ]
     iter_str_inlays_single: EXPECTED_INLAYS = [(pos((0, 13)), ": string", None)]
 
     await click_lenses_and_check_inlays(

--- a/tools/chpl-language-server/test/return_type_inlays.py
+++ b/tools/chpl-language-server/test/return_type_inlays.py
@@ -510,6 +510,32 @@ async def test_fn_type_inlay_per_instantiation(client: LanguageClient):
 
 
 @pytest.mark.asyncio
+async def test_fn_type_inlay_type(client: LanguageClient):
+    """
+    For functions whose return type depends on the instantiation (i.e.,
+    is not common), ensure that clicking a particular instantiation shows
+    an appropriate inlay for that instantiation.
+    """
+    proc_file = """
+            proc foo(type x, type z) type { return x; }
+            foo(int, string);
+            foo(real, string);
+           """
+    # 3 lenses: "Show Generic" + 2 instantiations
+    proc_lens = (pos((0, 5)), 3)
+
+    proc_generic_inlays: EXPECTED_INLAYS = [(pos((0, 19)), ": x", None)]
+    proc_int_inlays: EXPECTED_INLAYS = [(pos((0, 19)), ": int(64)", None)]
+    proc_real_inlays: EXPECTED_INLAYS = [(pos((0, 19)), ": real(64)", None)]
+
+    await click_lenses_and_check_inlays(
+        client,
+        proc_lens,
+        [proc_generic_inlays, proc_int_inlays, proc_real_inlays],
+        A=proc_file,
+    )
+
+@pytest.mark.asyncio
 async def test_fn_type_inlay_header_variants(client: LanguageClient):
     """
     More cases for return inlays: param intent, throws, where, and combinations.

--- a/tools/chpl-language-server/test/return_type_inlays.py
+++ b/tools/chpl-language-server/test/return_type_inlays.py
@@ -451,9 +451,20 @@ async def test_fn_type_inlay_per_instantiation(client: LanguageClient):
             for z in idk1I(10) do {}
             for z in idk1I(10.0) do {}
            """
+    proc_file_single = """
+            proc idk1(x) { return x; }
+            idk1("mystr");
+    """
+    iter_file_single = """
+            iter idk1I(x) { yield x; }
+            for z in idk1I("mystr") do {}
+    """
     # 3 lenses: "Show Generic" + 2 instantiations
     proc_lens = (pos((0, 5)), 3)
     iter_lens = (pos((0, 5)), 3)
+    # 2 lenses: "Show Generic" + 1 instantiation
+    proc_lens_single = (pos((0, 5)), 2)
+    iter_lens_single = (pos((0, 5)), 2)
 
     proc_generic_inlays: EXPECTED_INLAYS = [(pos((0, 12)), ": x.type", None)]
     proc_int_inlays: EXPECTED_INLAYS = [(pos((0, 12)), ": int(64)", None)]
@@ -462,6 +473,11 @@ async def test_fn_type_inlay_per_instantiation(client: LanguageClient):
     iter_generic_inlays: EXPECTED_INLAYS = [(pos((0, 13)), ": x.type", None)]
     iter_int_inlays: EXPECTED_INLAYS = [(pos((0, 13)), ": int(64)", None)]
     iter_real_inlays: EXPECTED_INLAYS = [(pos((0, 13)), ": real(64)", None)]
+
+    proc_generic_inlays_single: EXPECTED_INLAYS = [(pos((0, 12)), ": string", None)]
+    proc_str_inlays_single: EXPECTED_INLAYS = [(pos((0, 12)), ": string", None)]
+    iter_generic_inlays_single: EXPECTED_INLAYS = [(pos((0, 13)), ": string", None)]
+    iter_str_inlays_single: EXPECTED_INLAYS = [(pos((0, 13)), ": string", None)]
 
     await click_lenses_and_check_inlays(
         client,
@@ -474,6 +490,18 @@ async def test_fn_type_inlay_per_instantiation(client: LanguageClient):
         iter_lens,
         [iter_generic_inlays, iter_int_inlays, iter_real_inlays],
         A=iter_file,
+    )
+    await click_lenses_and_check_inlays(
+        client,
+        proc_lens_single,
+        [proc_generic_inlays_single, proc_str_inlays_single],
+        A=proc_file_single,
+    )
+    await click_lenses_and_check_inlays(
+        client,
+        iter_lens_single,
+        [iter_generic_inlays_single, iter_str_inlays_single],
+        A=iter_file_single,
     )
 
 

--- a/tools/chpl-language-server/test/show_generic.py
+++ b/tools/chpl-language-server/test/show_generic.py
@@ -442,7 +442,7 @@ async def test_lenses_default_rect_with_calls(client: LanguageClient):
         ),
         (pos((3, 17)), ": string", None),
     ]
-    generic_inlays = default_inlays 
+    generic_inlays = default_inlays
     all_inlays = [
         generic_inlays,
         default_inlays,

--- a/tools/chpl-language-server/test/show_generic.py
+++ b/tools/chpl-language-server/test/show_generic.py
@@ -431,7 +431,6 @@ async def test_lenses_default_rect_with_calls(client: LanguageClient):
 
     expected_lens = (pos((0, 5)), 2)
 
-    generic_inlays = []
     default_inlays = [
         (pos((1, 12)), "param value is 1", None),
         (pos((1, 12)), ": int(64)", None),
@@ -443,6 +442,7 @@ async def test_lenses_default_rect_with_calls(client: LanguageClient):
         ),
         (pos((3, 17)), ": string", None),
     ]
+    generic_inlays = default_inlays 
     all_inlays = [
         generic_inlays,
         default_inlays,

--- a/tools/chpl-language-server/test/type_inlays.py
+++ b/tools/chpl-language-server/test/type_inlays.py
@@ -549,6 +549,36 @@ async def test_common_inlays(client: LanguageClient):
 
 
 @pytest.mark.asyncio
+async def test_common_inlays_single_instantiation(client: LanguageClient):
+    """
+    Ensure that type inlays are shown properly for type variables
+    """
+
+    file = """
+            proc foo(x) {
+              var y = x;
+              var z = (x, x);
+              var xStr = x : string;
+              var zStr = z : (string, string);
+            }
+            foo(42);
+           """
+
+    inlays = [
+        (pos((0, 10)), "int(64)"),
+        (pos((1, 7)), "int(64)"),
+        (pos((2, 7)), "(int(64), int(64))"),
+        (pos((3, 10)), "string"),
+        (pos((4, 10)), "(string, string)"),
+    ]
+    async with source_file(client, file) as doc:
+        await check_type_inlay_hints(
+            client, doc, rng((0, 0), endpos(file)), inlays
+        )
+
+
+
+@pytest.mark.asyncio
 async def test_common_inlays_crossfile(client: LanguageClient):
     """
     Ensure that type inlays are shown properly for type variables

--- a/tools/chpl-language-server/test/type_inlays.py
+++ b/tools/chpl-language-server/test/type_inlays.py
@@ -578,7 +578,6 @@ async def test_common_inlays_single_instantiation(client: LanguageClient):
         )
 
 
-
 @pytest.mark.asyncio
 async def test_common_inlays_crossfile(client: LanguageClient):
     """

--- a/tools/chpl-language-server/test/type_inlays.py
+++ b/tools/chpl-language-server/test/type_inlays.py
@@ -514,10 +514,11 @@ async def test_type_inlay_type_variable(client: LanguageClient):
             type t = bar(int);
            """
 
-    y_inlay = (pos((1, 6)), "int(64)")
+    formal_inlay = (pos((0, 15)), "int(64)")
+    var_inlay = (pos((1, 6)), "int(64)")
     async with source_file(client, file) as doc:
         await check_type_inlay_hints(
-            client, doc, rng((0, 0), endpos(file)), [y_inlay]
+            client, doc, rng((0, 0), endpos(file)), [formal_inlay, var_inlay]
         )
 
 


### PR DESCRIPTION
Allows common inlays to show in more cases.

Previously, if a function had only 1 instantiation common inlays would be supressed. This PR removes that, since it can be confusing ("why does my variable that is definitely always an `int` not show as an `int`?") and just generally useful.

Resolves https://github.com/chapel-lang/chapel/issues/28992

[Reviewed by @arifthpe]