### PR TITLE
Install `libprotoc-dev` in GitHub CI Docker image

### DIFF
--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     libclang-19-dev \
     libclang-cpp19-dev \
     libedit-dev \
+    libprotoc-dev \
     llvm-19 \
     llvm-19-dev \
     llvm-19-tools \


### PR DESCRIPTION
Supporting https://github.com/chapel-lang/chapel/pull/29060, which requires it for `make protoc-gen-chpl`.

[trivial, not reviewed]