### PR TITLE
Disable function pointer type mismatch ubsan checking

### DIFF
--- a/make/compiler/Makefile.sanitizers
+++ b/make/compiler/Makefile.sanitizers
@@ -38,6 +38,20 @@ ifneq ($(CHPL_MAKE_SANITIZE), none)
   SANITIZER_CFLAGS += -fsanitize=$(CHPL_MAKE_SANITIZE)
   SANITIZER_LDFLAGS += -fsanitize=$(CHPL_MAKE_SANITIZE)
 
+  # Chapel relies heavily on function calls through function pointers of the wrong type
+  # (e.g., we reinterpret 'void (*)(void *)' for almost all indirect calls)
+  # this is actually undefined behavior, but it hasn't caused a problem so far
+  # and so its probably not worth fixing. However, the undefined behavior
+  # sanitizer will complain about it, so we disable it. GCC doesn't seem to
+  # flag for this (or have a 'function' option), but clang does, so we disable
+  # it for clang only.
+  ifeq ($(CHPL_MAKE_SANITIZE), undefined)
+  ifeq ($(CHPL_MAKE_CC), clang)
+  SANITIZER_CFLAGS += -fno-sanitize=function
+  SANITIZER_LDFLAGS += -fno-sanitize=function
+  endif
+  endif
+
   # If debugging with optimizations, lower optimization level and enable
   # frame pointers for better stack traces
   ifeq ($(DEBUG), 1)


### PR DESCRIPTION
Disables checking for function pointer type mismatch when doing undefined behavior checking with clang, since this is something Chapel relies on heavily.

For example, here is the output from the sanitizer firing on hello world
```
chpl-init.c:414:3: runtime error: call to function deinit_chpl15 through pointer to incorrect function type 'void (*)(void)'
Hello, world! (from locale 0 of 1)
(/hpcdc/data/users/chapelu/.chpl/chapel-test-oyigfV/hello6-taskpar-dist+0x350ea8): note: chpl_executable_init defined here
_main.c: note: chpl__auto_destroy_DefaultRectangularArr2 defined here
_main.c: note: chpl__auto_destroy_DefaultRectangularDom defined here
_main.c: note: decEltCountsIfNeeded_chpl4 defined here
_main.c: note: deinit_chpl15 defined here
_main.c: note: deinit_chpl25 defined here
_main.c: note: dsiDestroyArr_chpl3 defined here
_main.c: note: dsiGetBaseDom_chpl4 defined here
_main.c: note: dsiLinksDistribution_chpl2 defined here
_main.c: note: dsiLinksDistribution_chpl2 defined here
_main.c: note: dsiMyDist_chpl2 defined here
_main.c: note: dsiMyDist_chpl2 defined here
_main.c: note: dsiTrackDomains_chpl2 defined here
_main.c: note: _getChildCount_chpl3 defined here
_main.c: note: localeIDtoLocale_chpl2 defined here
_main.c: note: wrapcoforall_fn_hello6_HYPHEN_taskpar_HYPHEN_dist_line_35_chpl defined here
/ptmp/jenkins/chapel-ci/workspace/chapcs-correctness-test-ubsan.clang/runtime/include/chpl-gen-includes.h:51:3: runtime error: call to function wrapcoforall_fn_hello6_HYPHEN_taskpar_HYPHEN_dist_line_35_chpl through pointer to incorrect function type 'void (*)(void *)'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior chpl-init.c:414:3 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /ptmp/jenkins/chapel-ci/workspace/chapcs-correctness-test-ubsan.clang/runtime/include/chpl-gen-includes.h:51:3 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior tasks-qthreads.c:884:5 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelBase.c:2551:1 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelBase.c:2612:1 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelBase.c:2625:1 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:329:18 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:333:18 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:335:18 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:342:13 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:405:19 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:606:18 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:919:1 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:925:1 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelLocale.c:683:18 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /tmp/chpl-chapelu.deleteme-RnOm8q/ChapelLocale.c:865:1 
tasks-qthreads.c:884:5: runtime error: call to function chpl_executable_init through pointer to incorrect function type 'void (*)(void *)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelBase.c:2551:1: runtime error: call to function deinit_chpl25 through pointer to incorrect function type 'void (*)(struct chpl_BaseLocale_chpl_s *, long, int)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelBase.c:2612:1: runtime error: call to function chpl__auto_destroy_DefaultRectangularArr2 through pointer to incorrect function type 'void (*)(struct chpl_BaseArr_chpl_s *, long, int)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelBase.c:2625:1: runtime error: call to function chpl__auto_destroy_DefaultRectangularDom through pointer to incorrect function type 'void (*)(struct chpl_BaseDom_chpl_s *, long, int)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:329:18: runtime error: call to function dsiMyDist_chpl2 through pointer to incorrect function type 'struct chpl_BaseDist_chpl_s *(*)(struct chpl_BaseDom_chpl_s *, long, int)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:333:18: runtime error: call to function dsiTrackDomains_chpl2 through pointer to incorrect function type 'bool (*)(struct chpl_BaseDist_chpl_s *)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:335:18: runtime error: call to function dsiLinksDistribution_chpl2 through pointer to incorrect function type 'bool (*)(struct chpl_BaseDom_chpl_s *)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:342:13: runtime error: call to function dsiMyDist_chpl2 through pointer to incorrect function type 'struct chpl_BaseDist_chpl_s *(*)(struct chpl_BaseDom_chpl_s *, long, int)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:405:19: runtime error: call to function dsiLinksDistribution_chpl2 through pointer to incorrect function type 'bool (*)(struct chpl_BaseDom_chpl_s *)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:606:18: runtime error: call to function dsiGetBaseDom_chpl4 through pointer to incorrect function type 'struct chpl_BaseDom_chpl_s *(*)(struct chpl_BaseArr_chpl_s *, long, int)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:919:1: runtime error: call to function dsiDestroyArr_chpl3 through pointer to incorrect function type 'void (*)(struct chpl_BaseArr_chpl_s *, bool, long, int)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelDistribution.c:925:1: runtime error: call to function decEltCountsIfNeeded_chpl4 through pointer to incorrect function type 'void (*)(struct chpl_BaseArr_chpl_s *, long, int)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelLocale.c:683:18: runtime error: call to function _getChildCount_chpl3 through pointer to incorrect function type 'long (*)(struct chpl_BaseLocale_chpl_s *, long, int)'
/tmp/chpl-chapelu.deleteme-RnOm8q/ChapelLocale.c:865:1: runtime error: call to function localeIDtoLocale_chpl2 through pointer to incorrect function type 'void (*)(struct chpl_AbstractRootLocale_chpl_s *, chpl_localeID_t *, struct chpl_locale_chpl_s *, long, int)'
```

[Reviewed by @arifthpe]