### PR TITLE
Fix a typo in the CLS docs

### DIFF
--- a/doc/rst/tools/chpl-language-server/chpl-language-server.rst
+++ b/doc/rst/tools/chpl-language-server/chpl-language-server.rst
@@ -101,56 +101,56 @@ use them, enable ``--resolver``.
 The following features are extra visual aids:
 
 
-+----------------+--------------------------------------------+---------------------------------------+
-| Feature        | Description                                | Flag                                  |
-+----------------+--------------------------------------------+---------------------------------------+
-| Type Inlays    | Type information can be displayed inline   | ``--type-inlays`` (default),          |
-|                | as an inlay hint.                          | ``--no-type-inlays``                  |
-+----------------+--------------------------------------------+---------------------------------------+
-| Return Type    | Inferred return types for functions can    | ``--return-type-inlays`` (default),   |
-| Inlays         | be displayed where a return type           | ``--no-return-type-inlays``           |
-|                | annotation would normally occur.           |                                       |
-+----------------+--------------------------------------------+---------------------------------------+
-| Generic Return | In some cases, the language server can     | ``--generic-return-type-inlays``,     |
-| Type Inlays    | infer a general return type for a generic  | ``--no-generic-return-type-inlays``   |
-|                | function, written in terms of its formals  | (default)                             |
-|                | (e.g., ``myFormal.type``).                 |                                       |
-+----------------+--------------------------------------------+---------------------------------------+
-| Param Inlays   | ``param`` values can be computed and       | ``--param-inlays`` (default),         |
-|                | displayed inline as inlay hints.           | ``--no-param-inlays``                 |
-+----------------+--------------------------------------------+---------------------------------------+
-| Enum Inlays    | ``enum`` elements' numerical values can be | ``--enum-inlays`` (default),          |
-|                | inferred where not explicitly specified    | ``--no-enum-inlays``                  |
-|                | and displayed as inlay hints.              |                                       |
-+----------------+--------------------------------------------+---------------------------------------+
-| Evaluated      | ``param`` values can also be computed and  | ``--evaluate-expressions`` (default), |
-| Tooltips       | displayed as tooltips.                     | ``--no-evaluate-expressions``         |
-+----------------+--------------------------------------------+---------------------------------------+
-| Call Inlays    | Names of literal arguments can be          | ``--literal-arg-inlays`` (default),   |
-|                | displayed inline as inlay hints.           | ``--no-literal-arg-inlays``           |
-+----------------+--------------------------------------------+---------------------------------------+
-| Dead Code      | Dyno can determine compile-time dead code, | ``--dead-code`` (default),            |
-|                | which ``CLS`` highlights in the editor.    | ``--no-dead-code``                    |
-+----------------+--------------------------------------------+---------------------------------------+
-| Generic        | ``CLS`` can show the various               | ``--show-instantiations`` (default),  |
-| Instantiations | instantiations of a generic function.      | ``--no-show-instantiations``          |
-+----------------+--------------------------------------------+---------------------------------------+
-| Default        | Procedures accepting array formals are     | ``--default-rect-arrays`` (default),  |
-| Instantiations | usually generic over the array's dimension | ``--no-default-rect-arrays``          |
-| For Arrays     | and distribution. ``CLS`` can automatically|                                       |
-|                | create concrete instantiations with        |                                       |
-|                | "regular" (default-rectangular) arrays.    |                                       |
-+----------------+--------------------------------------------+---------------------------------------+
-| Common         | When generic functions are instantiated    | ``--common-inlays`` (default),        |
-| Instantiation  | with multiple different types, ``CLS`` can | ``--no-common-inlays``                |
-| Inlays         | show type inlays even for the generic      |                                       |
-|                | version of the function, by finding the    |                                       |
-|                | set of inlays shared between all           |                                       |
-|                | instantiations of the function.            |                                       |
-|                |                                            |                                       |
-|                | Affects type, param, and return type       |                                       |
-|                | inlays.                                    |                                       |
-+----------------+--------------------------------------------+---------------------------------------+
++----------------+--------------------------------------------+---------------------------------------------+
+| Feature        | Description                                | Flag                                        |
++----------------+--------------------------------------------+---------------------------------------------+
+| Type Inlays    | Type information can be displayed inline   | ``--type-inlays`` (default),                |
+|                | as an inlay hint.                          | ``--no-type-inlays``                        |
++----------------+--------------------------------------------+---------------------------------------------+
+| Return Type    | Inferred return types for functions can    | ``--return-type-inlays`` (default),         |
+| Inlays         | be displayed where a return type           | ``--no-return-type-inlays``                 |
+|                | annotation would normally occur.           |                                             |
++----------------+--------------------------------------------+---------------------------------------------+
+| Generic Return | In some cases, the language server can     | ``--generic-return-type-inlays`` (default), |
+| Type Inlays    | infer a general return type for a generic  | ``--no-generic-return-type-inlays``         |
+|                | function, written in terms of its formals  |                                             |
+|                | (e.g., ``myFormal.type``).                 |                                             |
++----------------+--------------------------------------------+---------------------------------------------+
+| Param Inlays   | ``param`` values can be computed and       | ``--param-inlays`` (default),               |
+|                | displayed inline as inlay hints.           | ``--no-param-inlays``                       |
++----------------+--------------------------------------------+---------------------------------------------+
+| Enum Inlays    | ``enum`` elements' numerical values can be | ``--enum-inlays`` (default),                |
+|                | inferred where not explicitly specified    | ``--no-enum-inlays``                        |
+|                | and displayed as inlay hints.              |                                             |
++----------------+--------------------------------------------+---------------------------------------------+
+| Evaluated      | ``param`` values can also be computed and  | ``--evaluate-expressions`` (default),       |
+| Tooltips       | displayed as tooltips.                     | ``--no-evaluate-expressions``               |
++----------------+--------------------------------------------+---------------------------------------------+
+| Call Inlays    | Names of literal arguments can be          | ``--literal-arg-inlays`` (default),         |
+|                | displayed inline as inlay hints.           | ``--no-literal-arg-inlays``                 |
++----------------+--------------------------------------------+---------------------------------------------+
+| Dead Code      | Dyno can determine compile-time dead code, | ``--dead-code`` (default),                  |
+|                | which ``CLS`` highlights in the editor.    | ``--no-dead-code``                          |
++----------------+--------------------------------------------+---------------------------------------------+
+| Generic        | ``CLS`` can show the various               | ``--show-instantiations`` (default),        |
+| Instantiations | instantiations of a generic function.      | ``--no-show-instantiations``                |
++----------------+--------------------------------------------+---------------------------------------------+
+| Default        | Procedures accepting array formals are     | ``--default-rect-arrays`` (default),        |
+| Instantiations | usually generic over the array's dimension | ``--no-default-rect-arrays``                |
+| For Arrays     | and distribution. ``CLS`` can automatically|                                             |
+|                | create concrete instantiations with        |                                             |
+|                | "regular" (default-rectangular) arrays.    |                                             |
++----------------+--------------------------------------------+---------------------------------------------+
+| Common         | When generic functions are instantiated    | ``--common-inlays`` (default),              |
+| Instantiation  | with multiple different types, ``CLS`` can | ``--no-common-inlays``                      |
+| Inlays         | show type inlays even for the generic      |                                             |
+|                | version of the function, by finding the    |                                             |
+|                | set of inlays shared between all           |                                             |
+|                | instantiations of the function.            |                                             |
+|                |                                            |                                             |
+|                | Affects type, param, and return type       |                                             |
+|                | inlays.                                    |                                             |
++----------------+--------------------------------------------+---------------------------------------------+
 
 Additionally, some of the above features can be tweaked.
 


### PR DESCRIPTION
Fixes a typo in the CLS docs that show the wrong default for a flag

[Reviewed by @arifthpe]