### PR TITLE
Add chapel-code-smoke-test GA job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -361,6 +361,8 @@ jobs:
 
           if [[ "${{ matrix.config }}" == "gasnet" ]] ; then
             source ./util/cron/common-gasnet.bash
+            # Silence warnings about not using ibv despite ibv hardware presence
+            export GASNET_QUIET=yes
           fi
 
           export NIGHTLY_TEST_SETTINGS=true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -349,6 +349,26 @@ jobs:
               python3-venv \
               tzdata
           fi
+
+          if [[ "${{ matrix.config }}" == "gasnet" ]] ; then
+            sudo apt install \
+              rdma-core \
+              libibmad5 \
+              opensm \
+              ibutils \
+              infiniband-diags \
+              perftest \
+              mstflint \
+              libibverbs1 \
+              libibverbs-dev \
+              librdmacm1 \
+              libibumad3 \
+              ibverbs-providers \
+              rdmacm-utils \
+              infiniband-diags \
+              libfabric1 \
+              ibverbs-utils
+          fi
       - name: setup env and run ./util/buildRelease/smokeTest
         run: |
           set -ex

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -311,6 +311,10 @@ jobs:
             config: gasnet
     runs-on: ${{ matrix.os }}
     steps:
+      - name: print config info
+        run: |
+          echo "${{ matrix.os }}"
+          echo "${{ matrix.config }}"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: run smokeTest
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -315,10 +315,12 @@ jobs:
       - name: run smokeTest
         run: |
           if [[ "${{ matrix.os }}" == "macos*" ]] ; then
+            brew install llvm
             source ./util/cron/common-darwin.bash
           fi
 
           if [[ "${{ matrix.config }}" == "gasnet" ]] ; then
+            sudo apt install llvm llvm-dev
             source ./util/cron/common-gasnet.bash
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -328,8 +328,7 @@ jobs:
               libclang-cpp-dev \
               libedit-dev \
               llvm \
-              llvm-dev \
-              llvm-tools
+              llvm-dev
           fi
       - name: setup env and run ./util/buildRelease/smokeTest
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -318,6 +318,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: run smokeTest
         run: |
+          set -ex
+
           source ./util/cron/common.bash
 
           if [[ "${{ matrix.os }}" == "macos*" ]] ; then

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -301,6 +301,31 @@ jobs:
       run: |
         make test-chpl-language-server -j`util/buildRelease/chpl-make-cpu_count`
 
+  chapel-code-smoke-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        config: [gasnet, none]
+        exclude:
+          - os: macos-latest
+            config: gasnet
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: run smokeTest
+        run: |
+            if [[ "${{ matrix.os }}" == "macos*" ]] ; then
+              source ./util/cron/common-darwin.bash
+            fi
+
+            if [[ "${{ matrix.config }}" == "gasnet" ]] ; then
+              source ./util/cron/common-gasnet.bash
+            fi
+
+            export NIGHTLY_TEST_SETTINGS=true
+
+          ./util/buildRelease/smokeTest
+
   # This job exists to have a single check for which failure means merging
   # should be blocked, for GH required status checks purposes.
   # It runs (and fails) if any of the jobs listed in its `needs` ran and
@@ -325,6 +350,7 @@ jobs:
       - run-shellcheck
       - check-format
       - test_chpl_language_server
+      - chapel-code-smoke-test
     steps:
       - name: Fail
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -314,6 +314,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: run smokeTest
         run: |
+          source ./util/cron/common.bash
+
           if [[ "${{ matrix.os }}" == "macos*" ]] ; then
             brew install llvm
             source ./util/cron/common-darwin.bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -303,6 +303,7 @@ jobs:
 
   chapel-code-smoke-test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         config: [gasnet, none]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -322,7 +322,7 @@ jobs:
 
           source ./util/cron/common.bash
 
-          if [[ "${{ matrix.os }}" == "macos*" ]] ; then
+          if [[ "${{ matrix.os }}" == "macos"* ]] ; then
             brew install llvm
             source ./util/cron/common-darwin.bash
           else

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -319,10 +319,36 @@ jobs:
           if [[ "${{ matrix.os }}" == "macos*" ]] ; then
             brew install llvm
             source ./util/cron/common-darwin.bash
+          else
+            sudo apt install \
+              bash \
+              clang-19 \
+              cmake \
+              cscope \
+              doxygen \
+              g++ \
+              gcc \
+              git \
+              libclang-19-dev \
+              libclang-cpp19-dev \
+              libedit-dev \
+              llvm-19 \
+              llvm-19-dev \
+              llvm-19-tools \
+              locales \
+              m4 \
+              make \
+              mawk \
+              perl \
+              pkg-config \
+              python3 \
+              python3-dev \
+              python3-pip \
+              python3-venv \
+              tzdata
           fi
 
           if [[ "${{ matrix.config }}" == "gasnet" ]] ; then
-            sudo apt install llvm llvm-dev
             source ./util/cron/common-gasnet.bash
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -323,13 +323,13 @@ jobs:
             brew install llvm
           else
             sudo apt install \
-              clang-19 \
-              libclang-19-dev \
-              libclang-cpp19-dev \
+              clang \
+              libclang-dev \
+              libclang-cpp-dev \
               libedit-dev \
