### PR TITLE
Work around bug in `paths-filter` action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -286,6 +286,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
+      options: --user 1001
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1


### PR DESCRIPTION
Work around https://github.com/dorny/paths-filter/issues/316 by setting the user the job's container runs as to the runner VM's `runner` user (https://github.com/actions/runner/issues/2033#issuecomment-1598547465).

Follow up to https://github.com/chapel-lang/chapel/pull/29049, which added the usage of dorny/paths-filter. This bug didn't appear for the workflow run on the PR, but did in the merge to `main` as the action works differently in that case.

[reviewed by @jabraham17 , thanks!]

Testing:
- [x] fixed issue as reproduced in separate test repo run (https://github.com/arifthpe/test/actions/runs/28538306557/job/84605271162)