### PR TITLE
Fix 2 GPU tests that rely on specifics of the CUDA API

### DIFF
--- a/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums.chpl
+++ b/test/gpu/native/cudaOnly/gpuAddNums/gpuAddNums.chpl
@@ -39,7 +39,12 @@ extern {
       char name[128];
       checkCudaErrors(cuDeviceGetName(name, 128, device), 4);
 
+      #if CUDA_VERSION >= 13000
+      CUctxCreateParams ctxCreateParams = {0};
+      checkCudaErrors(cuCtxCreate(&context, &ctxCreateParams, CU_CTX_BLOCKING_SYNC, device), 5);
+      #else
       checkCudaErrors(cuCtxCreate(&context, CU_CTX_BLOCKING_SYNC, device), 5);
+      #endif
     }
 
     checkCudaErrors(cuModuleLoadData(&cudaModule, chpl_gpuBinary), 6);

--- a/test/gpu/native/studies/math/mathKernels.precomp
+++ b/test/gpu/native/studies/math/mathKernels.precomp
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -exo pipefail
 
 chpl=$3
 chpl_home=$($chpl --print-chpl-home)
@@ -7,6 +9,8 @@ llvm_version=$($chpl_home/util/printchplenv --value --only CHPL_LLVM_VERSION)
 gpu_arch=$($chpl_home/util/printchplenv --value --only CHPL_GPU_ARCH)
 cuda_path=$($chpl_home/util/printchplenv --value --only CHPL_CUDA_PATH)
 nvcc_compiler=$cuda_path/bin/nvcc
+
+chpl_system_compile=$($chpl_home/util/printchplenv --value --only CHPL_TARGET_SYSTEM_COMPILE_ARGS)
 
 NVCC_FLAGS=""
 CLANG_FLAGS="--offload-arch=${gpu_arch}"
@@ -24,9 +28,9 @@ build_for_func() {
   $nvcc_compiler $DEFINES_nvcc -O3 --use_fast_math $NVCC_FLAGS -c mathKernels.cu -o mathKernels_cu_$func.o
   $nvcc_compiler -O3 --use_fast_math mathKernels_cu_$func.o -o mathKernelsDlinked_$func.o -dlink
 
-  local DEFINES_clang="$COMMON_DEFINES -Dmk_PREFIX=cu_clang_${func}_ -Dmk_LABEL=\"clang\" -D__STRICT_ANSI__=1"
+  local DEFINES_clang="$COMMON_DEFINES -Dmk_PREFIX=cu_clang_${func}_ -Dmk_LABEL=\"clang\""
   # build the clang version
-  $compiler $DEFINES_clang -I$cuda_path/include -O3 -ffast-math $CLANG_FLAGS -c mathKernels.cu -o mathKernels_clang_$func.o
+  $compiler $DEFINES_clang $chpl_system_compile -O3 -ffast-math $CLANG_FLAGS -c mathKernels.cu -o mathKernels_clang_$func.o
 }
 build_for_func tanhf
 build_for_func sqrtf


### PR DESCRIPTION
Fixes 2 GPU tests that rely on the specific of the CUDA API to work with CUDA 13

* `gpuAddNums.chpl` is a low-level mock implemention of how the Chapel runtime works, and needs to use a new API with CUDA 13
* `mathKernels.chpl` builds cuda code manually with clang and relies on certain compiler flags to be passed. Where these paths are got more complicated in CUDA 13, so has been adjusted to share logic with `printchplenv`

[Reviewed by @benharsh]