### PR TITLE
Move most cuda testing to cuda 13

### DIFF
--- a/doc/rst/technotes/gpu.rst
+++ b/doc/rst/technotes/gpu.rst
@@ -712,7 +712,7 @@ marked with * are covered in our nightly testing configurations.
 
   * Hardware: RTX A2000, P100*, V100*, A100*, H100, GH200
 
-  * Software: CUDA 11.7, 11.8, 12.0, 12.2, 12.4, 12.8, 12.9*, 13.0
+  * Software: CUDA 11.7, 11.8, 12.0, 12.2, 12.4, 12.8, 12.9*, 13.0*
 
 * AMD
 

--- a/util/cron/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
+++ b/util/cron/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
@@ -1,3 +1,3 @@
 # common settings for running GPU nightly testing on the HPE Cray EX system with CUDA 13
 
-module load cuda/13
+module load cuda/13.0

--- a/util/cron/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
+++ b/util/cron/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
@@ -1,0 +1,3 @@
+# common settings for running GPU nightly testing on the HPE Cray EX system with CUDA 13
+
+module load cuda/13

--- a/util/cron/test-gpu-ex-cuda-13.bash
+++ b/util/cron/test-gpu-ex-cuda-13.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# GPU native testing on a Cray EX (using none for CHPL_COMM)
+
+UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
+source $UTIL_CRON_DIR/common-native-gpu.bash
+source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
+
+export CHPL_COMM=none
+export CHPL_GPU=nvidia  # amd is also detected automatically
+
+module list
+
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-13"
+$UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-13.colocales.bash
+++ b/util/cron/test-gpu-ex-cuda-13.colocales.bash
@@ -7,7 +7,7 @@ source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
 source $UTIL_CRON_DIR/common-ofi.bash
 source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
-source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
 
 export SLURM_NETWORK=single_node_vni
 export CHPL_RT_LOCALES_PER_NODE=2
@@ -17,5 +17,5 @@ export CHPL_GPU=nvidia
 
 module list
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.colocales"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-13.colocales"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-13.interop.bash
+++ b/util/cron/test-gpu-ex-cuda-13.interop.bash
@@ -6,12 +6,12 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
 source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
-source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
 
 export CHPL_TEST_GPU=true
 export CHPL_NIGHTLY_TEST_DIRS="gpu/interop/"
 
 module list
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.interop"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-13.interop"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-13.ofi.bash
+++ b/util/cron/test-gpu-ex-cuda-13.ofi.bash
@@ -1,20 +1,17 @@
 #!/usr/bin/env bash
 #
-# GPU native testing on a Cray EX (using none for CHPL_COMM)
+# GPU native testing on a Cray EX
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
-source $UTIL_CRON_DIR/common-gpu-hpe-cray-ex.bash
 source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
-source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
 
-export CHPL_COMM=none
+export CHPL_COMM=ofi
 export CHPL_GPU=nvidia  # amd is also detected automatically
-
-export CHPL_GPU_SPECIALIZATION=y
 
 module list
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.specialization"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-13.ofi"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-gpu-ex-cuda-13.specialization.bash
+++ b/util/cron/test-gpu-ex-cuda-13.specialization.bash
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
 #
-# GPU native testing on a Cray EX
+# GPU native testing on a Cray EX (using none for CHPL_COMM)
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
+source $UTIL_CRON_DIR/common-gpu-hpe-cray-ex.bash
 source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
-source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
 
-export CHPL_COMM=ofi
+export CHPL_COMM=none
 export CHPL_GPU=nvidia  # amd is also detected automatically
+
+export CHPL_GPU_SPECIALIZATION=y
 
 module list
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-12.ofi"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="gpu-ex-cuda-13.specialization"
 $UTIL_CRON_DIR/nightly -cron ${nightly_args}

--- a/util/cron/test-perf.gpu-ex-cuda.bash
+++ b/util/cron/test-perf.gpu-ex-cuda.bash
@@ -6,12 +6,12 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
 source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
-source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
 
 export CHPL_COMM=none
 export CHPL_GPU=nvidia  # amd is detected automatically
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-ex-cuda-12"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-ex-cuda"
 
 export CHPL_TEST_PERF_CONFIG_NAME="1-node-a100" # pinoak has ampere GPUs
 source $UTIL_CRON_DIR/common-native-gpu-perf.bash

--- a/util/cron/test-perf.gpu-ex-cuda.um.bash
+++ b/util/cron/test-perf.gpu-ex-cuda.um.bash
@@ -6,13 +6,13 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 source $UTIL_CRON_DIR/common-native-gpu.bash
 source $UTIL_CRON_DIR/common-hpe-cray-ex.bash
 source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex.bash
-source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-12.bash
+source $UTIL_CRON_DIR/common-gpu-nvidia-hpe-cray-ex-cuda-13.bash
 
 export CHPL_COMM=none
 export CHPL_GPU=nvidia  # amd is detected automatically
 export CHPL_GPU_MEM_STRATEGY=unified_memory
 
-export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-ex-cuda-12.um"
+export CHPL_NIGHTLY_TEST_CONFIG_NAME="perf.gpu-ex-cuda.um"
 
 export CHPL_TEST_PERF_CONFIG_NAME="1-node-a100" # pinoak has ampere GPUs
 source $UTIL_CRON_DIR/common-native-gpu-perf.bash


### PR DESCRIPTION
Moves most cuda testing to cuda 13, keeping 1 config running cuda 12.9 to prevent regressions

[Reviewed by @arifthpe]