### PR TITLE
Avoid pointer arithmetic with void pointers in test

### DIFF
--- a/test/extern/ferguson/c_void_pointer.h
+++ b/test/extern/ferguson/c_void_pointer.h
@@ -1,6 +1,7 @@
+#include <stdint.h>
 static void* mytest(void* x) {
   unsigned char* xp = (unsigned char*) x;
-  xp += 2;
+  xp = (unsigned char*)((intptr_t)xp + 2);
   return xp;
 }
 


### PR DESCRIPTION
Adjusts a test to avoid void pointer arithmetic, which is undefined behavior

[Not reviewed - trivial]