### PR TITLE
Source common.bash from common-darwin.bash

### DIFF
--- a/util/cron/common-darwin.bash
+++ b/util/cron/common-darwin.bash
@@ -2,6 +2,8 @@
 
 UTIL_CRON_DIR=$(cd $(dirname ${BASH_SOURCE[0]}) ; pwd)
 
+source $UTIL_CRON_DIR/common.bash
+
 # 2017-11-03: needed on chapelmac since I.T. updates on 2017-10-10
 #             known to be needed on a Macbook when connected over VPN
 export CHPL_RT_MASTERIP=127.0.0.1


### PR DESCRIPTION
Source `util/cron/common.bash` from `util/cron/common-darwin.bash`, as most of the `common-*.bash` scripts do.

This just slightly simplifies loading dependencies for `util/buildRelease/smokeTest`, where currently we explicitly source `common.bash` if not getting it transitively. I don't expect this to change any behavior, since currently every config that sources `common-darwin.bash` also sources `common.bash`.

[reviewed by @jabraham17 , thanks!]