### PR TITLE
Parallelize CLS tests

### DIFF
--- a/LICENSE.devel
+++ b/LICENSE.devel
@@ -12,6 +12,7 @@ code that doesn't appear in the release.
      chpl-venv/       python packages supporting chplspell, CLS
        pytest         Python's testing framework                   MIT
        pytest-lsp     Pytest plugin for language servers           MIT
+       pytest-xdist   Pytest plugin for parallel execution         MIT
        scspell3k      Spell-checking utility                       GPL 2
        scspell SCOWL word lists
                       Spell-checking dictionaries                  MIT-like

--- a/third-party/chpl-venv/README.devel.md
+++ b/third-party/chpl-venv/README.devel.md
@@ -9,8 +9,8 @@ Python packages required by the developer tool `chplspell`.
 The primary package required by `chplspell` is `scspell3k`.
 
 The primary developer packages required by `chpl-language-server` (CLS) are
-`pytest` and `pytest-lsp`.  The general packages requires by CLS are mentioned
-in README.md.
+`pytest`, `pytest-lsp`, and   pytest-xdist`.
+The general packages requires by CLS are mentioned in README.md.
 
 
 ### scspell3k
@@ -42,3 +42,13 @@ Required for testing CLS.
 **License**: MIT
 
 **Website**: https://pypi.org/project/pytest-lsp/
+
+### pytest-xdist
+
+A pytest plugin for running tests in parallel.
+
+Required for testing CLS.
+
+**License**: MIT
+
+**Website**: https://pypi.org/project/pytest-xdist/

--- a/third-party/chpl-venv/cls-test-requirements.txt
+++ b/third-party/chpl-venv/cls-test-requirements.txt
@@ -1,2 +1,3 @@
 pytest==8.4.1
 pytest-lsp==0.4.3
+pytest-xdist==3.8.0

--- a/tools/chpl-language-server/Makefile
+++ b/tools/chpl-language-server/Makefile
@@ -41,13 +41,15 @@ chpl-language-server-test-venv: chpl-language-server-venv
 chpl-language-server: chpl-language-server-venv
 
 test-chpl-language-server: chpl-language-server chpl-language-server-test-venv
-	$(CHPL_MAKE_HOME)/util/config/run-in-venv-with-python-bindings.bash \
-		$(CHPL_MAKE_PYTHON) -m pytest test/*.py
+	JOBSFLAGS=`echo "$$MAKEFLAGS" | sed -n -E 's/.*(-j|--jobs=) *([0-9][0-9]*).*/-n \2/p'`; \
+    $(CHPL_MAKE_HOME)/util/config/run-in-venv-with-python-bindings.bash \
+      $(CHPL_MAKE_PYTHON) -m pytest $$JOBSFLAGS test/*.py
 
 # Same as above, but generates XML report
 test-chpl-language-server-junit: chpl-language-server chpl-language-server-test-venv
-	$(CHPL_MAKE_HOME)/util/config/run-in-venv-with-python-bindings.bash \
-		$(CHPL_MAKE_PYTHON) -m pytest test/*.py --junit-xml=test-chpl-language-server-report.xml
+	JOBSFLAGS=`echo "$$MAKEFLAGS" | sed -n -E 's/.*(-j|--jobs=) *([0-9][0-9]*).*/-n \2/p'`; \
+    $(CHPL_MAKE_HOME)/util/config/run-in-venv-with-python-bindings.bash \
+      $(CHPL_MAKE_PYTHON) -m pytest $$JOBSFLAGS test/*.py --junit-xml=test-chpl-language-server-report.xml
 
 clean: clean-link clean-link-shim clean-pycache
 


### PR DESCRIPTION
Enables parallel testing for CLS by adding pytest-xdist as a CLS test dependency

The amount of parallelism used will be inferred from the Makefile flags, so `make test-cls -j4` will use 4 workers.

[Reviewed by @arifthpe]