### PR TITLE
Move Linuxbrew Vagrant test to Ubuntu 24.04

### DIFF
--- a/util/devel/test/portability/vagrant/current/bento-ubuntu24.04-homebrew/Vagrantfile
+++ b/util/devel/test/portability/vagrant/current/bento-ubuntu24.04-homebrew/Vagrantfile
@@ -16,7 +16,7 @@
 # - Homebrew is meant to be run as non-root, which would require more work in
 #   the image build (and perhaps container run) to accommodate.
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/jammy64"
+  config.vm.box = "bento/ubuntu-24.04"
 
   config.vm.provision "shell" do |s|
     s.env =  { http_proxy:ENV['http_proxy'], https_proxy:ENV['https_proxy'] }


### PR DESCRIPTION
Change the Vagrant box we use for Ubuntu Linuxbrew (non-containerized) testing from `ubuntu/jammy64` to `bento/ubuntu-24.04`.

Switched to the `bento` box because there are no [official ubuntu Vagrant images](https://portal.cloud.hashicorp.com/vagrant/discover/ubuntu) after 22.04.

[reviewed by @jabraham17 , thanks!]

Testing:
- [x] local run of `chapelquickcheck.sh`