### PR TITLE
Update debian12 package to use correct llvm

### DIFF
--- a/util/packaging/apt/debian12/Dockerfile.template
+++ b/util/packaging/apt/debian12/Dockerfile.template
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y \
       curl wget vim sudo gcc g++ m4 perl chrpath \
       python3 python3-dev python3-venv bash make mawk git pkg-config cmake \
-      llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev \
+      llvm-15-dev llvm-15 clang-15 libclang-15-dev libclang-cpp15-dev libedit-dev \
       pkgconf libgmp-dev libhwloc-dev \
       libunwind-dev
 

--- a/util/packaging/apt/debian12/control.template
+++ b/util/packaging/apt/debian12/control.template
@@ -3,4 +3,4 @@ Version: @@{CHAPEL_VERSION}
 Maintainer: chapel-lang
 Architecture: @@{TARGETARCH}
 Description: Chapel Programming Language
-Depends: git,gcc,llvm-dev,llvm,clang,libclang-dev,libclang-cpp-dev,python3,python3-dev,python3-venv,make,pkgconf,libgmp-dev,libhwloc-dev,libunwind-dev
+Depends: git,gcc,llvm-15-dev,llvm-15,clang-15,libclang-15-dev,libclang-cpp15-dev,python3,python3-dev,python3-venv,make,pkgconf,libgmp-dev,libhwloc-dev,libunwind-dev


### PR DESCRIPTION
Update the debian12 package to use LLVM 15

This was missed in https://github.com/chapel-lang/chapel/pull/28995

[Reviewed by @benharsh and @arifthpe]