### PR TITLE
Prevent potential overflow in readStringImpl

### DIFF
--- a/modules/standard/IO.chpl
+++ b/modules/standard/IO.chpl
@@ -8111,7 +8111,7 @@ private proc readStringImpl(ch: fileReader, ref out_var: string, len: int(64)) :
         // make sure to at least request 16 bytes
         if requestSz < n + 16 then requestSz = n + 16;
         // but don't ever ask for more bytes than maxBytes + 5
-        if maxBytes < max(c_ssize_t) && requestSz > maxBytes + 5 then
+        if maxBytes < max(c_ssize_t) - 4 && requestSz > maxBytes + 5 then
           requestSz = maxBytes + 5;
         (buff, buffSz) = bufferEnsureSize(buff, buffSz, requestSz);
         assert(n + 5 < buffSz);


### PR DESCRIPTION
Prevent potential int overflow in readStringImpl, which could occur if `maxBytes` is `2**63 - 2`.

Resolves part of https://github.com/chapel-lang/chapel/issues/29034

[Reviewed by @benharsh]