### PR TITLE
Fix 3 potential bugs caught by sanitizers in the compiler

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -2231,7 +2231,8 @@ static void codegen_header(std::set<const char*> & cnames,
     current.move(next);
     current.set_to_vec();
 
-    qsort(current.v, current.n, sizeof(current.v[0]), compareSymbol2);
+    if (current.n)
+      qsort(current.v, current.n, sizeof(current.v[0]), compareSymbol2);
 
     next.clear();
   }

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -601,12 +601,11 @@ bool ErrorHandlingVisitor::enterForallStmt(ForallStmt* node) {
   return true;
 }
 
-void ErrorHandlingVisitor::exitForallLoop(Stmt* node)
-{
+void ErrorHandlingVisitor::exitForallLoop(Stmt* node) {
   if (tryStack.empty())
     return;
 
-  TryInfo& info = tryStack.top();
+  TryInfo info = tryStack.top();
   if (info.throwingForall == NULL)
     return;
   else if (info.throwingForall != node)

--- a/compiler/passes/scopeResolve.cpp
+++ b/compiler/passes/scopeResolve.cpp
@@ -770,7 +770,7 @@ static void processImportExprs() {
               ResolveScope* last = scopes.top();
               BlockStmt* lastAst = last->asBlockStmt();
               BlockStmt* curBlock = scope->asBlockStmt();
-              if (curBlock != NULL) {
+              if (curBlock && lastAst) {
                 if (lastAst->contains(curBlock)) {
                   scopes.push(scope);
                 } else {


### PR DESCRIPTION
Fixes three potential bugs I found in the compiler. This could all be triggered by `make check` but we seem to have never had an issue. However, the sanitizer flagged these and they all seemed like true bugs.


* fixed passing a nullptr to qsort
* fixed using a reference after its no longer valid
* fixed calling a method on a null pointer

- [x] paratest

[Reviewed by @dlongnecke-cray]