-              llvm-19 \
-              llvm-19-dev \
-              llvm-19-tools
+              llvm \
+              llvm-dev \
+              llvm-tools
           fi
       - name: setup env and run ./util/buildRelease/smokeTest
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -314,15 +314,15 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: run smokeTest
         run: |
-            if [[ "${{ matrix.os }}" == "macos*" ]] ; then
-              source ./util/cron/common-darwin.bash
-            fi
+          if [[ "${{ matrix.os }}" == "macos*" ]] ; then
+            source ./util/cron/common-darwin.bash
+          fi
 
-            if [[ "${{ matrix.config }}" == "gasnet" ]] ; then
-              source ./util/cron/common-gasnet.bash
-            fi
+          if [[ "${{ matrix.config }}" == "gasnet" ]] ; then
+            source ./util/cron/common-gasnet.bash
+          fi
 
-            export NIGHTLY_TEST_SETTINGS=true
+          export NIGHTLY_TEST_SETTINGS=true
 
           ./util/buildRelease/smokeTest
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -323,31 +323,13 @@ jobs:
             brew install llvm
           else
             sudo apt install \
-              bash \
               clang-19 \
-              cmake \
-              cscope \
-              doxygen \
-              g++ \
-              gcc \
-              git \
               libclang-19-dev \
               libclang-cpp19-dev \
               libedit-dev \
               llvm-19 \
               llvm-19-dev \
-              llvm-19-tools \
-              locales \
-              m4 \
-              make \
-              mawk \
-              perl \
-              pkg-config \
-              python3 \
-              python3-dev \
-              python3-pip \
-              python3-venv \
-              tzdata
+              llvm-19-tools
           fi
       - name: setup env and run ./util/buildRelease/smokeTest
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -317,15 +317,10 @@ jobs:
           echo "${{ matrix.os }}"
           echo "${{ matrix.config }}"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: run smokeTest
+      - name: install deps
         run: |
-          set -ex
-
-          source ./util/cron/common.bash
-
           if [[ "${{ matrix.os }}" == "macos"* ]] ; then
             brew install llvm
-            source ./util/cron/common-darwin.bash
           else
             sudo apt install \
               bash \
@@ -353,6 +348,15 @@ jobs:
               python3-pip \
               python3-venv \
               tzdata
+          fi
+      - name: setup env and run ./util/buildRelease/smokeTest
+        run: |
+          set -ex
+
+          source ./util/cron/common.bash
+
+          if [[ "${{ matrix.os }}" == "macos"* ]] ; then
+            source ./util/cron/common-darwin.bash
           fi
 
           if [[ "${{ matrix.config }}" == "gasnet" ]] ; then

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -349,26 +349,6 @@ jobs:
               python3-venv \
               tzdata
           fi
-
-          if [[ "${{ matrix.config }}" == "gasnet" ]] ; then
-            sudo apt install \
-              rdma-core \
-              libibmad5 \
-              opensm \
-              ibutils \
-              infiniband-diags \
-              perftest \
-              mstflint \
-              libibverbs1 \
-              libibverbs-dev \
-              librdmacm1 \
-              libibumad3 \
-              ibverbs-providers \
-              rdmacm-utils \
-              infiniband-diags \
-              libfabric1 \
-              ibverbs-utils
-          fi
       - name: setup env and run ./util/buildRelease/smokeTest
         run: |
           set -ex

--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -12,7 +12,6 @@ export CHPL_COMM=gasnet
 export GASNET_SPAWNFN=L
 export CHPL_RT_MASTERIP=127.0.0.1
 export GASNET_ROUTE_OUTPUT=0
-export CHPL_GASNET_CFG_OPTIONS=--disable-ibv
 
 # Bump the timeout slightly just because we're oversubscribed
 export CHPL_TEST_TIMEOUT=500

--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -12,6 +12,7 @@ export CHPL_COMM=gasnet
 export GASNET_SPAWNFN=L
 export CHPL_RT_MASTERIP=127.0.0.1
 export GASNET_ROUTE_OUTPUT=0
+CHPL_COMM_SUBSTRATE=udp
 
 # Bump the timeout slightly just because we're oversubscribed
 export CHPL_TEST_TIMEOUT=500

--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -12,7 +12,6 @@ export CHPL_COMM=gasnet
 export GASNET_SPAWNFN=L
 export CHPL_RT_MASTERIP=127.0.0.1
 export GASNET_ROUTE_OUTPUT=0
-CHPL_COMM_SUBSTRATE=udp
 
 # Bump the timeout slightly just because we're oversubscribed
 export CHPL_TEST_TIMEOUT=500

--- a/util/cron/common-gasnet.bash
+++ b/util/cron/common-gasnet.bash
@@ -12,6 +12,7 @@ export CHPL_COMM=gasnet
 export GASNET_SPAWNFN=L
 export CHPL_RT_MASTERIP=127.0.0.1
 export GASNET_ROUTE_OUTPUT=0
+export CHPL_GASNET_CFG_OPTIONS=--disable-ibv
 
 # Bump the timeout slightly just because we're oversubscribed
 export CHPL_TEST_TIMEOUT=500


### PR DESCRIPTION
Add a GA job `chapel-code-smoke-test`, which runs `./util/buildRelease/smokeTest` on:
- linux comm=none
- linux comm=gasnet
- macos comm=none

Note to reviewer: Best to review changes as a whole, as I did a lot of experimenting along the way.

[reviewed by @jabraham17 , thanks!]