### PR TITLE
Prevent undefined behavior with `--cpp-lines`

### DIFF
--- a/compiler/backend/beautify.cpp
+++ b/compiler/backend/beautify.cpp
@@ -227,12 +227,8 @@ void beautify(fileinfo* origfile) {
         }
         fprintf(outputfile, ZLINEFORMAT, zlineP, zname);
       }
-    }
 
-    if (cp[strlen(cp)-1] == '\n')
-      new_line = TRUE;
-    else {
-      new_line = FALSE;
+      new_line = cp[strlen(cp)-1] == '\n';
     }
 
     switch (cp[0]) {

--- a/compiler/backend/beautify.cpp
+++ b/compiler/backend/beautify.cpp
@@ -227,8 +227,9 @@ void beautify(fileinfo* origfile) {
         }
         fprintf(outputfile, ZLINEFORMAT, zlineP, zname);
       }
-
       new_line = cp[strlen(cp)-1] == '\n';
+    } else {
+      new_line = FALSE;
     }
 
     switch (cp[0]) {


### PR DESCRIPTION
Fixes an issue where `--cpp-lines` could attempt to index an empty string with `-1`.

In some cases, `cp` could be `""` and `strlen(cp)` would be 0. This means we would attempt to index the array with a negative value (undefined behavior!)

[Reviewed by @arifthpe]