### PR TITLE
Explicitly preserve Chapel globals with AMD codegen

### DIFF
--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -4480,7 +4480,7 @@ static void linkGpuDeviceLibraries() {
     if (g.hasExternalLinkage()) {
       externals.insert(g.getGUID());
       // keep track of Chapel-emitted external globals like `chpl_nodeID`
-      // that might not have debice-size uses.
+      // that might not have device-side uses.
       // We need to explicitly preserve them
       if (!g.isDeclaration()) {
         preservedGlobals.push_back(&g);

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -91,6 +91,7 @@
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #endif
 #include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
 
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Passes/OptimizationLevel.h"
@@ -4474,9 +4475,16 @@ static void linkGpuDeviceLibraries() {
       externals.insert(f.getGUID());
     }
   }
-  for (const auto& g: info->module->globals()) {
+  std::vector<llvm::GlobalValue*> preservedGlobals;
+  for (auto& g: info->module->globals()) {
     if (g.hasExternalLinkage()) {
       externals.insert(g.getGUID());
+      // keep track of Chapel-emitted external globals like `chpl_nodeID`
+      // that might not have debice-size uses.
+      // We need to explicitly preserve them
+      if (!g.isDeclaration()) {
+        preservedGlobals.push_back(&g);
+      }
     }
   }
 
@@ -4517,6 +4525,10 @@ static void linkGpuDeviceLibraries() {
     return externals.count(gv.getGUID()) > 0;
   });
   iPass.internalizeModule(*info->module);
+
+  if (!preservedGlobals.empty()) {
+    llvm::appendToCompilerUsed(*info->module, preservedGlobals);
+  }
 }
 
 // If we're using the LLVM wide optimizations, we have to add


### PR DESCRIPTION
Fixes issues with GPU programs built with `--fast` (specifically --optimize) which could result in strange runtime erros about missing symbols (or just crashes).

For example, `radixSortGpu` crashed with

```
internal error: gpu-amd-cub.cc:106: Error calling HIP function:
named symbol not found (Code: 500)
```

The crash location varied (a CUB sort was just one symptom) and could appear at
any `ROCM_CALL`, which obscured the real cause. The same programs worked without
`--optimize`.

The root cause was the LLVM internalize pass internalizing (and thus removing Chapel-specific device global variables (`chpl_nodeID`, `chpl_haltFlag`, `chpl_privateObjects`, `chpl_globals_registry`, etc.) that have no device-side
uses. Because they were unused (and subsequently marked internal), the optimizer would remove them. This would then manifest as "not found" errors at runtime.

I debugged this with the following
* running with `AMD_LOG_LEVEL=4` to see debug output from amd on the runtime error
* compared optimized O1 vs O0 device code (`chpl__gpu_module-opt1.bc`, w/wo `--optimize`).
* bisected using `--mllvm '-opt-bisect-limit ...'` until I identified the bad pass. this showed the internalize pass being a problem (matching observations by @benharsh )
* compared the IR before/after internalize to determine what changed

The fix is to explicitly tell the LLVM optimizer that these Chapel globals are used and should not be considered unused.

This resolves some of the issues with https://github.com/chapel-lang/chapel/issues/28955, namely `gpu/native/studies/sort/radixSortGpu` and `gpu/native/studies/chop/queens_GPU_CPU_single_node`. `shoc-sort` is still outstanding.

Note: an AI was used both to help compare the IR and to write the fix

[Reviewed by @benharsh]