### PR TITLE
Serialize runs of `build-CI-container` workflow

### DIFF
--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -10,7 +10,7 @@ env:
 # Serialize runs of this workflow, to prevent a build from an older ref pushing
 # and overriding the results of a concurrently-building newer ref.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.repository }}
   queue: max
 
 on:

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -7,10 +7,10 @@ env:
   # NOTE: if this filename changes, also update in the on.paths section below
   DOCKERFILE: util/packaging/docker/github-ci/Dockerfile
 
-# Serialize runs of this workflow, to prevent a build from an older ref pushing
-# and overriding the results of a concurrently-building newer ref.
+# Serialize runs of this workflow on 'main', to prevent a build from an older
+# ref pushing and overriding the results of a concurrently-building newer ref.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}
+  group: ${{ github.workflow }}-${{ case(github.ref == 'refs/heads/main', 'main', github.sha) }}
   queue: max
 
 on:

--- a/.github/workflows/build-CI-container.yml
+++ b/.github/workflows/build-CI-container.yml
@@ -7,6 +7,12 @@ env:
   # NOTE: if this filename changes, also update in the on.paths section below
   DOCKERFILE: util/packaging/docker/github-ci/Dockerfile
 
+# Serialize runs of this workflow, to prevent a build from an older ref pushing
+# and overriding the results of a concurrently-building newer ref.
+concurrency:
+  group: ${{ github.workflow }}
+  queue: max
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Serialize runs of the `build-CI-container` workflow, to prevent older builds from racing and potentially overwriting the results of newer builds.

This `concurrency` block should serialize all runs of this workflow on `main`, queuing up new ones as they come in. See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency.

[reviewed by @jabraham17 , thanks!]