### PR TITLE
Improve `**` on integers

### DIFF
--- a/frontend/lib/immediates/num.cpp
+++ b/frontend/lib/immediates/num.cpp
@@ -386,18 +386,18 @@ coerce_immediate(chpl::Context* context, Immediate *from, Immediate *to) {
     if (base == 1) {                                     \
       res = 1;                                           \
     } else if (base == -1) {                             \
-      res = exp % 2 == 0 ? 1 : -1;                       \
+      res = exp & 1 ? -1 : 1;                            \
     } else {                                             \
       res = 0;                                           \
     }                                                    \
   } else {                                               \
     type i = exp;                                        \
     type z = base;                                       \
-    while (i != 0) {                                     \
-      if (i % 2 == 1)                                    \
-        res *= z;                                        \
+    for (;;) {                                           \
+      if (i & 1) res *= z;                               \
+      i >>= 1;                                           \
+      if (!i) break;                                     \
       z *= z;                                            \
-      i /= 2;                                            \
     }                                                    \
   }
 
@@ -407,11 +407,11 @@ coerce_immediate(chpl::Context* context, Immediate *from, Immediate *to) {
   type res = 1;                                      \
   type i = exp;                                      \
   type z = base;                                     \
-  while (i != 0) {                                   \
-    if (i % 2 == 1)                                  \
-      res *= z;                                      \
+  for (;;) {                                         \
+    if (i & 1) res *= z;                             \
+    i >>= 1;                                         \
+    if (!i) break;                                   \
     z *= z;                                          \
-    i /= 2;                                          \
   }
 
 #define DO_FOLDPOW() \

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -890,7 +890,7 @@ module ChapelBase {
     }
     var i = b, y:a.type = 1, z = a;
     while true {
-      if i & 1 then res *= z;
+      if i & 1 then y *= z;
       i >>= 1;
       if !i then break;
       z *= z;

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -884,16 +884,16 @@ module ChapelBase {
       if a == 1 then
         return 1;
       else if a == -1 then
-        return if b % 2 == 0 then 1 else -1;
+        return if b & 1 then -1 else 1;
       else
         return 0;
     }
     var i = b, y:a.type = 1, z = a;
-    while i != 0 {
-      if i % 2 == 1 then
-        y *= z;
+    while true {
+      if (i & 1) res *= z;
+      i >>= 1;
+      if (!i) break;
       z *= z;
-      i /= 2;
     }
     return y;
   }

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -890,9 +890,9 @@ module ChapelBase {
     }
     var i = b, y:a.type = 1, z = a;
     while true {
-      if (i & 1) res *= z;
+      if i & 1 then res *= z;
       i >>= 1;
-      if (!i) break;
+      if !i then break;
       z *= z;
     }
     return y;


### PR DESCRIPTION
Improves the implementation of `**` on integers to avoid overflow and have better codegen

We have new tests flagging integer overflow on `**` (e.g., `2**62` would trigger overflow). This was because of the unconditional `2**32 * 2**32` that could occur in this case. The result was unused, but it would still trigger an overflow.

Rewriting the avoid this overflow reveals better ways to write `**`, which I did in this PR. This not only removes the overflow, but reduces the generated assembly with GCC: https://godbolt.org/z/ev1xjjWe7

- [x] paratest

[Reviewed by @arifthpe]