### PR TITLE
Allow suppressing `check_large_files` via PR label

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,6 +150,7 @@ jobs:
     - name: smokeTest lint
       run: |
         ./util/buildRelease/smokeTest lint
+
   check_large_files:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -154,6 +154,8 @@ jobs:
   check_large_files:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      IGNORE_LABEL: "large files ok"
     steps:
       - name: count PR commits
         run: echo "PR_NUM_COMMITS=$(( ${{ github.event.pull_request.commits }} + 2 ))" >> "${GITHUB_ENV}"
@@ -164,7 +166,6 @@ jobs:
       - name: check commits for large files
         run: |
           FILE_SIZE_LIMIT_KB=1024
-          IGNORE_LABEL="large files ok"
 
           baseSHA=${{github.event.pull_request.base.sha}}
           headSHA=${{github.event.pull_request.head.sha}}
@@ -208,10 +209,10 @@ jobs:
           done
 
           if [ "$errorCount" -gt 0 ]; then
-            if [ ${{ contains(github.event.*.labels.*.name, $IGNORE_LABEL) }} = "true" ]; then
-              echo "Ignoring errors due to '$IGNORE_LABEL' label presence"
+            if [ ${{ contains(github.event.*.labels.*.name, env.IGNORE_LABEL) }} = "true" ]; then
+              echo "Ignoring errors due to '${{ env.IGNORE_LABEL }}' label presence"
             else
-              echo "If you want to ignore errors for this PR, add the label '$IGNORE_LABEL', then close and reopen the PR"
+              echo "If you want to ignore errors for this PR, add the label '${{ env.IGNORE_LABEL }}', then close and reopen the PR"
               exit 1
             fi
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -210,6 +210,7 @@ jobs:
             if [ ${{ contains(github.event.*.labels.*.name, 'large files ok') }} = "true" ]; then
               echo "Ignoring errors due to 'large files ok' label presence"
             else
+              echo "If you want to ignore errors for this PR, add the label 'large files ok', then close and reopen the PR"
               exit 1
             fi
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -175,6 +175,7 @@ jobs:
           # Loop backward through commits added in the PR, starting from the
           # latest.
           commitIdx=0
+          errorCount=0
           for commit in $(git rev-list $baseSHA..$headSHA)
           do
             echo "Checking commit: $commit"
@@ -193,11 +194,7 @@ jobs:
 
               if [ "$file_size_kb" -ge "$FILE_SIZE_LIMIT_KB" ]; then
                 echo "Error: ${file} is too large (size ${file_size_kb}KB, limit ${FILE_SIZE_LIMIT_KB}KB). Introduced in commit: $commit"
-                if [ ${{ contains(github.event.*.labels.*.name, 'large files ok') }} = "true" ]; then
-                  echo "Ignoring error due to 'large files ok' label presence"
-                  break
-                fi
-                exit 1
+                errorCount=$((errorCount+1))
               fi
             done <<< "$newFiles"
 
@@ -208,6 +205,14 @@ jobs:
               break
             fi
           done
+
+          if [ "$errorCount" -gt 0 ]; then
+            if [ ${{ contains(github.event.*.labels.*.name, 'large files ok') }} = "true" ]; then
+              echo "Ignoring errors due to 'large files ok' label presence"
+            else
+              exit 1
+            fi
+          fi
 
   publish-docs:
     if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -164,6 +164,7 @@ jobs:
       - name: check commits for large files
         run: |
           FILE_SIZE_LIMIT_KB=1024
+          IGNORE_LABEL="large files ok"
 
           baseSHA=${{github.event.pull_request.base.sha}}
           headSHA=${{github.event.pull_request.head.sha}}
@@ -207,10 +208,10 @@ jobs:
           done
 
           if [ "$errorCount" -gt 0 ]; then
-            if [ ${{ contains(github.event.*.labels.*.name, 'large files ok') }} = "true" ]; then
-              echo "Ignoring errors due to 'large files ok' label presence"
+            if [ ${{ contains(github.event.*.labels.*.name, $IGNORE_LABEL) }} = "true" ]; then
+              echo "Ignoring errors due to '$IGNORE_LABEL' label presence"
             else
-              echo "If you want to ignore errors for this PR, add the label 'large files ok', then close and reopen the PR"
+              echo "If you want to ignore errors for this PR, add the label '$IGNORE_LABEL', then close and reopen the PR"
               exit 1
             fi
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,7 +152,7 @@ jobs:
         ./util/buildRelease/smokeTest lint
 
   check_large_files:
-    if: ${{ github.event_name == 'pull_request' && !contains(github.event.*.labels.*.name, 'large files ok') }}
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: count PR commits
@@ -193,6 +193,10 @@ jobs:
 
               if [ "$file_size_kb" -ge "$FILE_SIZE_LIMIT_KB" ]; then
                 echo "Error: ${file} is too large (size ${file_size_kb}KB, limit ${FILE_SIZE_LIMIT_KB}KB). Introduced in commit: $commit"
+                if [ ${{ contains(github.event.*.labels.*.name, 'large files ok') }} = "true" ]; then
+                  echo "Ignoring error due to 'large files ok' label presence"
+                  break
+                fi
                 exit 1
               fi
             done <<< "$newFiles"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,7 +152,7 @@ jobs:
         ./util/buildRelease/smokeTest lint
 
   check_large_files:
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.*.labels.*.name, 'large files ok') }}
     runs-on: ubuntu-latest
     steps:
       - name: count PR commits


### PR DESCRIPTION
Make the `check_large_files` GA check pass no matter what (still printing would-be failures) if the new `large files ok` label is set on the PR.

As this workflow is triggered on the `pull_request` event, and adding/removing labels does not fire a new such event, one needs to close+reopen the PR after adding/removing the label for the job to pick it up. This should be a rare enough occasion that I think that's acceptable.

While here, also change the behavior of this check to print all offending files (not just the first) -- whether or not the failure will be suppressed.

Part of https://github.com/cray/chapel-private/issues/7743.

[reviewed by @jabraham17 , thanks!]

Testing:
- [x] job still correctly fails for large file added and subsequently removed
- [x] correct failure is suppressed if PR has label