### PR TITLE
Prevent LICM hoisting expressions that are not guaranteed to execute

### DIFF
--- a/compiler/optimizations/loopInvariantCodeMotion.cpp
+++ b/compiler/optimizations/loopInvariantCodeMotion.cpp
@@ -1126,6 +1126,37 @@ static bool defDominatesAllExits(Loop* loop, SymExpr* def, std::vector<BitVec*>&
 }
 
 
+/*
+ * Check that a definition is guaranteed to be executed on every iteration of
+ * the loop. This is the case when the block containing the definition dominates
+ * every exit block of the loop.
+ *
+ * If a definition is only conditionally executed within the loop (for instance,
+ * an operand of a short-circuiting && or ||, which the compiler lowers into a
+ * conditional), hoisting it into the preheader would cause it to execute
+ * unconditionally. For primitives this can change program semantics or
+ * introduce undefined behavior (e.g. signed integer overflow) that would not
+ * have occurred otherwise. To avoid speculatively executing such computations,
+ * we only hoist definitions that are guaranteed to run on each iteration.
+ *
+ * See https://github.com/chapel-lang/chapel/issues/29034
+ */
+static bool defIsGuaranteedToExecute(Loop* loop, SymExpr* def, std::vector<BitVec*>& dominators, std::map<SymExpr*, int>& localMap) {
+  int defBlock = localMap[def];
+
+  BitVec* bitExits = loop->getBitExits();
+
+  for(size_t i = 0; i < bitExits->size(); i++) {
+    if(bitExits->test(i)) {
+      if(dominates(defBlock, i, dominators) == false) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+
 
 /*
  * Collects the uses and defs of symbols the baseAST
@@ -1277,10 +1308,12 @@ static void licmFn(FnSymbol* fn) {
       if(CallExpr* call = toCallExpr(symExpr->parentExpr)) {
         if(defDominatesAllUses(curLoop, symExpr, dominators, localMap, localUseMap)) {
           if(defDominatesAllExits(curLoop, symExpr, dominators, localMap)) {
-            if(defsInLoop.count(symExpr->symbol()) == 1) {
-              curLoop->insertBefore(symExpr->symbol()->defPoint);
+            if(defIsGuaranteedToExecute(curLoop, symExpr, dominators, localMap)) {
+              if(defsInLoop.count(symExpr->symbol()) == 1) {
+                curLoop->insertBefore(symExpr->symbol()->defPoint);
+              }
+              curLoop->insertBefore(call);
             }
-            curLoop->insertBefore(call);
           }
         }
       }

--- a/test/llvm/licm/dontHoistConditional.chpl
+++ b/test/llvm/licm/dontHoistConditional.chpl
@@ -1,0 +1,1 @@
+../../optimizations/licm/dontHoistConditional.chpl

--- a/test/llvm/licm/dontHoistConditional.compopts
+++ b/test/llvm/licm/dontHoistConditional.compopts
@@ -1,0 +1,1 @@
+--llvm-print-ir tester --llvm-print-ir-stage none --llvm-print-ir-file dontHoistConditional.ll --ccflags -fno-discard-value-names --no-checks

--- a/test/optimizations/licm/dontHoistConditional.chpl
+++ b/test/optimizations/licm/dontHoistConditional.chpl
@@ -1,0 +1,35 @@
+// Regression test for https://github.com/chapel-lang/chapel/issues/29034
+//
+// LICM must not hoist a loop-invariant computation that is only conditionally
+// executed within the loop.  Here `maxBytes + 5` is guarded by the
+// short-circuiting `&&` (lowered to a conditional), so hoisting it out of the
+// loop would make it execute unconditionally and can cause signed integer
+// overflow.  In contrast, `maxBytes < max(int)` is executed every iteration and
+// may be hoisted.  The prediff inspects the generated C to confirm this.
+proc tester(maxBytes, maxChars) {
+  var buffSz = 10;
+  var n = 0;
+  var nChars = 0;
+  // CHECK-LABEL: @tester
+  // CHECK: entry:
+  // CHECK: icmp slt i64 %maxBytes, 9223372036854775807
+  // CHECK phi i64
+  while nChars < maxChars {
+    var requestSz = 2*buffSz;
+    // make sure to at least request 16 bytes
+    if requestSz < n + 16 then requestSz = n + 16;
+
+    // CHECK: %[[PLUS_5:.+]] = add nsw i64 %maxBytes, 5
+    // CHECK: icmp sgt i64 %requestSz{{.*}}, %[[PLUS_5]]
+
+    // but don't ever ask for more bytes than maxBytes + 5
+    if maxBytes < max(int) && requestSz > maxBytes + 5 then
+      requestSz = maxBytes + 5;
+    nChars += requestSz;
+  }
+  return n;
+}
+config const maxBytes:int, maxChars:int;
+proc main() {
+  tester(maxBytes, maxChars);
+}

--- a/test/optimizations/licm/dontHoistConditional.compopts
+++ b/test/optimizations/licm/dontHoistConditional.compopts
@@ -1,0 +1,1 @@
+--savec gen_output

--- a/test/optimizations/licm/dontHoistConditional.good
+++ b/test/optimizations/licm/dontHoistConditional.good
@@ -1,0 +1,2 @@
+PASS: (maxBytes < max(int)) hoisted before loop
+PASS: (maxBytes + 5) kept inside loop

--- a/test/optimizations/licm/dontHoistConditional.prediff
+++ b/test/optimizations/licm/dontHoistConditional.prediff
@@ -1,0 +1,21 @@
+#!/bin/sh
+# $1 = test name, $2 = output file to be diffed against the .good file.
+#
+# Inspect the generated C for the 'tester' function to confirm that LICM:
+#   * hoisted the unconditional `maxBytes < max(int)` comparison before the loop
+#   * left the conditionally-executed `maxBytes + 5` inside the loop
+# See https://github.com/chapel-lang/chapel/issues/29034
+awk '
+  /tester_chpl\(/ { infn=1 }
+  infn && /while *\(/ { inloop=1 }
+  infn && /maxBytes.*< INT64\(9223372036854775807\)/ { if (inloop) cmpIn=1; else cmpBefore=1 }
+  infn && /maxBytes.*\+ INT64\(5\)/ { if (inloop) addIn=1; else addBefore=1 }
+  infn && /^}/ { infn=0 }
+  END {
+    if (cmpBefore && !cmpIn) print "PASS: (maxBytes < max(int)) hoisted before loop";
+    else print "FAIL: (maxBytes < max(int)) not hoisted before loop";
+    if (addIn && !addBefore) print "PASS: (maxBytes + 5) kept inside loop";
+    else print "FAIL: (maxBytes + 5) hoisted out of loop";
+  }
+' gen_output/$1.c >> $2
+rm -r gen_output

--- a/test/optimizations/licm/dontHoistConditional.skipif
+++ b/test/optimizations/licm/dontHoistConditional.skipif
@@ -1,0 +1,3 @@
+# This test inspects the generated C code, which is only produced by the
+# C backend. Skip it when compiling for the LLVM backend.
+CHPL_TARGET_COMPILER == llvm


### PR DESCRIPTION
Prevents LICM hoisting expressions that are not guaranteed to execute, as this can break semantics

This fixes #29034, where LICM speculatively hoisted loop-invariant primitive computations that were only conditionally executed inside the loop (such as an operand of a short-circuiting &&), causing them to run unconditionally and potentially trigger undefined behavior like signed integer overflow. The fix is to only hoist a definition when it dominates every loop exit, meaning it will always execute.

Two regression tests are added, one with the LLVM backend and one with the C backend

I am not entirely sure how this will affect performance. This is a pretty conservative fix, but I don't want to try and prove that a conditionally executed piece of code is safe to hoist. Arguably, no conditionally executed code can ever be safe to hoist since that changes program semantics. I hope (and suspect) we will not lose much, since the backend will also run its own LICM which probably is more aggressive than ours (and hopefully they do more work to prove the hoist is semantically sound).

- [ ] paratest

[Reviewed by @]