### PR TITLE
Update the locally vendored brg_sha.c in a test

### DIFF
--- a/test/studies/uts/COMPOPTS
+++ b/test/studies/uts/COMPOPTS
@@ -1,1 +1,1 @@
--O --no-checks brg_sha1.c brg_sha1.h
+-O --no-checks brg_sha1.c brg_sha1.h rng_brg.c rng_brg.h

--- a/test/studies/uts/brg_sha1.c
+++ b/test/studies/uts/brg_sha1.c
@@ -1,42 +1,24 @@
 /*
- ---------------------------------------------------------------------------
- Copyright (c) 2002, Dr Brian Gladman, Worcester, UK.   All rights reserved.
+---------------------------------------------------------------------------
+Copyright (c) 1998-2010, Brian Gladman, Worcester, UK. All rights reserved.
 
- LICENSE TERMS
+The redistribution and use of this software (with or without changes)
+is allowed without the payment of fees or royalties provided that:
 
- The free distribution and use of this software in both source and binary
- form is allowed (with or without changes) provided that:
+  source code distributions include the above copyright notice, this
+  list of conditions and the following disclaimer;
 
-   1. distributions of this source code include the above copyright
-      notice, this list of conditions and the following disclaimer;
+  binary distributions include the above copyright notice, this list
+  of conditions and the following disclaimer in their documentation.
 
-   2. distributions in binary form include the above copyright
-      notice, this list of conditions and the following disclaimer
-      in the documentation and/or other associated materials;
-
-   3. the copyright holder's name is not used to endorse products
-      built using this software without specific written permission.
-
- ALTERNATIVELY, provided that this notice is retained in full, this product
- may be distributed under the terms of the GNU General Public License (GPL),
- in which case the provisions of the GPL apply INSTEAD OF those given above.
-
- DISCLAIMER
-
- This software is provided 'as is' with no explicit or implied warranties
- in respect of its properties, including, but not limited to, correctness
- and/or fitness for purpose.
- ---------------------------------------------------------------------------
- Issue Date: 01/08/2005
-
- This is a byte oriented version of SHA1 that operates on arrays of bytes
- stored in memory.
-
- Source code origin listed in README file.
+This software is provided 'as is' with no explicit or implied warranties
+in respect of its operation, including, but not limited to, correctness
+and fitness for purpose.
+---------------------------------------------------------------------------
+Issue Date: 20/12/2007
 */
 
 #include <string.h>     /* for memcpy() etc.        */
-#include <stdio.h>
 
 #include "brg_sha1.h"
 #include "brg_endian.h"
