### PR TITLE
Prevent CLS crash on invalid code lens

### DIFF
--- a/frontend/include/chpl/framework/Context.h
+++ b/frontend/include/chpl/framework/Context.h
@@ -842,6 +842,13 @@ class Context {
   void advanceToNextRevision(bool prepareToGC);
 
   /**
+    Returns the current revision number
+  */
+  int currentRevision() const {
+    return int(currentRevisionNumber);
+  }
+
+  /**
     Returns the number of query bodies executed in this revision.
    */
   int numQueriesRunThisRevision() const {

--- a/tools/chapel-py/src/method-tables/core-methods.h
+++ b/tools/chapel-py/src/method-tables/core-methods.h
@@ -75,6 +75,8 @@ CLASS_BEGIN(Context)
 
          auto prepareToGc = std::get<0>(args);
          node->advanceToNextRevision(prepareToGc))
+  METHOD(Context, current_revision, "Get the current revision number of the context",
+         int(), return node->currentRevision())
   METHOD(Context, get_file_text, "Get the text of the file at the given path",
          std::string(chpl::UniqueString), return parsing::fileText(node, std::get<0>(args)).text())
   METHOD(Context, get_compiler_version, "Get the version of the Chapel compiler",

--- a/tools/chpl-language-server/src/chpl-language-server.py
+++ b/tools/chpl-language-server/src/chpl-language-server.py
@@ -1755,6 +1755,7 @@ def run_lsp():
                                 decl.node.unique_id(),
                                 i,
                                 from_file.uri,
+                                from_file.context.revision(),
                             ],
                         ),
                         range=decl.rng,
@@ -1781,13 +1782,16 @@ def run_lsp():
 
     @server.command("chpl-language-server/showInstantiation")
     async def show_instantiation(
-        ls: ChapelLanguageServer, data: Tuple[str, str, int, str]
+        ls: ChapelLanguageServer, data: Tuple[str, str, int, str, int]
     ):
-        uri, unique_id, i, source_uri = data
+        uri, unique_id, i, source_uri, revision = data
 
         fi, _ = ls.get_file_info(uri)
         source_fi, _ = ls.get_file_info(source_uri)
         decl = fi.find_decl_by_unique_id(unique_id)
+
+        if source_fi.context.revision() != revision:
+            return
 
         if decl is None:
             return

--- a/tools/chpl-language-server/src/lsp_util.py
+++ b/tools/chpl-language-server/src/lsp_util.py
@@ -695,6 +695,9 @@ class ContextContainer:
             self.std_module_root, self.module_paths, self.file_paths
         )
 
+    def revision(self) -> int:
+        return self.context.current_revision()
+
     def register_signature(self, sig: chapel.TypedSignature) -> str:
         """
         The language server can't send over typed signatures directly for

--- a/tools/chpl-language-server/test/util/utils.py
+++ b/tools/chpl-language-server/test/util/utils.py
@@ -805,7 +805,7 @@ async def click_lenses_and_check_inlays(
                 else:
                     assert (
                         command.arguments is not None
-                        and len(command.arguments) == 4
+                        and len(command.arguments) == 5
                     )
                     idx = command.arguments[2]
                     assert idx is not None


### PR DESCRIPTION
Fixes a potential CLS crash when clicking on an invalid code lens

While code lenses get invalidated rapidly by the language server (making this rare), the client can be slow to invalidate the lens. This can result in an invalid code lens being shown to users. Previously, if they clicked on (for example, to "Show Instantiation"), this would result in a hard crash. Now, the language server will just do nothing. This is accomplished by keeping track of the current context revision. When the revision is incremented (which is also when the lens should be invalidated), then the two revisions will no longer match.

[Reviewed by @benharsh]