### PR TITLE
Adjusts Immediate to make compiler debugging easier

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -480,6 +480,8 @@ llvm::Value* codegenImmediateLLVM(Immediate* i)
       ret = info->irBuilder->CreateGlobalString(newString);
       trackLLVMValue(ret);
       break;
+    default:
+      INT_ASSERT("Unsupported immediate type");
   }
 
   return ret;

--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -471,7 +471,7 @@ llvm::Value* codegenImmediateLLVM(Immediate* i)
           INT_ASSERT("unsupported complex floating point width");
       }
       break;
-    case CONST_KIND_STRING:
+    case CONST_KIND_STRING: {
       // Note that string immediate values are stored
       // with C escapes - that is newline is 2 chars \ n
       // so we have to convert to a sequence of bytes
@@ -480,6 +480,7 @@ llvm::Value* codegenImmediateLLVM(Immediate* i)
       ret = info->irBuilder->CreateGlobalString(newString);
       trackLLVMValue(ret);
       break;
+    }
     default:
       INT_ASSERT("Unsupported immediate type");
   }

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -997,7 +997,7 @@ static bool handleNumericUnaryPrefixExpr(const MacroInfo* inMacro,
     if (got == false || tmpCastToTy != NULL)
       return false;
 
-    int p = 0;
+    auto p = chpl::uast::primtags::PrimitiveTag::PRIM_UNKNOWN;
     switch (start->getKind()) {
       case tok::plus:   p = P_prim_plus;    break;
       case tok::minus:  p = P_prim_minus;   break;
@@ -1182,7 +1182,7 @@ static bool handleNumericBinOpExpr(const MacroInfo* inMacro,
     return false;
 
   // Apply the binary operator to the immediate
-  int p = 0;
+  auto p = chpl::uast::primtags::PrimitiveTag::PRIM_UNKNOWN;
   switch (op->getKind()) {
     case tok::lessless:   p = P_prim_lsh;    break;
     default:

--- a/frontend/lib/immediates/num.cpp
+++ b/frontend/lib/immediates/num.cpp
@@ -156,6 +156,7 @@ snprint_imm(char *str, size_t max, const Immediate &imm) {
       res = snprintf(str, max, fmt, imm.v_string.c_str());
       break;
     }
+    default: CHPL_ASSERT(false && "Unhandled case in switch statement");
   }
   return res;
 }
@@ -374,6 +375,7 @@ coerce_immediate(chpl::Context* context, Immediate *from, Immediate *to) {
             default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
           } \
           break; \
+        default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 #define COMPUTE_INT_POW(type, b, e)                      \
@@ -500,6 +502,7 @@ coerce_immediate(chpl::Context* context, Immediate *from, Immediate *to) {
       case NUM_KIND_IMAG: case NUM_KIND_COMPLEX:                        \
           CHPL_ASSERT(false && "Cannot fold ** on floating point values"); \
           break; \
+      default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 static void doFoldSqrt(chpl::Context* context,
@@ -557,6 +560,7 @@ static void doFoldSqrt(chpl::Context* context,
         default: CHPL_ASSERT(false && "Unhandled case in switch statement");
       }
       break;
+    default: CHPL_ASSERT(false && "Unhandled case in switch statement");
   }
 }
 
@@ -625,6 +629,7 @@ static void doFoldAbs(chpl::Context* context,
         default: CHPL_ASSERT(false && "Unhandled case in switch statement");
       }
       break;
+    default: CHPL_ASSERT(false && "Unhandled case in switch statement");
   }
 }
 
@@ -643,6 +648,7 @@ static void doFoldGetReal(chpl::Context* context,
         default: CHPL_ASSERT(false && "Unhandled case in switch statement");
       }
       break;
+    default: CHPL_ASSERT(false && "Unhandled case in switch statement");
   }
 }
 
@@ -661,6 +667,7 @@ static void doFoldGetImag(chpl::Context* context,
         default: CHPL_ASSERT(false && "Unhandled case in switch statement");
       }
       break;
+    default: CHPL_ASSERT(false && "Unhandled case in switch statement");
   }
 }
 
@@ -726,6 +733,7 @@ static void doFoldGetImag(chpl::Context* context,
             default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
           } \
           break; \
+        default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 #define DO_FOLDI(_op) \
@@ -765,6 +773,7 @@ static void doFoldGetImag(chpl::Context* context,
         } \
         case NUM_KIND_REAL: case NUM_KIND_IMAG: case NUM_KIND_COMPLEX: \
           CHPL_ASSERT(false && "Unhandled case in switch statement"); \
+        default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 #define DO_FOLD1(_op) \
@@ -824,6 +833,7 @@ static void doFoldGetImag(chpl::Context* context,
             default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
           } \
           break; \