@@ -46,86 +28,9 @@ extern "C"
 {
 #endif
 
-/** BEGIN: UTS RNG Harness **/
-
-void rng_init(RNG_state *newstate, int seed)
-{
-  struct sha1_context ctx;
-  struct state_t gen;
-  int i;
-
-  for (i=0; i < 16; i++) 
-    gen.state[i] = 0;
-  gen.state[16] = (uint_8t)(0xFF & (seed >> 24));
-  gen.state[17] = (uint_8t)(0xFF & (seed >> 16));
-  gen.state[18] = (uint_8t)(0xFF & (seed >> 8));
-  gen.state[19] = (uint_8t)(0xFF & (seed >> 0));
-  
-  sha1_begin(&ctx);
-  sha1_hash(gen.state, 20, &ctx);
-  sha1_end(newstate, &ctx);
-}
-
-void rng_spawn(RNG_state *mystate, RNG_state *newstate, int spawnnumber)
-{
-	struct sha1_context ctx;
-	uint_8t  bytes[4];
-	
-	bytes[0] = (uint_8t)(0xFF & (spawnnumber >> 24));
-	bytes[1] = (uint_8t)(0xFF & (spawnnumber >> 16));
-	bytes[2] = (uint_8t)(0xFF & (spawnnumber >> 8));
-	bytes[3] = (uint_8t)(0xFF & spawnnumber);
-	
-	sha1_begin(&ctx);
-	sha1_hash(mystate, 20, &ctx);
-	sha1_hash(bytes, 4, &ctx);
-	sha1_end(newstate, &ctx);
-}
-
-int rng_rand(RNG_state *mystate){
-        int r;
-	uint_32t b =  (mystate[16] << 24) | (mystate[17] << 16)
-		| (mystate[18] << 8) | (mystate[19] << 0);
-	b = b & POS_MASK;
-	
-	r = (int) b;
-	//printf("b: %d\t, r: %d\n", b, r);
-	return r;
-}
-
-int rng_nextrand(RNG_state *mystate){
-	struct sha1_context ctx;
-	int r;
-	uint_32t b;
-
-	sha1_begin(&ctx);
-	sha1_hash(mystate, 20, &ctx);
-	sha1_end(mystate, &ctx);
-	b =  (mystate[16] << 24) | (mystate[17] << 16)
-		| (mystate[18] << 8) | (mystate[19] << 0);
-	b = b & POS_MASK;
-	
-	r = (int) b;
-	return r;
-}
-
-/* condense state into string to display during debugging */
-char * rng_showstate(RNG_state *state, char *s){
-  snprintf(s, 8 * sizeof(char), "%.2X%.2X...", state[0],state[1]);
-  return s;
-}
-
-/* describe random number generator type into string */
-int rng_showtype(char *strBuf, int ind) {
-  ind += snprintf(strBuf + ind, 25 * sizeof(char), "SHA-1 (state size = %uB)",
-                  (unsigned)sizeof(struct state_t));
-  return ind;
-}
-
-/** END: UTS RNG Harness **/
-
 #if defined( _MSC_VER ) && ( _MSC_VER > 800 )
 #pragma intrinsic(memcpy)
+#pragma intrinsic(memset)
 #endif
 
 #if 0 && defined(_MSC_VER)
@@ -148,7 +53,7 @@ int rng_showtype(char *strBuf, int ind) {
 
 #if defined(SWAP_BYTES)
 #define bsw_32(p,n) \
-    { int _i = (n); while(_i--) ((uint_32t*)p)[_i] = bswap_32(((uint_32t*)p)[_i]); }
+    { int _i = (n); while(_i--) ((uint32_t*)p)[_i] = bswap_32(((uint32_t*)p)[_i]); }
 #else
 #define bsw_32(p,n)
 #endif
@@ -195,13 +100,13 @@ int rng_showtype(char *strBuf, int ind) {
     one_cycle(v, 1,2,3,4,0, f,k,hf(i+4))
 
 VOID_RETURN sha1_compile(sha1_ctx ctx[1])
-{   uint_32t    *w = ctx->wbuf;
+{   uint32_t    *w = ctx->wbuf;
 
 #ifdef ARRAY
-    uint_32t    v[5];
-    memcpy(v, ctx->hash, 5 * sizeof(uint_32t));
+    uint32_t    v[5];
+    memcpy(v, ctx->hash, sizeof(ctx->hash));
 #else
-    uint_32t    v0, v1, v2, v3, v4;
+    uint32_t    v0, v1, v2, v3, v4;
     v0 = ctx->hash[0]; v1 = ctx->hash[1];
     v2 = ctx->hash[2]; v3 = ctx->hash[3];
     v4 = ctx->hash[4];
@@ -252,7 +157,7 @@ VOID_RETURN sha1_compile(sha1_ctx ctx[1])
 
 VOID_RETURN sha1_begin(sha1_ctx ctx[1])
 {
-    ctx->count[0] = ctx->count[1] = 0;
+    memset(ctx, 0, sizeof(sha1_ctx));
     ctx->hash[0] = 0x67452301;
     ctx->hash[1] = 0xefcdab89;
     ctx->hash[2] = 0x98badcfe;
@@ -261,43 +166,78 @@ VOID_RETURN sha1_begin(sha1_ctx ctx[1])
 }
 
 /* SHA1 hash data in an array of bytes into hash buffer and */
-/* call the hash_compile function as required.              */
+/* call the hash_compile function as required. For both the */
+/* bit and byte orientated versions, the block length 'len' */
+/* must not be greater than 2^32 - 1 bits (2^29 - 1 bytes)  */ 
 
 VOID_RETURN sha1_hash(const unsigned char data[], unsigned long len, sha1_ctx ctx[1])
-{   uint_32t pos = (uint_32t)(ctx->count[0] & SHA1_MASK),
-            space = SHA1_BLOCK_SIZE - pos;
+{   uint32_t pos = (uint32_t)((ctx->count[0] >> 3) & SHA1_MASK);
     const unsigned char *sp = data;
-
+    unsigned char *w = (unsigned char*)ctx->wbuf;
+#if SHA1_BITS == 1
+    uint32_t ofs = (ctx->count[0] & 7);
+#else
+    len <<= 3;
+#endif
     if((ctx->count[0] += len) < len)
         ++(ctx->count[1]);
-
-    while(len >= space)     /* tranfer whole blocks if possible  */
+#if SHA1_BITS == 1
+    if(ofs)                 /* if not on a byte boundary    */
     {
-        memcpy(((unsigned char*)ctx->wbuf) + pos, sp, space);
-        sp += space; len -= space; space = SHA1_BLOCK_SIZE; pos = 0;
-        bsw_32(ctx->wbuf, SHA1_BLOCK_SIZE >> 2);
-        sha1_compile(ctx);
-    }
+        if(ofs + len < 8)   /* if no added bytes are needed */
+        {
+            w[pos] |= (*sp >> ofs);
+        }
+        else                /* otherwise and add bytes      */
+        {   unsigned char part = w[pos];
 
-    memcpy(((unsigned char*)ctx->wbuf) + pos, sp, len);
+            while((int)(ofs + (len -= 8)) >= 0)
+            {
+                w[pos++] = part | (*sp >> ofs);
+                part = *sp++ << (8 - ofs);
+                if(pos == SHA1_BLOCK_SIZE)
+                {
+                    bsw_32(w, SHA1_BLOCK_SIZE >> 2);
+                    sha1_compile(ctx); pos = 0;
+                }
+            }
+
+            w[pos] = part;
+        }
+    }
+    else    /* data is byte aligned */
+#endif
+    {   uint32_t space = SHA1_BLOCK_SIZE - pos;
+
+        while(len >= (space << 3))
+        {
+            memcpy(w + pos, sp, space);
+            bsw_32(w, SHA1_BLOCK_SIZE >> 2);
+            sha1_compile(ctx); 
+            sp += space; len -= (space << 3); 
+            space = SHA1_BLOCK_SIZE; pos = 0;
+        }
+        memcpy(w + pos, sp, (len + 7 * SHA1_BITS) >> 3);
+    }
 }
 
 /* SHA1 final padding and digest calculation  */
 
 VOID_RETURN sha1_end(unsigned char hval[], sha1_ctx ctx[1])
-{   uint_32t    i = (uint_32t)(ctx->count[0] & SHA1_MASK);
+{   uint32_t    i = (uint32_t)((ctx->count[0] >> 3) & SHA1_MASK), m1;
 
     /* put bytes in the buffer in an order in which references to   */
     /* 32-bit words will put bytes with lower addresses into the    */
     /* top of 32 bit words on BOTH big and little endian machines   */
-    bsw_32(ctx->wbuf, (i + 3) >> 2);
+    bsw_32(ctx->wbuf, (i + 3 + SHA1_BITS) >> 2);
 
     /* we now need to mask valid bytes and add the padding which is */
     /* a single 1 bit and as many zero bits as necessary. Note that */
     /* we can always add the first padding byte here because the    */
     /* buffer always has at least one empty slot                    */
-    ctx->wbuf[i >> 2] &= 0xffffff80 << 8 * (~i & 3);
-    ctx->wbuf[i >> 2] |= 0x00000080 << 8 * (~i & 3);
+    m1 = (unsigned char)0x80 >> (ctx->count[0] & 7);
+    ctx->wbuf[i >> 2] &= ((0xffffff00 | (~m1 + 1)) << 8 * (~i & 3));
+    ctx->wbuf[i >> 2] |= (m1 << 8 * (~i & 3));
 
     /* we need 9 or more empty positions, one for the padding byte  */
     /* (above) and eight for the length count. If there is not      */
@@ -318,14 +258,14 @@ VOID_RETURN sha1_end(unsigned char hval[], sha1_ctx ctx[1])
     /* wrong byte order on little endian machines but this is       */
     /* corrected later since they are only ever used as 32-bit      */
     /* word values.                                                 */
-    ctx->wbuf[14] = (ctx->count[1] << 3) | (ctx->count[0] >> 29);
-    ctx->wbuf[15] = ctx->count[0] << 3;
+    ctx->wbuf[14] = ctx->count[1];
+    ctx->wbuf[15] = ctx->count[0];
     sha1_compile(ctx);
 
     /* extract the hash value as bytes in case the hash buffer is   */
     /* misaligned for 32-bit words                                  */
     for(i = 0; i < SHA1_DIGEST_SIZE; ++i)
-        hval[i] = (unsigned char)(ctx->hash[i >> 2] >> (8 * (~i & 3)));
+        hval[i] = ((ctx->hash[i >> 2] >> (8 * (~i & 3))) & 0xff);
 }
 
 VOID_RETURN sha1(unsigned char hval[], const unsigned char data[], unsigned long len)

--- a/test/studies/uts/brg_sha1.h
+++ b/test/studies/uts/brg_sha1.h
@@ -1,39 +1,34 @@
 /*
- ---------------------------------------------------------------------------
- Copyright (c) 2002, Dr Brian Gladman, Worcester, UK.   All rights reserved.
+---------------------------------------------------------------------------
+Copyright (c) 1998-2010, Brian Gladman, Worcester, UK. All rights reserved.
 
- LICENSE TERMS
+The redistribution and use of this software (with or without changes)
+is allowed without the payment of fees or royalties provided that:
 
- The free distribution and use of this software in both source and binary
- form is allowed (with or without changes) provided that:
+  source code distributions include the above copyright notice, this
+  list of conditions and the following disclaimer;
 
-   1. distributions of this source code include the above copyright
-      notice, this list of conditions and the following disclaimer;
+  binary distributions include the above copyright notice, this list
+  of conditions and the following disclaimer in their documentation.
 
-   2. distributions in binary form include the above copyright
-      notice, this list of conditions and the following disclaimer
-      in the documentation and/or other associated materials;
-
-   3. the copyright holder's name is not used to endorse products
-      built using this software without specific written permission.
-
- ALTERNATIVELY, provided that this notice is retained in full, this product
- may be distributed under the terms of the GNU General Public License (GPL),
- in which case the provisions of the GPL apply INSTEAD OF those given above.
-
- DISCLAIMER
-
- This software is provided 'as is' with no explicit or implied warranties
- in respect of its properties, including, but not limited to, correctness
- and/or fitness for purpose.
- ---------------------------------------------------------------------------
- Issue Date: 01/08/2005
-
- Source code origin listed in README file.
+This software is provided 'as is' with no explicit or implied warranties
+in respect of its operation, including, but not limited to, correctness
+and fitness for purpose.
+---------------------------------------------------------------------------
+Issue Date: 20/12/2007
 */
 
 #ifndef _SHA1_H
 #define _SHA1_H
+
+/* define for bit or byte oriented SHA   */
+#if 1
+#  define SHA1_BITS 0   /* byte oriented */
+#else
+#  define SHA1_BITS 1   /* bit oriented  */
+#endif
+
+#define SHA_1
 
 #include <stdlib.h>
 #include "brg_types.h"
@@ -46,49 +41,22 @@ extern "C"
 {
 #endif
 
-/** BEGIN: UTS RNG Harness **/
-
-#define POS_MASK    0x7fffffff
-#define HIGH_BITS   0x80000000
-
-#define sha1_context sha1_ctx_s
-
-/**********************************/
-/* random number generator state  */
-/**********************************/
-struct state_t {
-  uint_8t state[20];
-};
-
-typedef uint_8t RNG_state;
-
-/***************************************/
-/* random number generator operations  */
-/***************************************/
-void   rng_init(RNG_state *state, int seed);
-void   rng_spawn(RNG_state *mystate, RNG_state *newstate, int spawnNumber);
-int    rng_rand(RNG_state *mystate);
-int    rng_nextrand(RNG_state *mystate);
-char * rng_showstate(RNG_state *state, char *s);
-int    rng_showtype(char *strBuf, int ind);
-
-/** END: UTS RNG Harness **/
 /* type to hold the SHA256 context  */
 
-struct sha1_ctx_s
-{   uint_32t count[2];
-    uint_32t hash[5];
-    uint_32t wbuf[16];
-};
-
-typedef struct sha1_ctx_s sha1_ctx;
+typedef struct
+{   uint32_t count[2];
+    uint32_t hash[SHA1_DIGEST_SIZE >> 2];
+    uint32_t wbuf[SHA1_BLOCK_SIZE >> 2];
+} sha1_ctx;
 
 /* Note that these prototypes are the same for both bit and */
 /* byte oriented implementations. However the length fields */
 /* are in bytes or bits as appropriate for the version used */
 /* and bit sequences are input as arrays of bytes in which  */
 /* bit sequences run from the most to the least significant */
-/* end of each byte                                         */
+/* end of each byte. The value 'len' in sha1_hash for the   */
+/* byte oriented version of SHA1 is limited to 2^29 bytes,  */
+/* but multiple calls will handle longer data blocks.       */
 
 VOID_RETURN sha1_compile(sha1_ctx ctx[1]);
 

--- a/test/studies/uts/brg_types.h
+++ b/test/studies/uts/brg_types.h
@@ -1,160 +1,133 @@
 /*
- ---------------------------------------------------------------------------
- Copyright (c) 1998-2006, Brian Gladman, Worcester, UK. All rights reserved.
+---------------------------------------------------------------------------
+Copyright (c) 1998-2013, Brian Gladman, Worcester, UK. All rights reserved.
 
- LICENSE TERMS
+The redistribution and use of this software (with or without changes)
+is allowed without the payment of fees or royalties provided that:
 
- The free distribution and use of this software in both source and binary
- form is allowed (with or without changes) provided that:
+  source code distributions include the above copyright notice, this
+  list of conditions and the following disclaimer;
 
-   1. distributions of this source code include the above copyright
-      notice, this list of conditions and the following disclaimer;
+  binary distributions include the above copyright notice, this list
+  of conditions and the following disclaimer in their documentation.
 
-   2. distributions in binary form include the above copyright
-      notice, this list of conditions and the following disclaimer
-      in the documentation and/or other associated materials;
-
-   3. the copyright holder's name is not used to endorse products
-      built using this software without specific written permission.
-
- ALTERNATIVELY, provided that this notice is retained in full, this product
- may be distributed under the terms of the GNU General Public License (GPL),
- in which case the provisions of the GPL apply INSTEAD OF those given above.
-
- DISCLAIMER
-
- This software is provided 'as is' with no explicit or implied warranties
- in respect of its properties, including, but not limited to, correctness
- and/or fitness for purpose.
- ---------------------------------------------------------------------------
- Issue 09/09/2006
-
- The unsigned integer types defined here are of the form uint_<nn>t where
- <nn> is the length of the type; for example, the unsigned 32-bit type is
- 'uint_32t'.  These are NOT the same as the 'C99 integer types' that are
- defined in the inttypes.h and stdint.h headers since attempts to use these
- types have shown that support for them is still highly variable.  However,
- since the latter are of the form uint<nn>_t, a regular expression search
- and replace (in VC++ search on 'uint_{:z}t' and replace with 'uint\1_t')
- can be used to convert the types used here to the C99 standard types.
-
- Source code origin listed in README file.
+This software is provided 'as is' with no explicit or implied warranties
+in respect of its operation, including, but not limited to, correctness
+and fitness for purpose.
+---------------------------------------------------------------------------
+Issue Date: 30/09/2017
 */
 
-#ifndef BRG_TYPES_H
-#define BRG_TYPES_H
+#ifndef _BRG_TYPES_H
+#define _BRG_TYPES_H
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
 #include <limits.h>
-
-/* Try one of these if things don't work automatically */
-#ifdef BRG_C99_TYPES
-#include <inttypes.h>
 #include <stdint.h>
-#  define BRG_UI8
-     typedef uint8_t uint_8t;
-#  define BRG_UI16
-     typedef uint16_t uint_16t;
-#  define BRG_UI32
-#    define li_32(h) 0x##h##u
-     typedef uint32_t uint_32t;
-#  define BRG_UI64
+
+#if defined( _MSC_VER ) && ( _MSC_VER >= 1300 )
+#  include <stddef.h>
+#  define ptrint_t intptr_t
+#elif defined( __ECOS__ )
+#  define intptr_t unsigned int
+#  define ptrint_t intptr_t
+#elif defined( __GNUC__ ) && ( __GNUC__ >= 3 ) && !(defined( __HAIKU__ ) || defined( __VxWorks__ ))
+#  define ptrint_t intptr_t
+#else
+#  define ptrint_t int
+#endif
+
+/* define unsigned 8-bit type if not available in stdint.h */
+#if !defined(UINT8_MAX)
+  typedef unsigned char uint8_t;
+#endif
+
+/* define unsigned 16-bit type if not available in stdint.h */
+#if !defined(UINT16_MAX)
+  typedef unsigned short uint16_t;
+#endif
+
+/* define unsigned 32-bit type if not available in stdint.h and define the
+   macro li_32(h) which converts a sequence of eight hexadecimal characters
+   into a 32 bit constant 
+*/
+#if defined(UINT_MAX) && UINT_MAX == 4294967295u
+#  define li_32(h) 0x##h##u
+#  if !defined(UINT32_MAX)
+     typedef unsigned int uint32_t;
+#  endif
+#elif defined(ULONG_MAX) && ULONG_MAX == 4294967295u
+#  define li_32(h) 0x##h##ul
+#  if !defined(UINT32_MAX)
+     typedef unsigned long uint32_t;
+#  endif
+#elif defined( _CRAY )
+#  error This code needs 32-bit data types, which Cray machines do not provide
+#else
+#  error Please define uint32_t as a 32-bit unsigned integer type in brg_types.h
+#endif
+
+/* define unsigned 64-bit type if not available in stdint.h and define the
+   macro li_64(h) which converts a sequence of eight hexadecimal characters
+   into a 64 bit constant 
+*/
+#if defined( __BORLANDC__ ) && !defined( __MSDOS__ )
+#  define li_64(h) 0x##h##ui64
+#  if !defined(UINT64_MAX)
+     typedef unsigned __int64 uint64_t;  
+#  endif
+#elif defined( _MSC_VER ) && ( _MSC_VER < 1300 )    /* 1300 == VC++ 7.0 */
+#  define li_64(h) 0x##h##ui64
+#  if !defined(UINT64_MAX)
+     typedef unsigned __int64 uint64_t;
+#  endif
+#elif defined( __sun ) && defined( ULONG_MAX ) && ULONG_MAX == 0xfffffffful
+#  define li_64(h) 0x##h##ull
+#  if !defined(UINT64_MAX)
+     typedef unsigned long long uint64_t;
+#  endif
+#elif defined( __MVS__ )
+#  define li_64(h) 0x##h##ull
+#  if !defined(UINT64_MAX)
+     typedef unsigned long long uint64_t;
+#  endif
+#elif defined( UINT_MAX ) && UINT_MAX > 4294967295u
+#  if UINT_MAX == 18446744073709551615u
 #    define li_64(h) 0x##h##u
-     typedef uint64_t uint_64t;
-
-#elif defined( BRG_STD_TYPES )
-#include <sys/types.h>
-#  define BRG_UI8
-     typedef u_int8_t uint_8t;
-#  define BRG_UI16
-     typedef u_int16_t uint_16t;
-#  define BRG_UI32
-#    define li_32(h) 0x##h##u
-     typedef u_int32_t uint_32t;
-#  define BRG_UI64
-#    define li_64(h) 0x##h##u
-     typedef u_int64_t uint_64t;
-
-#endif
-
-#ifndef BRG_UI8
-#  define BRG_UI8
-#  if UCHAR_MAX == 255u
-     typedef unsigned char uint_8t;
-#  else
-#    error Please define uint_8t as an 8-bit unsigned integer type in brg_types.h
+#    if !defined(UINT64_MAX)
+       typedef unsigned int uint64_t;
+#    endif
 #  endif
-#endif
-
-#ifndef BRG_UI16
-#  define BRG_UI16
-#  if USHRT_MAX == 65535u
-     typedef unsigned short uint_16t;
-#  else
-#    error Please define uint_16t as a 16-bit unsigned short type in brg_types.h
+#elif defined( ULONG_MAX ) && ULONG_MAX > 4294967295u
+#  if ULONG_MAX == 18446744073709551615ul
+#    define li_64(h) 0x##h##ul
+#    if !defined(UINT64_MAX) && !defined(_UINT64_T)
+       typedef unsigned long uint64_t;
+#    endif
 #  endif
-#endif
-
-#ifndef BRG_UI32
-#  define BRG_UI32
-#  if UINT_MAX == 4294967295u
-#    define li_32(h) 0x##h##u
-     typedef unsigned int uint_32t;
-#  elif ULONG_MAX == 4294967295u
-#    define li_32(h) 0x##h##ul
-     typedef unsigned long uint_32t;
-#  elif defined( _CRAY )
-#    error This code needs 32-bit data types, which Cray machines do not provide
-#  else
-#    error Please define uint_32t as a 32-bit unsigned integer type in brg_types.h
-#  endif
-#endif
-
-#ifndef BRG_UI64
-#  if defined( __BORLANDC__ ) && !defined( __MSDOS__ )
-#    define BRG_UI64
+#elif defined( ULLONG_MAX ) && ULLONG_MAX > 4294967295u
+#  if ULLONG_MAX == 18446744073709551615ull
 #    define li_64(h) 0x##h##ull
-     typedef unsigned __int64 uint_64t;
-#  elif defined( _MSC_VER ) && ( _MSC_VER < 1300 )    /* 1300 == VC++ 7.0 */
-#    define BRG_UI64
-#    define li_64(h) 0x##h##ui64
-     typedef unsigned __int64 uint_64t;
-#  elif defined( __sun ) && defined(ULONG_MAX) && ULONG_MAX == 0xfffffffful
-#    define BRG_UI64
+#    if !defined(UINT64_MAX) && !defined( __HAIKU__ )
+       typedef unsigned long long uint64_t;
+#    endif
+#  endif
+#elif defined( ULONG_LONG_MAX ) && ULONG_LONG_MAX > 4294967295u
+#  if ULONG_LONG_MAX == 18446744073709551615ull
 #    define li_64(h) 0x##h##ull
-     typedef unsigned long long uint_64t;
-#  elif defined( UINT_MAX ) && UINT_MAX > 4294967295u
-#    if UINT_MAX == 18446744073709551615u
-#      define BRG_UI64
-#      define li_64(h) 0x##h##u
-       typedef unsigned int uint_64t;
-#    endif
-#  elif defined( ULONG_MAX ) && ULONG_MAX > 4294967295u
-#    if ULONG_MAX == 18446744073709551615ul
-#      define BRG_UI64
-#      define li_64(h) 0x##h##ul
-       typedef unsigned long uint_64t;
-#    endif
-#  elif defined( ULLONG_MAX ) && ULLONG_MAX > 4294967295u
-#    if ULLONG_MAX == 18446744073709551615ull
-#      define BRG_UI64
-#      define li_64(h) 0x##h##ull
-       typedef unsigned long long uint_64t;
-#    endif
-#  elif defined( ULONG_LONG_MAX ) && ULONG_LONG_MAX > 4294967295u
-#    if ULONG_LONG_MAX == 18446744073709551615ull
-#      define BRG_UI64
-#      define li_64(h) 0x##h##ull
-       typedef unsigned long long uint_64t;
+#    if !defined(UINT64_MAX)
+       typedef unsigned long long uint64_t;
 #    endif
 #  endif
 #endif
 
-#if defined( NEED_UINT_64T ) && !defined( BRG_UI64 )
-#  error Please define uint_64t as an unsigned 64 bit type in brg_types.h
+#if !defined( li_64 )
+#  if defined( NEED_UINT_64T )
+#    error Please define uint64_t as an unsigned 64 bit type in brg_types.h
+#  endif
 #endif
 
 #ifndef RETURN_VALUES
@@ -188,26 +161,54 @@ extern "C" {
 #  endif
 #endif
 
+/*	These defines are used to detect and set the memory alignment of pointers.
+    Note that offsets are in bytes.
+
+    ALIGN_OFFSET(x,n)			return the positive or zero offset of 
+                                the memory addressed by the pointer 'x' 
+                                from an address that is aligned on an 
+                                'n' byte boundary ('n' is a power of 2)
+
+    ALIGN_FLOOR(x,n)			return a pointer that points to memory
+                                that is aligned on an 'n' byte boundary 
+                                and is not higher than the memory address
+                                pointed to by 'x' ('n' is a power of 2)
+
+    ALIGN_CEIL(x,n)				return a pointer that points to memory
+                                that is aligned on an 'n' byte boundary 
+                                and is not lower than the memory address
+                                pointed to by 'x' ('n' is a power of 2)
+*/
+
+#define ALIGN_OFFSET(x,n)	(((ptrint_t)(x)) & ((n) - 1))
+#define ALIGN_FLOOR(x,n)	((uint8_t*)(x) - ( ((ptrint_t)(x)) & ((n) - 1)))
+#define ALIGN_CEIL(x,n)		((uint8_t*)(x) + (-((ptrint_t)(x)) & ((n) - 1)))
+
 /*  These defines are used to declare buffers in a way that allows
     faster operations on longer variables to be used.  In all these
-    defines 'size' must be a power of 2 and >= 8
+    defines 'size' must be a power of 2 and >= 8. NOTE that the 
+    buffer size is in bytes but the type length is in bits
 
-    dec_unit_type(size,x)       declares a variable 'x' of length 
+    UNIT_TYPEDEF(x,size)        declares a variable 'x' of length 
                                 'size' bits
 
-    dec_bufr_type(size,bsize,x) declares a buffer 'x' of length 'bsize' 
+    BUFR_TYPEDEF(x,size,bsize)  declares a buffer 'x' of length 'bsize' 
                                 bytes defined as an array of variables
                                 each of 'size' bits (bsize must be a 
                                 multiple of size / 8)
 
-    ptr_cast(x,size)            casts a pointer to a pointer to a 
-                                varaiable of length 'size' bits
+    UNIT_CAST(x,size)           casts a variable to a type of 
+                                length 'size' bits
+
+    UPTR_CAST(x,size)           casts a pointer to a pointer to a 
+                                variable of length 'size' bits
 */
 
-#define ui_type(size)               uint_##size##t
-#define dec_unit_type(size,x)       typedef ui_type(size) x
-#define dec_bufr_type(size,bsize,x) typedef ui_type(size) x[bsize / (size >> 3)]
-#define ptr_cast(x,size)            ((ui_type(size)*)(x))
+#define UI_TYPE(size)               uint##size##_t
+#define UNIT_TYPEDEF(x,size)        typedef UI_TYPE(size) x
+#define BUFR_TYPEDEF(x,size,bsize)  typedef UI_TYPE(size) x[bsize / (size >> 3)]
+#define UNIT_CAST(x,size)           ((UI_TYPE(size) )(x))  
+#define UPTR_CAST(x,size)           ((UI_TYPE(size)*)(x))
 
 #if defined(__cplusplus)
 }

--- a/test/studies/uts/rng_brg.c
+++ b/test/studies/uts/rng_brg.c
@@ -1,0 +1,78 @@
+#include <stdio.h>
+
+#include "brg_sha1.h"
+#include "rng_brg.h"
+
+void rng_init(RNG_state *newstate, int seed)
+{
+  sha1_ctx ctx;
+  struct state_t gen;
+  int i;
+
+  for (i=0; i < 16; i++) 
+    gen.state[i] = 0;
+  gen.state[16] = 0xFF & (seed >> 24);
+  gen.state[17] = 0xFF & (seed >> 16);
+  gen.state[18] = 0xFF & (seed >> 8);
+  gen.state[19] = 0xFF & (seed >> 0);
+  
+  sha1_begin(&ctx);
+  sha1_hash(gen.state, 20, &ctx);
+  sha1_end(newstate, &ctx);
+}
+
+void rng_spawn(RNG_state *mystate, RNG_state *newstate, int spawnnumber)
+{
+	sha1_ctx ctx;
+	uint8_t  bytes[4];
+	
+	bytes[0] = 0xFF & (spawnnumber >> 24u);
+	bytes[1] = 0xFF & (spawnnumber >> 16u);
+	bytes[2] = 0xFF & (spawnnumber >> 8u);
+	bytes[3] = 0xFF & spawnnumber;
+	
+	sha1_begin(&ctx);
+	sha1_hash(mystate, 20, &ctx);
+	sha1_hash(bytes, 4, &ctx);
+	sha1_end(newstate, &ctx);
+}
+
+int rng_rand(RNG_state *mystate){
+        int r;
+	uint32_t b =  ((uint32_t)mystate[16] << (uint32_t)24u) | ((uint32_t)mystate[17] << (uint32_t)16u)
+		| ((uint32_t)mystate[18] << (uint32_t)8u) | ((uint32_t)mystate[19] << (uint32_t)0u);
+	b = b & POS_MASK;
+	
+	r = (int) b;
+	return r;
+}
+
+int rng_nextrand(RNG_state *mystate){
+	sha1_ctx ctx;
+	int r;
+	uint32_t b;
+
+	sha1_begin(&ctx);
+	sha1_hash(mystate, 20, &ctx);
+	sha1_end(mystate, &ctx);
+	b =  (mystate[16] << 24u) | (mystate[17] << 16u)
+		| (mystate[18] << 8u) | (mystate[19] << 0u);
+	b = b & POS_MASK;
+	
+	r = (int) b;
+	return r;
+}
+
+/* condense state into string to display during debugging */
+char * rng_showstate(RNG_state *state, char *s){
+  sprintf(s,"%.2X%.2X...", state[0],state[1]);
+  return s;
+}
+
+/* describe random number generator type into string */
+int rng_showtype(char *strBuf, int ind) {
+  ind += sprintf(strBuf+ind, "SHA-1 (state size = %uB)",
+                 (unsigned) sizeof(struct state_t));
+  return ind;
+}
+

--- a/test/studies/uts/rng_brg.h
+++ b/test/studies/uts/rng_brg.h
@@ -1,0 +1,28 @@
+#ifndef RNG_BRG_H
+#define RNG_BRG_H
+
+#include "brg_sha1.h"
+
+#define POS_MASK    0x7fffffff
+#define HIGH_BITS   0x80000000
+
+/**********************************/
+/* random number generator state  */
+/**********************************/
+struct state_t {
+  uint8_t state[20];
+};
+
+typedef uint8_t RNG_state;
+
+/***************************************/
+/* random number generator operations  */
+/***************************************/
+void   rng_init(RNG_state *state, int seed);
+void   rng_spawn(RNG_state *mystate, RNG_state *newstate, int spawnNumber);
+int    rng_rand(RNG_state *mystate);
+int    rng_nextrand(RNG_state *mystate);
+char * rng_showstate(RNG_state *state, char *s);
+int    rng_showtype(char *strBuf, int ind);
+
+#endif


### PR DESCRIPTION
Updates the locally vendored brg_sha.c to a newer version. This is only used by a handful of tests, but they tripped some new undefined behavior testing. It turns out, qthreads vendors these and uses them too, and they have a newer version. Just updating to that newer version from qthreads resolves the issues, so I have done that in this PR

[Not reviewed - trivial]