### PR TITLE
Prevent undefined behavior when printing real/imag

### DIFF
--- a/runtime/src/qio/qio_formatted.c
+++ b/runtime/src/qio/qio_formatted.c
@@ -3452,19 +3452,19 @@ int _ftoa(char* restrict dst, size_t size, double num, int base, bool needs_i, c
 
   // How many bytes are we adding for the sign?
   sign_base_width = 0;
-  if( style->showplus || shownegative ) sign_base_width++;
-  if( showbase ) sign_base_width+=2; // for 0x.
+  if (style->showplus || shownegative) sign_base_width++;
+  if (showbase) sign_base_width+=2; // for 0x.
 
   // Fill sign_base_width with spaces
   // (useful for debugging and clarity).
-  if( sign_base_width < size ) {
+  if (sign_base_width < size) {
     for( i = 0; i < sign_base_width; i++ ) {
       dst[i] = ' '; // put spaces to overwrite later
     }
   }
 
   skip = 0;
-  got = _ftoa_core(&dst[sign_base_width],
+  got = _ftoa_core(dst ? &dst[sign_base_width] : NULL,
                    (size>sign_base_width)?(size-sign_base_width):0,
                    num, base, style->realfmt,
                    precision, style->uppercase, style->prefix_base,


### PR DESCRIPTION
Fixes undefined behavior when printing real/imag numbers

When printing real/imag numbers, the following occurs
* Attempt to print the number to the cache (a buffer in memory)
* If the cache is NULL, write manually to the stream using a localbuffer
* otherwise, succeed.

This is the fast path, and is a valid pattern. We call the function to determine how big a buffer we need, then allocate the buffer and call it again (same pattern used by snprintf, which is used internally). But, we attempt to manipulate the NULL pointer, which is undefined behavior. The fix is to just explicitly pass NULL when the buffer is NULL, instead of indexing by some offset (since the value of the buffer should be NULL)

[Reviewed by @arifthpe]