+        default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 #define DO_FOLD1I(_op) \
@@ -864,6 +874,7 @@ static void doFoldGetImag(chpl::Context* context,
         case NUM_KIND_REAL: case NUM_KIND_IMAG: case NUM_KIND_COMPLEX: \
           CHPL_ASSERT(false && "Unhandled case in switch statement"); \
           break; \
+        default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 static int

--- a/frontend/lib/immediates/num.cpp
+++ b/frontend/lib/immediates/num.cpp
@@ -1015,7 +1015,7 @@ fold_result(Immediate *im1, Immediate *im2, Immediate *imm) {
 }
 
 void
-fold_constant(chpl::Context* context, int op,
+fold_constant(chpl::Context* context, chpl::uast::primtags::PrimitiveTag op,
               Immediate *aim1, Immediate *aim2, Immediate *imm) {
 
   Immediate im1(*aim1), im2, coerce;

--- a/frontend/lib/immediates/num.h
+++ b/frontend/lib/immediates/num.h
@@ -111,10 +111,10 @@ class Immediate { public:
   // readable enum)
   union {
     uint8_t          num_index;
-    IF1_bool_type    boolIndex;
-    IF1_int_type     intIndex;
-    IF1_float_type   floatIndex;
-    IF1_complex_type complexIndex;
+    IF1_bool_type    _boolIndex;
+    IF1_int_type     _intIndex;
+    IF1_float_type   _floatIndex;
+    IF1_complex_type _complexIndex;
   };
   union {
     // Unions are initialized based off the first element, so we need to have

--- a/frontend/lib/immediates/num.h
+++ b/frontend/lib/immediates/num.h
@@ -23,6 +23,7 @@
 
 #include "chpl/framework/Context.h"
 #include "chpl/framework/UniqueString.h"
+#include "chpl/uast/PrimOp.h"
 
 extern "C" {
   #include "complex-support.h"
@@ -45,18 +46,14 @@ extern unsigned int open_hash_multipliers[256];
 
 using ImmString = chpl::detail::PODUniqueString;
 
-//
-// NOTE: NUM_KIND_LAST is used to mark the last entry in this enum. The
-// 'IF1_const_kind' enum below uses it to set values.
-//
-enum IF1_num_kind : uint8_t {
-  NUM_KIND_NONE, NUM_KIND_BOOL, NUM_KIND_UINT, NUM_KIND_INT, NUM_KIND_REAL,
-  NUM_KIND_IMAG, NUM_KIND_COMPLEX, NUM_KIND_COMMID, NUM_KIND_LAST
-};
 
 enum IF1_const_kind : uint8_t {
-  CONST_KIND_STRING = NUM_KIND_LAST + 1, CONST_KIND_SYMBOL
+  NUM_KIND_NONE, NUM_KIND_BOOL, NUM_KIND_UINT, NUM_KIND_INT, NUM_KIND_REAL,
+  NUM_KIND_IMAG, NUM_KIND_COMPLEX, NUM_KIND_COMMID,
+  CONST_KIND_STRING, CONST_KIND_SYMBOL
 };
+// maintain old name for backwards compatibility
+using IF1_num_kind = IF1_const_kind;
 
 enum IF1_string_kind : uint8_t {
   STRING_KIND_STRING,
@@ -106,7 +103,7 @@ namespace chpl {
 namespace types {
 
 class Immediate { public:
-  uint8_t const_kind;
+  IF1_const_kind const_kind;
   IF1_string_kind string_kind;
   uint8_t num_index;
   union {
@@ -387,7 +384,7 @@ int fprint_imm(FILE *fp, const Immediate &imm, bool showType = false);
 int snprint_imm(char *s, size_t max, const Immediate &imm);
 void coerce_immediate(chpl::Context* context, Immediate *from, Immediate *to);
 void fold_result(Immediate *imm1, Immediate *imm2, Immediate *imm);
-void fold_constant(chpl::Context* context, int op,
+void fold_constant(chpl::Context* context, chpl::uast::primtags::PrimitiveTag op,
                    Immediate *im1, Immediate *im2, Immediate *imm);
 ImmString istrFromUserBool(chpl::Context* context, bool b);
 ImmString istrFromUserUint(chpl::Context* context, uint64_t i);

--- a/frontend/lib/immediates/num.h
+++ b/frontend/lib/immediates/num.h
@@ -105,7 +105,17 @@ namespace types {
 class Immediate { public:
   IF1_const_kind const_kind;
   IF1_string_kind string_kind;
-  uint8_t num_index;
+  // NOTE: only num_index is ever used! boolIndex, intIndex, floatIndex, and
+  // complexIndex are only used to make the union more readable in the debugger
+  // (so the debugger can show the value of the correct type as a human
+  // readable enum)
+  union {
+    uint8_t          num_index;
+    IF1_bool_type    boolIndex;
+    IF1_int_type     intIndex;
+    IF1_float_type   floatIndex;
+    IF1_complex_type complexIndex;
+  };
   union {
     // Unions are initialized based off the first element, so we need to have
     // the largest thing first to make sure it is all zero initialized

--- a/frontend/lib/types/Param.cpp
+++ b/frontend/lib/types/Param.cpp
@@ -599,7 +599,7 @@ QualifiedType Param::fold(Context* context,
   Immediate result;
 
   // fold
-  int immOp = op;
+  auto immOp = op;
 
   if (op == chpl::uast::PrimitiveTag::PRIM_CAST) {
     // valid param casts should always be foldable


### PR DESCRIPTION
Adjusts the definition of Immediate to make compiler debugging easier

* combines `IF1_const_kind` and `IF1_num_kind` since there is no strong reason for them to be separate
* uses the correct enum type for primitive ops instead of `int`
* adds a type-punned union for `num_index`, the other values of the union are never used but they make it possible for the debugger to interpret the enums better (this is required since we can't easily combine the various num_index enums)

This makes the debugger output easier to quickly understand

<img width="1492" height="96" alt="Screenshot 2026-07-01 at 10 24 04 AM" src="https://github.com/user-attachments/assets/b5351ccd-8fc0-4ba1-ac03-25fbb468fc68" />


[Reviewed by @benharsh]