### PR TITLE
Limit CI workflow permissions to read-only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,21 @@ jobs:
       run: |
         ./util/buildRelease/smokeTest chpl
 
+  test-make_doc:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - name: test upload docs
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: readme
+        path: README.rst
+
   make_doc:
     runs-on: ubuntu-latest
     container:
@@ -220,6 +235,21 @@ jobs:
               exit 1
             fi
           fi
+
+  test-publish-docs:
+    runs-on: ubuntu-latest
+    needs: test-make_doc
+    steps:
+      - name: test download artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: readme
+      - name: read artifact
+        run: |
+          cat README.rst
+      - name: check accessing secret
+        run: |
+          echo "${{ secrets.WEBSITE_KEY }}" > /dev/null
 
   publish-docs:
     if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
+  packages: read
 
 env:
   NIGHTLY_TEST_SETTINGS: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -222,7 +222,7 @@ jobs:
     steps:
       - name: test reading secret
         run: |
-          echo "${{ secrets.NONEXISTENT }}" > /dev/null
+          echo "${{ secrets.WEBSITE_KEY }}" > /dev/null
 
   publish-docs:
     if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   NIGHTLY_TEST_SETTINGS: true
 
@@ -216,13 +220,6 @@ jobs:
               exit 1
             fi
           fi
-
-  test-access-secret:
-    runs-on: ubuntu-latest
-    steps:
-      - name: test reading secret
-        run: |
-          echo "${{ secrets.WEBSITE_KEY }}" > /dev/null
 
   publish-docs:
     if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions: read-all
 
 env:
   NIGHTLY_TEST_SETTINGS: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,10 +5,6 @@ on:
     branches: [ main ]
   pull_request:
 
-permissions:
-  contents: read
-  packages: read
-
 env:
   NIGHTLY_TEST_SETTINGS: true
 
@@ -220,6 +216,13 @@ jobs:
               exit 1
             fi
           fi
+
+  test-access-secret:
+    runs-on: ubuntu-latest
+    steps:
+      - name: test reading secret
+        run: |
+          echo "${{ secrets.WEBSITE_KEY }}" > /dev/null
 
   publish-docs:
     if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -222,7 +222,7 @@ jobs:
     steps:
       - name: test reading secret
         run: |
-          echo "${{ secrets.WEBSITE_KEY }}" > /dev/null
+          echo "${{ secrets.NONEXISTENT }}" > /dev/null
 
   publish-docs:
     if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,21 +34,6 @@ jobs:
       run: |
         ./util/buildRelease/smokeTest chpl
 
-  test-make_doc:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
-    steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-    - name: test upload docs
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: readme
-        path: README.rst
-
   make_doc:
     runs-on: ubuntu-latest
     container:
@@ -235,21 +220,6 @@ jobs:
               exit 1
             fi
           fi
-
-  test-publish-docs:
-    runs-on: ubuntu-latest
-    needs: test-make_doc
-    steps:
-      - name: test download artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: readme
-      - name: read artifact
-        run: |
-          cat README.rst
-      - name: check accessing secret
-        run: |
-          echo "${{ secrets.WEBSITE_KEY }}" > /dev/null
 
   publish-docs:
     if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'


### PR DESCRIPTION
Restrict the CI workflow to have only the `contents` and `packages` permissions (set to `read`), with all other permissions removed.

This is to limit the potential damage if an action we rely on is compromised.

See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions for the meaning of these.

Note to reviewer:
- Review changes as a whole.
- I am not sure if the `publish-docs` job will work properly with this change, but can't test it without merging to `main`. I verified artifact uploads and downloads work, so the remaining question is if `secrets` access will. In my test jobs, accessing a nonexistent secret looked the same in logs as accessing the actual secret to push docs, and both succeeded, so I don't know how to test it.

[reviewed by @jabraham17 , thanks!]

Testing:
- [x] all CI jobs run successfully
- [x] uploading and downloading artifacts still works