### PR TITLE
Adjust mentions of 'chpl_preUserCodeHook' -> 'chpl_preUserCodeSync'

### DIFF
--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -1931,7 +1931,7 @@ void TConverter::createMainFunctions() {
     chpl_gen_main->insertAtTail(new CallExpr(PRIM_SET_DYNAMIC_END_COUNT, endCount));
   }
 
-  chpl_gen_main->insertAtTail(new CallExpr("chpl_rt_preUserCodeHook"));
+  chpl_gen_main->insertAtTail(new CallExpr("chpl_preUserCodeSync"));
 
   // We have to initialize the main module explicitly.
   // It will initialize all the modules it uses, recursively.

--- a/modules/internal/ChapelProgramEntrypoints.chpl
+++ b/modules/internal/ChapelProgramEntrypoints.chpl
@@ -128,7 +128,7 @@ module ChapelProgramEntrypoints {
     chpl_task_callMain(p2);
 
     // @dlongnecke-cray, 11/16/2020
-    // TODO: Call chpl_rt_preUserCodeHook() here for Locale[0]?
+    // TODO: Call chpl_preUserCodeSync() here for Locale[0]?
     initTaskDynamicEndCount();
 
     // Now that module initialization is done, set the flag to 'true'.


### PR DESCRIPTION
Adjust two mentions of the old symbol `chpl_preUserCodeHook` to point to the new one `chpl_preUserCodeSync`. I didn't catch these because they were in commented out code and a comment.