### PR TITLE
Fix Data Storage for New Spectral Norm Benchmark

### DIFF
--- a/test/studies/shootout/submitted/spectralnorm-submitted-40000.graph
+++ b/test/studies/shootout/submitted/spectralnorm-submitted-40000.graph
@@ -1,5 +1,5 @@
 perfkeys: real, real
-graphkeys: release, submitted, submitted (2)
+graphkeys: submitted, submitted (2)
 files: spectralnorm-submitted-40000.dat, spectralnorm2-40000.dat
 graphtitle: Submitted Spectral Norm Shootout Benchmark for 40000x40000
 ylabel: Time (seconds)

--- a/test/studies/shootout/submitted/spectralnorm.perfexecopts
+++ b/test/studies/shootout/submitted/spectralnorm.perfexecopts
@@ -1,2 +1,2 @@
---n=5500
+--n=5500  # spectralnorm-submitted
 --n=40000 # spectralnorm-submitted-40000

--- a/test/studies/shootout/submitted/spectralnorm.perfkeys
+++ b/test/studies/shootout/submitted/spectralnorm.perfkeys
@@ -1,3 +1,2 @@
-# file: spectralnorm-submitted.dat
 real
 verify:-4: 1.274224153

--- a/test/studies/shootout/submitted/spectralnorm2.perfexecopts
+++ b/test/studies/shootout/submitted/spectralnorm2.perfexecopts
@@ -1,2 +1,2 @@
 --n=5500  # spectralnorm2
---n=40000 # spectralnorm2-submitted-40000
+--n=40000 # spectralnorm2-40000


### PR DESCRIPTION
The benchmark results for the new spectralnorm benchmark size were getting dropped into the same file as the old smaller benchmark size. It turned out that having the name specified in the perfkeys file was overriding the two distinct filenames in the perfexecopts file. While here I also removed the reference to the spectralnorm-release.dat file in the associated graph file since that doesn't appear to be generated by anything specific right now.