### PR TITLE
Skip undefined behavior testing with revcomp9

### DIFF
--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.skipif
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8-algs.skipif
@@ -1,0 +1,4 @@
+# relies on undefined behavior
+# reinterprets uint8_t* as uint16_t*, and makes misaligned loads/stores to it
+# the original revcomp this is based on relies on the same behavior
+CHPL_SANITIZE_EXE==undefined

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8.skipif
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc-gcc8.skipif
@@ -1,0 +1,1 @@
+revcomp-blc-gcc8-algs.skipif

--- a/test/studies/shootout/reverse-complement/bradc/revcomp-blc.skipif
+++ b/test/studies/shootout/reverse-complement/bradc/revcomp-blc.skipif
@@ -1,0 +1,1 @@
+revcomp-blc-gcc8-algs.skipif

--- a/test/studies/shootout/submitted/revcomp9.skipif
+++ b/test/studies/shootout/submitted/revcomp9.skipif
@@ -1,0 +1,1 @@
+../reverse-complement/bradc/revcomp-blc-gcc8-algs.skipif


### PR DESCRIPTION
Skips UB testing with revcomp9, since it relies on UB. The original C version also relies on UB

[Not reviewed - trivial]