### PR TITLE
Allow disabling dyno asserts in developer builds

### DIFF
--- a/compiler/make/Makefile.compiler.head
+++ b/compiler/make/Makefile.compiler.head
@@ -22,8 +22,6 @@
 
 # Set CHPL_DEVELOPER to 0 if it is not set yet
 CHPL_DEVELOPER ?= 0
-# set DYNO_ENABLE_ASSERTIONS to 0 if it is not set yet
-DYNO_ENABLE_ASSERTIONS ?= 0
 
 ifneq ($(NO_DEPEND), 1)
 DEPEND=1
@@ -41,10 +39,13 @@ else
 DEBUG=1
 WARNINGS=1
 TAGS=1
-# always enable assertions in CHPL_DEVELOPER/debug mode
-DYNO_ENABLE_ASSERTIONS=1
+# enable assertions if unset in CHPL_DEVELOPER/debug mode
+DYNO_ENABLE_ASSERTIONS ?= 1
 endif
 #PROFILE=1
+
+# set DYNO_ENABLE_ASSERTIONS to 0 if it is not set yet
+DYNO_ENABLE_ASSERTIONS ?= 0
 
 ifeq ($(DYNO_ENABLE_ASSERTIONS), 0)
   # disable assertions


### PR DESCRIPTION
Allows disabling dyno asserts in developer builds.

This allows developers to have both `CHPL_DEVELOPER=1` and `DYNO_ENABLE_ASSERTIONS=0`, which was not possible before. This is useful when testing resolver features for the language server.

[Reviewed by @benharsh]