### PR TITLE
Change CI container build job name 'build'->'build-ci-container'

### DIFF
--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -30,7 +30,7 @@ on:
 
 
 jobs:
-  build:
+  build-ci-container:
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
I would like to make it a required pre-merge check (if I can do so without blocking jobs that don't trigger it to rebuild), but 'build' felt like too general a name and too likely to target something unintended.

[trivial, not reviewed]