### PR TITLE
Revert "Adjusts Immediate to make compiler debugging easier (#29057)"

### DIFF
--- a/compiler/codegen/cg-symbol.cpp
+++ b/compiler/codegen/cg-symbol.cpp
@@ -471,7 +471,7 @@ llvm::Value* codegenImmediateLLVM(Immediate* i)
           INT_ASSERT("unsupported complex floating point width");
       }
       break;
-    case CONST_KIND_STRING: {
+    case CONST_KIND_STRING:
       // Note that string immediate values are stored
       // with C escapes - that is newline is 2 chars \ n
       // so we have to convert to a sequence of bytes
@@ -480,9 +480,6 @@ llvm::Value* codegenImmediateLLVM(Immediate* i)
       ret = info->irBuilder->CreateGlobalString(newString);
       trackLLVMValue(ret);
       break;
-    }
-    default:
-      INT_ASSERT("Unsupported immediate type");
   }
 
   return ret;

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -997,7 +997,7 @@ static bool handleNumericUnaryPrefixExpr(const MacroInfo* inMacro,
     if (got == false || tmpCastToTy != NULL)
       return false;
 
-    auto p = chpl::uast::primtags::PrimitiveTag::PRIM_UNKNOWN;
+    int p = 0;
     switch (start->getKind()) {
       case tok::plus:   p = P_prim_plus;    break;
       case tok::minus:  p = P_prim_minus;   break;
@@ -1182,7 +1182,7 @@ static bool handleNumericBinOpExpr(const MacroInfo* inMacro,
     return false;
 
   // Apply the binary operator to the immediate
-  auto p = chpl::uast::primtags::PrimitiveTag::PRIM_UNKNOWN;
+  int p = 0;
   switch (op->getKind()) {
     case tok::lessless:   p = P_prim_lsh;    break;
     default:

--- a/frontend/lib/immediates/num.cpp
+++ b/frontend/lib/immediates/num.cpp
@@ -156,7 +156,6 @@ snprint_imm(char *str, size_t max, const Immediate &imm) {
       res = snprintf(str, max, fmt, imm.v_string.c_str());
       break;
     }
-    default: CHPL_ASSERT(false && "Unhandled case in switch statement");
   }
   return res;
 }
@@ -375,7 +374,6 @@ coerce_immediate(chpl::Context* context, Immediate *from, Immediate *to) {
             default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
           } \
           break; \
-        default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 #define COMPUTE_INT_POW(type, b, e)                      \
@@ -502,7 +500,6 @@ coerce_immediate(chpl::Context* context, Immediate *from, Immediate *to) {
       case NUM_KIND_IMAG: case NUM_KIND_COMPLEX:                        \
           CHPL_ASSERT(false && "Cannot fold ** on floating point values"); \
           break; \
-      default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 static void doFoldSqrt(chpl::Context* context,
@@ -560,7 +557,6 @@ static void doFoldSqrt(chpl::Context* context,
         default: CHPL_ASSERT(false && "Unhandled case in switch statement");
       }
       break;
-    default: CHPL_ASSERT(false && "Unhandled case in switch statement");
   }
 }
 
@@ -629,7 +625,6 @@ static void doFoldAbs(chpl::Context* context,
         default: CHPL_ASSERT(false && "Unhandled case in switch statement");
       }
       break;
-    default: CHPL_ASSERT(false && "Unhandled case in switch statement");
   }
 }
 
@@ -648,7 +643,6 @@ static void doFoldGetReal(chpl::Context* context,
         default: CHPL_ASSERT(false && "Unhandled case in switch statement");
       }
       break;
-    default: CHPL_ASSERT(false && "Unhandled case in switch statement");
   }
 }
 
@@ -667,7 +661,6 @@ static void doFoldGetImag(chpl::Context* context,
         default: CHPL_ASSERT(false && "Unhandled case in switch statement");
       }
       break;
-    default: CHPL_ASSERT(false && "Unhandled case in switch statement");
   }
 }
 
@@ -733,7 +726,6 @@ static void doFoldGetImag(chpl::Context* context,
             default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
           } \
           break; \
-        default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 #define DO_FOLDI(_op) \
@@ -773,7 +765,6 @@ static void doFoldGetImag(chpl::Context* context,
         } \
         case NUM_KIND_REAL: case NUM_KIND_IMAG: case NUM_KIND_COMPLEX: \
           CHPL_ASSERT(false && "Unhandled case in switch statement"); \
-        default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 #define DO_FOLD1(_op) \
@@ -833,7 +824,6 @@ static void doFoldGetImag(chpl::Context* context,
             default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
           } \
           break; \
