### PR TITLE
Prevent users setting CHPL_LLVM_CONFIG to a bad value

### DIFF
--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -376,6 +376,16 @@ def get_llvm_config():
     elif llvm_config == "none":
         if llvm_val == "system" or llvm_support_val == "system":
             llvm_config = find_system_llvm_config()
+    
+    else:
+        # check that the provided llvm-config is valid
+        version, config_err = check_llvm_config(llvm_config)
+        if config_err:
+            error(
+                "Problem with llvm-config at {0} -- {1}".format(
+                    llvm_config, config_err
+                )
+            )
 
     return llvm_config
 

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -376,7 +376,7 @@ def get_llvm_config():
     elif llvm_config == "none":
         if llvm_val == "system" or llvm_support_val == "system":
             llvm_config = find_system_llvm_config()
-    
+
     else:
         # check that the provided llvm-config is valid
         version, config_err = check_llvm_config(llvm_config)

--- a/util/chplenv/chpl_llvm.py
+++ b/util/chplenv/chpl_llvm.py
@@ -279,6 +279,13 @@ def check_llvm_packages(llvm_config):
 def find_system_llvm_config():
     llvm_config = overrides.get("CHPL_LLVM_CONFIG", "none")
     if llvm_config != "none":
+        _, config_err = check_llvm_config(llvm_config)
+        if config_err:
+            error(
+                "Problem with llvm-config at {0} -- {1}".format(
+                    llvm_config, config_err
+                )
+            )
         return llvm_config
 
     llvm_config = chpl_gpu.get_llvm_override()
@@ -379,7 +386,7 @@ def get_llvm_config():
 
     else:
         # check that the provided llvm-config is valid
-        version, config_err = check_llvm_config(llvm_config)
+        _, config_err = check_llvm_config(llvm_config)
         if config_err:
             error(
                 "Problem with llvm-config at {0} -- {1}".format(


### PR DESCRIPTION
Adds a check to prevent users setting CHPL_LLVM_CONFIG to a bad value, resulting in confusing errors later.

For example, if a user set `CHPL_LLVM_CONFIG=$(which llvm-config)`, they would expect it to work. But if that llvm is too old, they could get strange errors that do not tell them what actually went wrong (and might look like a bug in Chapel). Or, a user could set `CHPL_LLVM_CONFIG` to some garbage value.

Fixed by just validating `CHPL_LLVM_CONFIG` with a quick check that it exists and is the correct version. Full validation is done at a later step.

[Reviewed by @arifthpe]