### PR TITLE
Ensure chpl_bool defaults to false

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -901,6 +901,8 @@ void VarSymbol::codegenDefC(bool global, bool isHeader) {
         str += " = {CHPL_LOCALEID_T_INIT, NULL}";
       }
     }
+  } else if (isBoolType(type) && isFnSymbol(defPoint->parentSymbol)) {
+    str += " = false";
   }
 
   if (fGenIDS)


### PR DESCRIPTION
Adjusts the compiler to codegen chpl_bool local variables to false.

In some cases, an early return due to a thrown error could cause a function to return a bool value that had not yet been initialized, which was filled with garbage and tripped an undefined behavior sanitizer.

[Reviewed by @arifthpe]