### PR TITLE
Ensure CHPL_MAKE is always set appropriately within a Chapel build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@
 #
 MAKEFLAGS = --no-print-directory
 
+# issue #29014: Ensure nested make invocations use a compatible make:
+export CHPL_MAKE := $(MAKE)
 export CHPL_MAKE_HOME=$(shell pwd)
 export CHPL_MAKE_PYTHON := $(shell $(CHPL_MAKE_HOME)/util/config/find-python.sh)
 

--- a/make/Makefile.base
+++ b/make/Makefile.base
@@ -28,6 +28,8 @@ include $(CHPL_MAKE_HOME)/make/Makefile.isTrue
 
 MAKEFLAGS = --no-print-directory
 
+# issue #29014: Ensure nested make invocations use a compatible make:
+export CHPL_MAKE := $(MAKE)
 
 #
 # Don't let CONFIG_SITE mess up our third-party/ builds.


### PR DESCRIPTION
Once the top-level GNU Make has been invoked in a Chapel build tree, there is no longer any "choice" about which GNU Make to use; any sub-make invocations *must* match that top-level invocation of Make.

This avoids problems where nested Make invocations from inside a subshell (e.g. a Python script) might otherwise find and invoke an incompatible version of GNU Make, leading to fatal Make internal errors in parallel builds.

Fixes #29014