### PR TITLE
Disable LICM for nightly UBSan testing and note in docs

### DIFF
--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -1440,7 +1440,7 @@ static ArgumentDescription arg_desc[] = {
  {"inline-iterators", ' ', NULL, "Enable [disable] iterator inlining", "n", &fNoInlineIterators, "CHPL_DISABLE_INLINE_ITERATORS", NULL},
  {"inline-iterators-yield-limit", ' ', "<limit>", "Limit number of yields permitted in inlined iterators", "I", &inline_iter_yield_limit, "CHPL_INLINE_ITER_YIELD_LIMIT", NULL},
  {"live-analysis", ' ', NULL, "Enable [disable] live variable analysis", "n", &fNoLiveAnalysis, "CHPL_DISABLE_LIVE_ANALYSIS", NULL},
- {"loop-invariant-code-motion", ' ', NULL, "Enable [disable] loop invariant code motion", "n", &fNoLoopInvariantCodeMotion, NULL, NULL},
+ {"loop-invariant-code-motion", ' ', NULL, "Enable [disable] loop invariant code motion", "n", &fNoLoopInvariantCodeMotion, "CHPL_LOOP_INVARIANT_CODE_MOTION", NULL},
  {"optimize-forall-unordered-ops", ' ', NULL, "Enable [disable] optimization of foralls to unordered operations", "n", &fNoOptimizeForallUnordered, "CHPL_DISABLE_OPTIMIZE_FORALL_UNORDERED_OPS", NULL},
  {"optimize-range-iteration", ' ', NULL, "Enable [disable] optimization of iteration over anonymous ranges", "n", &fNoOptimizeRangeIteration, "CHPL_DISABLE_OPTIMIZE_RANGE_ITERATION", NULL},
  {"optimize-loop-iterators", ' ', NULL, "Enable [disable] optimization of iterators composed of a single loop", "n", &fNoOptimizeLoopIterators, "CHPL_DISABLE_OPTIMIZE_LOOP_ITERATORS", NULL},

--- a/doc/rst/developer/bestPractices/Sanitizers.rst
+++ b/doc/rst/developer/bestPractices/Sanitizers.rst
@@ -97,3 +97,12 @@ code (including internal modules).
 
     chpl <program.chpl> --ccflags=-fsanitize=undefined --ldflags=-fsanitize=undefined
     ./<program>
+
+
+.. note::
+
+    UBSan has been found to interact poorly with some Chapel optimizations.
+    LICM (loop invariant code motion) in particular can result in
+    false positives. Nightly testing with UBSan is done with LICM disabled.
+    If you are using UBSan and seeing what looks like a false positive, try
+    disabling LICM with ``--no-loop-invariant-code-motion``.

--- a/doc/rst/usingchapel/debugging/sanitizers.rst
+++ b/doc/rst/usingchapel/debugging/sanitizers.rst
@@ -89,11 +89,19 @@ sanitizers. In particular:
 Other Sanitizers
 ----------------
 
-Currently, only AddressSanitizer is regularly tested, but the options passed to
-``CHPL_SANITIZE_EXE`` are passed directly to the backend compiler's
-``-fsanitize=`` option, so other sanitizers can be enabled. For example, to use
-C undefined behavior sanitizer and address sanitizer set
-``CHPL_SANITIZE_EXE=undefined,memory``.
+Currently, only AddressSanitizer and UndefinedBehaviorSanitizer are regularly
+tested, but the options passed to ``CHPL_SANITIZE_EXE`` are passed directly to
+the backend compiler's ``-fsanitize=`` option, so other sanitizers can be
+enabled. For example, to use C undefined behavior sanitizer and address
+sanitizer set ``CHPL_SANITIZE_EXE=undefined,memory``.
+
+.. note::
+
+   ``CHPL_SANITIZE_EXE=undefined`` can result in false positives due to
+   optimizations performed by the Chapel compiler. Specifically,
+   loop invariant code motion (LICM) can result in false positives.
+   If you are using UBSan and seeing what looks like a false positive,
+   try disabling LICM with ``--no-loop-invariant-code-motion``.
 
 
 .. TODO: tsan fails in the runtime: https://github.com/chapel-lang/chapel/issues/27670

--- a/test/llvm/licm/COMPOPTS
+++ b/test/llvm/licm/COMPOPTS
@@ -1,0 +1,1 @@
+--loop-invariant-code-motion

--- a/test/optimizations/licm/COMPOPTS
+++ b/test/optimizations/licm/COMPOPTS
@@ -1,0 +1,1 @@
+--loop-invariant-code-motion

--- a/util/cron/common-ubsan.bash
+++ b/util/cron/common-ubsan.bash
@@ -7,3 +7,7 @@ UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 export CHPL_TARGET_MEM=cstdlib
 export CHPL_HOST_MEM=cstdlib
 export CHPL_SANITIZE=undefined
+# disable licm, since this can result in false positives
+# e.g.: x < max(int) && x + 2, if `x + 2` is hoisted there will be an overflow
+# but its harmless because the result is never used.
+export CHPL_LOOP_INVARIANT_CODE_MOTION=false


### PR DESCRIPTION
Disables LICM for nightly UBSan testing due to false positives with LICM.

This is then noted in the docs for users who might want to use UBSan.

[Reviewed by @benharsh]