-        default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 #define DO_FOLD1I(_op) \
@@ -874,7 +864,6 @@ static void doFoldGetImag(chpl::Context* context,
         case NUM_KIND_REAL: case NUM_KIND_IMAG: case NUM_KIND_COMPLEX: \
           CHPL_ASSERT(false && "Unhandled case in switch statement"); \
           break; \
-        default: CHPL_ASSERT(false && "Unhandled case in switch statement"); \
       }
 
 static int
@@ -1026,7 +1015,7 @@ fold_result(Immediate *im1, Immediate *im2, Immediate *imm) {
 }
 
 void
-fold_constant(chpl::Context* context, chpl::uast::primtags::PrimitiveTag op,
+fold_constant(chpl::Context* context, int op,
               Immediate *aim1, Immediate *aim2, Immediate *imm) {
 
   Immediate im1(*aim1), im2, coerce;

--- a/frontend/lib/immediates/num.h
+++ b/frontend/lib/immediates/num.h
@@ -23,7 +23,6 @@
 
 #include "chpl/framework/Context.h"
 #include "chpl/framework/UniqueString.h"
-#include "chpl/uast/PrimOp.h"
 
 extern "C" {
   #include "complex-support.h"
@@ -46,14 +45,18 @@ extern unsigned int open_hash_multipliers[256];
 
 using ImmString = chpl::detail::PODUniqueString;
 
+//
+// NOTE: NUM_KIND_LAST is used to mark the last entry in this enum. The
+// 'IF1_const_kind' enum below uses it to set values.
+//
+enum IF1_num_kind : uint8_t {
+  NUM_KIND_NONE, NUM_KIND_BOOL, NUM_KIND_UINT, NUM_KIND_INT, NUM_KIND_REAL,
+  NUM_KIND_IMAG, NUM_KIND_COMPLEX, NUM_KIND_COMMID, NUM_KIND_LAST
+};
 
 enum IF1_const_kind : uint8_t {
-  NUM_KIND_NONE, NUM_KIND_BOOL, NUM_KIND_UINT, NUM_KIND_INT, NUM_KIND_REAL,
-  NUM_KIND_IMAG, NUM_KIND_COMPLEX, NUM_KIND_COMMID,
-  CONST_KIND_STRING, CONST_KIND_SYMBOL
+  CONST_KIND_STRING = NUM_KIND_LAST + 1, CONST_KIND_SYMBOL
 };
-// maintain old name for backwards compatibility
-using IF1_num_kind = IF1_const_kind;
 
 enum IF1_string_kind : uint8_t {
   STRING_KIND_STRING,
@@ -103,19 +106,9 @@ namespace chpl {
 namespace types {
 
 class Immediate { public:
-  IF1_const_kind const_kind;
+  uint8_t const_kind;
   IF1_string_kind string_kind;
-  // NOTE: only num_index is ever used! boolIndex, intIndex, floatIndex, and
-  // complexIndex are only used to make the union more readable in the debugger
-  // (so the debugger can show the value of the correct type as a human
-  // readable enum)
-  union {
-    uint8_t          num_index;
-    IF1_bool_type    _boolIndex;
-    IF1_int_type     _intIndex;
-    IF1_float_type   _floatIndex;
-    IF1_complex_type _complexIndex;
-  };
+  uint8_t num_index;
   union {
     // Unions are initialized based off the first element, so we need to have
     // the largest thing first to make sure it is all zero initialized
@@ -394,7 +387,7 @@ int fprint_imm(FILE *fp, const Immediate &imm, bool showType = false);
 int snprint_imm(char *s, size_t max, const Immediate &imm);
 void coerce_immediate(chpl::Context* context, Immediate *from, Immediate *to);
 void fold_result(Immediate *imm1, Immediate *imm2, Immediate *imm);
-void fold_constant(chpl::Context* context, chpl::uast::primtags::PrimitiveTag op,
+void fold_constant(chpl::Context* context, int op,
                    Immediate *im1, Immediate *im2, Immediate *imm);
 ImmString istrFromUserBool(chpl::Context* context, bool b);
 ImmString istrFromUserUint(chpl::Context* context, uint64_t i);

--- a/frontend/lib/types/Param.cpp
+++ b/frontend/lib/types/Param.cpp
@@ -599,7 +599,7 @@ QualifiedType Param::fold(Context* context,
   Immediate result;
 
   // fold
-  auto immOp = op;
+  int immOp = op;
 
   if (op == chpl::uast::PrimitiveTag::PRIM_CAST) {
     // valid param casts should always be foldable


### PR DESCRIPTION
Reverts https://github.com/chapel-lang/chapel/pull/29057 due to linux32 failures