### PR TITLE
Fix UB from doing pointer math on a NULL pointer

### DIFF
--- a/runtime/src/config.c
+++ b/runtime/src/config.c
@@ -534,8 +534,8 @@ void parseConfigFile(const char* configFilename,
           handleUnexpectedConfigVar(moduleName, varName, 0,
                                     CHPL_FILE_IDX_SAVED_FILENAME);
         } else {
-          char* value = equalsSign + 1;
-          if (equalsSign && *value) {
+          char* value = equalsSign ? equalsSign + 1 : NULL;
+          if (value && *value) {
             initSetValue(varName, value, moduleName, 0,
                          CHPL_FILE_IDX_SAVED_FILENAME);
           } else {


### PR DESCRIPTION
Fixes potential UB when doing pointer math on a NULL pointer

This is the same change as https://github.com/chapel-lang/chapel/pull/28908, just made in another place

[Reviewed by @arifthpe]