### PR TITLE
Make sure asan is not used with llvm 15

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2524,6 +2524,8 @@ static PassBuilder constructPassBuilder(
 }
 
 
+// asan only supported in Chapel in LLVM 16+
+#if LLVM_VERSION_MAJOR >= 16
 //
 // Copied from clang/lib/CodeGen/BackendUtil.cpp
 // It's probably not really relevant to Chapel since we don't do GC, but this
@@ -2554,6 +2556,7 @@ static bool asanUseGlobalsGC(const Triple &T, const CodeGenOptions &CGOpts) {
   }
   return false;
 }
+#endif
 
 
 static void runModuleOptPipeline(bool addWideOpts) {
@@ -2610,6 +2613,8 @@ static void runModuleOptPipeline(bool addWideOpts) {
     MPM = PB.buildPerModuleDefaultPipeline(optLvl);
   }
 
+  // asan only supported in Chapel in LLVM 16+
+#if LLVM_VERSION_MAJOR >= 16
   if (strcmp(envMap["CHPL_SANITIZE_EXE"], "address") == 0) {
 
     // if `--no-llvm-wide-opt` add asan
@@ -2642,6 +2647,7 @@ static void runModuleOptPipeline(bool addWideOpts) {
       PB.registerOptimizerLastEPCallback(AsanCallback);
     }
   }
+#endif
 
   // Add the Global to Wide optimization if necessary.
   // This is done in this way to be added even with -O0


### PR DESCRIPTION
Fixes an issue introduced by https://github.com/chapel-lang/chapel/pull/28995 where we could no longer build with LLVM 15. This was due to trying to use an asan pass that did not exist in LLVM 15. We already didn't support asan with llvm 15, so this is not a new change, just a fix to the regression.

Note: Not sure how this slipped past my build with LLVM 15, but nightly caught it.

[Reviewed by @arifthpe]