### PR TITLE
Unpin llvm in vagrant testing

### DIFF
--- a/util/devel/test/portability/provision-scripts/apt-get-and-linuxbrew.sh
+++ b/util/devel/test/portability/provision-scripts/apt-get-and-linuxbrew.sh
@@ -26,8 +26,7 @@ brew install gcc #hide
 
 # install some dependencies in homebrew
 brew install cmake python gmp #unsudo
-# Pin LLVM 21 since we don't support the latest LLVM yet
-brew install llvm@21 #unsudo
+brew install llvm #unsudo
 
 # we could use Homebrew's gcc if that becomes important in the future:
 # # link the homebrew-installed gcc-* to gcc


### PR DESCRIPTION
Unpin LLVM 21 from vagrant testing, since we now support the default

[Not reviewed - trivial]