### PR TITLE
Avoid zero length vla in comm interface

### DIFF
--- a/runtime/include/chpl-comm-strd-xfer.h
+++ b/runtime/include/chpl-comm-strd-xfer.h
@@ -142,6 +142,9 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
                      size_t maxOutstandingXfers, void (yieldFn)(void),
                      int32_t commID, int ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
+  // allocate arrays with at least 1 element to avoid zero-length arrays
+  // if strlvls is 0, these arrays will not be used
+  const size_t strlvls_nz = strlvls > 0 ? strlvls : 1;
   size_t i,j,k,t,total,off,x,carry;
 
   int8_t* dstaddr,*dstaddr1;
@@ -149,10 +152,8 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
 
   int *srcdisp, *dstdisp;
 
-  // allocate arrays with at least 1 element to avoid zero-length arrays
-  // if strlvls is 0, these arrays will not be used
-  size_t dststr[strlvls > 0 ? strlvls : 1];
-  size_t srcstr[strlvls > 0 ? strlvls : 1];
+  size_t dststr[strlvls_nz];
+  size_t srcstr[strlvls_nz];
   size_t cnt[strlvls+1];
 
   chpl_comm_nb_handle_t handles[maxOutstandingXfers];
@@ -290,16 +291,17 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
                      size_t maxOutstandingXfers, void (yieldFn)(void),
                      int32_t commID, int ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
+  // allocate arrays with at least 1 element to avoid zero-length arrays
+  // if strlvls is 0, these arrays will not be used
+  const size_t strlvls_nz = strlvls > 0 ? strlvls : 1;
   size_t i,j,k,t,total,off,x,carry;
 
   int8_t* dstaddr,*dstaddr1;
   int8_t* srcaddr,*srcaddr1;
 
   int *srcdisp, *dstdisp;
-  // allocate arrays with at least 1 element to avoid zero-length arrays
-  // if strlvls is 0, these arrays will not be used
-  size_t dststr[strlvls > 0 ? strlvls : 1];
-  size_t srcstr[strlvls > 0 ? strlvls : 1];
+  size_t dststr[strlvls_nz];
+  size_t srcstr[strlvls_nz];
   size_t cnt[strlvls+1];
 
   chpl_comm_nb_handle_t handles[maxOutstandingXfers];
@@ -447,16 +449,17 @@ void strd_common_call(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
                                       /* ln */ int, /* fn */ int32_t),
                       int32_t commID, int ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
+  // allocate arrays with at least 1 element to avoid zero-length arrays
+  // if strlvls is 0, these arrays will not be used
+  const size_t strlvls_nz = strlvls > 0 ? strlvls : 1;
   size_t i,j,k,t,total,off,x,carry;
 
   int8_t* dstaddr,*dstaddr1;
   int8_t* srcaddr,*srcaddr1;
 
   int *srcdisp, *dstdisp;
-  // allocate arrays with at least 1 element to avoid zero-length arrays
-  // if strlvls is 0, these arrays will not be used
-  size_t dststr[strlvls > 0 ? strlvls : 1];
-  size_t srcstr[strlvls > 0 ? strlvls : 1];
+  size_t dststr[strlvls_nz];
+  size_t srcstr[strlvls_nz];
   size_t cnt[strlvls+1];
 
   //Only count[0] and strides are measured in number of bytes.

--- a/runtime/include/chpl-comm-strd-xfer.h
+++ b/runtime/include/chpl-comm-strd-xfer.h
@@ -149,8 +149,10 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
 
   int *srcdisp, *dstdisp;
 
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
+  // allocate arrays with at least 1 element to avoid zero-length arrays
+  // if strlvls is 0, these arrays will not be used
+  size_t dststr[strlvls > 0 ? strlvls : 1];
+  size_t srcstr[strlvls > 0 ? strlvls : 1];
   size_t cnt[strlvls+1];
 
   chpl_comm_nb_handle_t handles[maxOutstandingXfers];
@@ -294,8 +296,10 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
   int8_t* srcaddr,*srcaddr1;
 
   int *srcdisp, *dstdisp;
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
+  // allocate arrays with at least 1 element to avoid zero-length arrays
+  // if strlvls is 0, these arrays will not be used
+  size_t dststr[strlvls > 0 ? strlvls : 1];
+  size_t srcstr[strlvls > 0 ? strlvls : 1];
   size_t cnt[strlvls+1];
 
   chpl_comm_nb_handle_t handles[maxOutstandingXfers];
