### PR TITLE
Prevent taking a reference to a nullptr in frontend

### DIFF
--- a/frontend/include/chpl/resolution/ResolutionContext.h
+++ b/frontend/include/chpl/resolution/ResolutionContext.h
@@ -269,7 +269,8 @@ class ResolutionContext {
   }
   template <typename T>
   bool canUseGlobalCacheConsidering(const T* t) const {
-    return canUseGlobalCacheConsidering(*t);
+    if (!isUnstable()) return true;
+    return ResolutionContext::canUseGlobalCache(context_, t);
   }
   template <typename... Ts>
   bool canUseGlobalCacheConsidering(const std::tuple<Ts...>& ts) {


### PR DESCRIPTION
Adjusts some frontend compiler code to avoid potential nullptr dereferencing and subsequent taking a reference to a nullptr.

[Reviewed by @benharsh]