@@ -449,8 +453,10 @@ void strd_common_call(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
   int8_t* srcaddr,*srcaddr1;
 
   int *srcdisp, *dstdisp;
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
+  // allocate arrays with at least 1 element to avoid zero-length arrays
+  // if strlvls is 0, these arrays will not be used
+  size_t dststr[strlvls > 0 ? strlvls : 1];
+  size_t srcstr[strlvls > 0 ? strlvls : 1];
   size_t cnt[strlvls+1];
 
   //Only count[0] and strides are measured in number of bytes.

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -1037,6 +1037,9 @@ void chpl_gpu_comm_get_strd(c_sublocid_t dst_subloc,
   // Note: This function differs from the original in chpl-comm-strd-xfer.h by
   // not supporting non-blocking communication calls.
   const size_t strlvls=(size_t)stridelevels;
+  // allocate arrays with at least 1 element to avoid zero-length arrays
+  // if strlvls is 0, these arrays will not be used
+  const size_t strlvls_nz = strlvls > 0 ? strlvls : 1;
   size_t i,j,k,t,total,off,x,carry;
 
   int8_t* dstaddr,*dstaddr1;
@@ -1045,8 +1048,8 @@ void chpl_gpu_comm_get_strd(c_sublocid_t dst_subloc,
   int *srcdisp, *dstdisp;
   // allocate arrays with at least 1 element to avoid zero-length arrays
   // if strlvls is 0, these arrays will not be used
-  size_t dststr[strlvls > 0 ? strlvls : 1];
-  size_t srcstr[strlvls > 0 ? strlvls : 1];
+  size_t dststr[strlvls_nz];
+  size_t srcstr[strlvls_nz];
   size_t cnt[strlvls+1];
 
 
@@ -1174,6 +1177,9 @@ void chpl_gpu_comm_put_strd(c_sublocid_t src_subloc,
   // Note: This function differs from the original in chpl-comm-strd-xfer.h by
   // not supporting non-blocking communication calls.
   const size_t strlvls=(size_t)stridelevels;
+  // allocate arrays with at least 1 element to avoid zero-length arrays
+  // if strlvls is 0, these arrays will not be used
+  const size_t strlvls_nz = strlvls > 0 ? strlvls : 1;
   size_t i,j,k,t,total,off,x,carry;
 
   int8_t* dstaddr,*dstaddr1;
@@ -1182,8 +1188,8 @@ void chpl_gpu_comm_put_strd(c_sublocid_t src_subloc,
   int *srcdisp, *dstdisp;
   // allocate arrays with at least 1 element to avoid zero-length arrays
   // if strlvls is 0, these arrays will not be used
-  size_t dststr[strlvls > 0 ? strlvls : 1];
-  size_t srcstr[strlvls > 0 ? strlvls : 1];
+  size_t dststr[strlvls_nz];
+  size_t srcstr[strlvls_nz];
   size_t cnt[strlvls+1];
 
 

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -1043,8 +1043,10 @@ void chpl_gpu_comm_get_strd(c_sublocid_t dst_subloc,
   int8_t* srcaddr,*srcaddr1;
 
   int *srcdisp, *dstdisp;
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
+  // allocate arrays with at least 1 element to avoid zero-length arrays
+  // if strlvls is 0, these arrays will not be used
+  size_t dststr[strlvls > 0 ? strlvls : 1];
+  size_t srcstr[strlvls > 0 ? strlvls : 1];
   size_t cnt[strlvls+1];
 
 
@@ -1178,8 +1180,10 @@ void chpl_gpu_comm_put_strd(c_sublocid_t src_subloc,
   int8_t* srcaddr,*srcaddr1;
 
   int *srcdisp, *dstdisp;
-  size_t dststr[strlvls];
-  size_t srcstr[strlvls];
+  // allocate arrays with at least 1 element to avoid zero-length arrays
+  // if strlvls is 0, these arrays will not be used
+  size_t dststr[strlvls > 0 ? strlvls : 1];
+  size_t srcstr[strlvls > 0 ? strlvls : 1];
   size_t cnt[strlvls+1];
 
 

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -1580,7 +1580,7 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
   const size_t strlvls = (size_t)stridelevels;
   // Avoid 0-length VLA when stridelevels is 0 (contiguous transfer), gasnet
   // will ignore arrays in this case
-  const size_t strlvls_nz = strlvls == 0 ? 1 : strlvls;
+  const size_t strlvls_nz = strlvls > 0 ? strlvls : 1;
   const gasnet_node_t srcnode = (gasnet_node_t)srcnode_id;
 
   ptrdiff_t dststr[strlvls_nz];
@@ -1623,7 +1623,7 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
   const size_t strlvls = (size_t)stridelevels;
   // Avoid 0-length VLA when stridelevels is 0 (contiguous transfer), gasnet
   // will ignore arrays in this case
-  const size_t strlvls_nz = strlvls == 0 ? 1 : strlvls;
+  const size_t strlvls_nz = strlvls > 0 ? strlvls : 1;
   const gasnet_node_t dstnode = (gasnet_node_t)dstnode_id;
 
   ptrdiff_t dststr[strlvls_nz];


### PR DESCRIPTION
Avoids using zero length vla in the comm interface.

This got flagged in our new ubsan testing.
```
> ../../../include/chpl-comm-strd-xfer.h:297:10: runtime error: variable length array bound evaluates to non-positive value 0
> ../../../include/chpl-comm-strd-xfer.h:298:10: runtime error: variable length array bound evaluates to non-positive value 0
```

The simple fix is to always allocate a non-zero length vla, which will be unused but avoids the undefined behavior.

Note: after fixing this I found this old PR that did something similar. This PR subsumes that and closes https://github.com/chapel-lang/chapel/pull/23851/

[Reviewed by @benharsh]