### PR TITLE
Add missing complex ops at compile-time (`*` and `/`)

### DIFF
--- a/compiler/AST/checkAST.cpp
+++ b/compiler/AST/checkAST.cpp
@@ -230,6 +230,7 @@ void checkPrimitives()
      case PRIM_CHECK_NIL:
      case PRIM_GET_REAL:            // get complex real component
      case PRIM_GET_IMAG:            // get complex imag component
+     case PRIM_BUILD_COMPLEX:     // build complex from real and imag
      case PRIM_QUERY:               // query expression primitive
      case PRIM_LOCAL_CHECK:         // assert that a wide ref is on this locale
      case PRIM_GET_END_COUNT:

--- a/compiler/AST/primitive.cpp
+++ b/compiler/AST/primitive.cpp
@@ -154,6 +154,20 @@ returnInfoComplexField(CallExpr* call) {  // for get real/imag primitives
 }
 
 static QualifiedType
+returnInfoComplex(CallExpr* call) {
+  Type *t = call->get(1)->getValType();
+  if (t == dtReal[FLOAT_SIZE_32] || t == dtImag[FLOAT_SIZE_32]) {
+    return QualifiedType(dtComplex[COMPLEX_SIZE_64], QUAL_VAL);
+  } else if (t == dtReal[FLOAT_SIZE_64] || t == dtImag[FLOAT_SIZE_64]) {
+    return QualifiedType(dtComplex[COMPLEX_SIZE_128], QUAL_VAL);
+  } else {
+    INT_FATAL( call, "unsupported complex size");
+  }
+  return QualifiedType(dtUnknown);
+}
+
+
+static QualifiedType
 returnInfoAbs(CallExpr* call) {
   Type *t = call->get(1)->getValType();
   if (t == dtComplex[COMPLEX_SIZE_64]) {
@@ -913,6 +927,7 @@ initPrimitive() {
   prim_def(PRIM_GET_REAL, "complex_get_real", returnInfoComplexField);
   // given a complex value, produce a reference to the imag component
   prim_def(PRIM_GET_IMAG, "complex_get_imag", returnInfoComplexField);
+  prim_def(PRIM_BUILD_COMPLEX, "build_complex", returnInfoComplex);
   // query expression primitive
   prim_def(PRIM_QUERY, "query", returnInfoUnknown);
   prim_def(PRIM_QUERY_PARAM_FIELD, "query param field", returnInfoGetMemberRef);

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -652,6 +652,9 @@ static Expr* postFoldPrimop(CallExpr* call) {
 
   } else if (call->isPrimitive(PRIM_GET_IMAG) == true) {
     FOLD_CALL1(P_prim_get_imag);
+  
+  } else if (call->isPrimitive(PRIM_BUILD_COMPLEX) == true) {
+    FOLD_CALL2(P_prim_build_complex);
 
   } else if (call->isPrimitive(PRIM_ADD) == true) {
     FOLD_CALL2(P_prim_add);

--- a/compiler/resolution/postFold.cpp
+++ b/compiler/resolution/postFold.cpp
@@ -652,7 +652,7 @@ static Expr* postFoldPrimop(CallExpr* call) {
 
   } else if (call->isPrimitive(PRIM_GET_IMAG) == true) {
     FOLD_CALL1(P_prim_get_imag);
-  
+
   } else if (call->isPrimitive(PRIM_BUILD_COMPLEX) == true) {
     FOLD_CALL2(P_prim_build_complex);
 

--- a/frontend/include/chpl/uast/prim-ops-list.h
+++ b/frontend/include/chpl/uast/prim-ops-list.h
@@ -136,6 +136,7 @@ PRIMITIVE_R(NEW_WITH_ALLOCATOR, "new with allocator")
 
 PRIMITIVE_G(GET_REAL, "complex_get_real")
 PRIMITIVE_G(GET_IMAG, "complex_get_imag")
+PRIMITIVE_R(BUILD_COMPLEX, "build_complex")
 
 PRIMITIVE_R(QUERY, "query")
 PRIMITIVE_R(QUERY_PARAM_FIELD, "query param field")

--- a/frontend/lib/immediates/complex-support.c
+++ b/frontend/lib/immediates/complex-support.c
@@ -77,3 +77,59 @@ struct complex128 complexSqrt128(struct complex128 x) {
   ret.i = cimag(n);
   return ret;
 }
+
+struct complex64 complexPow64(struct complex64 x, struct complex64 y) {
+  float complex c = makeFloatComplex(x.r, x.i);
+  float complex n = cpowf(c, makeFloatComplex(y.r, y.i));
+  struct complex64 ret;
+  ret.r = crealf(n);
+  ret.i = cimagf(n);
+  return ret;
+}
+struct complex128 complexPow128(struct complex128 x, struct complex128 y) {
+  double complex c = makeDoubleComplex(x.r, x.i);
+  double complex n = cpow(c, makeDoubleComplex(y.r, y.i));
+  struct complex128 ret;
+  ret.r = creal(n);
+  ret.i = cimag(n);
+  return ret;
+}
+
+struct complex64 complexMul64(struct complex64 c1, struct complex64 c2) {
+  float complex n1 = makeFloatComplex(c1.r, c1.i);
+  float complex n2 = makeFloatComplex(c2.r, c2.i);
+  float complex n = n1 * n2;
+  struct complex64 ret;
+  ret.r = crealf(n);
+  ret.i = cimagf(n);
+  return ret;
+}
+
+struct complex128 complexMul128(struct complex128 c1, struct complex128 c2) {
+  double complex n1 = makeDoubleComplex(c1.r, c1.i);
+  double complex n2 = makeDoubleComplex(c2.r, c2.i);
+  double complex n = n1 * n2;
+  struct complex128 ret;
+  ret.r = creal(n);
+  ret.i = cimag(n);
+  return ret;
+}
+
+struct complex64 complexDiv64(struct complex64 c1, struct complex64 c2) {
+  float complex n1 = makeFloatComplex(c1.r, c1.i);
+  float complex n2 = makeFloatComplex(c2.r, c2.i);
+  float complex n = n1 / n2;
+  struct complex64 ret;
+  ret.r = crealf(n);
+  ret.i = cimagf(n);
+  return ret;
+}
+struct complex128 complexDiv128(struct complex128 c1, struct complex128 c2) {
+  double complex n1 = makeDoubleComplex(c1.r, c1.i);
+  double complex n2 = makeDoubleComplex(c2.r, c2.i);
+  double complex n = n1 / n2;
+  struct complex128 ret;
+  ret.r = creal(n);
+  ret.i = cimag(n);
+  return ret;
+}

--- a/frontend/lib/immediates/complex-support.c
+++ b/frontend/lib/immediates/complex-support.c
@@ -78,23 +78,6 @@ struct complex128 complexSqrt128(struct complex128 x) {
   return ret;
 }
 
-struct complex64 complexPow64(struct complex64 x, struct complex64 y) {
-  float complex c = makeFloatComplex(x.r, x.i);
-  float complex n = cpowf(c, makeFloatComplex(y.r, y.i));
-  struct complex64 ret;
-  ret.r = crealf(n);
-  ret.i = cimagf(n);
-  return ret;
-}
-struct complex128 complexPow128(struct complex128 x, struct complex128 y) {
-  double complex c = makeDoubleComplex(x.r, x.i);
-  double complex n = cpow(c, makeDoubleComplex(y.r, y.i));
-  struct complex128 ret;
-  ret.r = creal(n);
-  ret.i = cimag(n);
-  return ret;
-}
-
 struct complex64 complexMul64(struct complex64 c1, struct complex64 c2) {
   float complex n1 = makeFloatComplex(c1.r, c1.i);
   float complex n2 = makeFloatComplex(c2.r, c2.i);

--- a/frontend/lib/immediates/complex-support.h
+++ b/frontend/lib/immediates/complex-support.h
@@ -25,7 +25,7 @@
  This header exists to work around a problem with complex square root being
  inaccurate on libc++ by using C functions to do the complex square root.
 
- This is also used by complex pow
+ This is also used by complex multiplication and division to avoid the same problem.
 
  */
 
@@ -40,9 +40,6 @@ struct complex128 {
 
 struct complex64 complexSqrt64(struct complex64 x);
 struct complex128 complexSqrt128(struct complex128 x);
-
-struct complex64 complexPow64(struct complex64 x, struct complex64 y);
-struct complex128 complexPow128(struct complex128 x, struct complex128 y);
 
 struct complex64 complexMul64(struct complex64 c1, struct complex64 c2);
 struct complex128 complexMul128(struct complex128 c1, struct complex128 c2);

--- a/frontend/lib/immediates/complex-support.h
+++ b/frontend/lib/immediates/complex-support.h
@@ -25,6 +25,8 @@
  This header exists to work around a problem with complex square root being
  inaccurate on libc++ by using C functions to do the complex square root.
 
+ This is also used by complex pow
+
  */
 
 struct complex64 {
@@ -38,5 +40,14 @@ struct complex128 {
 
 struct complex64 complexSqrt64(struct complex64 x);
 struct complex128 complexSqrt128(struct complex128 x);
+
+struct complex64 complexPow64(struct complex64 x, struct complex64 y);
+struct complex128 complexPow128(struct complex128 x, struct complex128 y);
+
+struct complex64 complexMul64(struct complex64 c1, struct complex64 c2);
+struct complex128 complexMul128(struct complex128 c1, struct complex128 c2);
+
+struct complex64 complexDiv64(struct complex64 c1, struct complex64 c2);
+struct complex128 complexDiv128(struct complex128 c1, struct complex128 c2);
 
 #endif

--- a/frontend/lib/immediates/num.cpp
+++ b/frontend/lib/immediates/num.cpp
@@ -502,6 +502,48 @@ coerce_immediate(chpl::Context* context, Immediate *from, Immediate *to) {
           break; \
       }
 
+#define DO_FOLDDIV()                                                    \
+      switch (imm->const_kind) {                                        \
+        case NUM_KIND_COMPLEX:                                          \
+          switch (imm->num_index) {                                     \
+            case COMPLEX_SIZE_64:                                       \
+              {                                                         \
+                imm->v_complex64 = complexDiv64(im1.v_complex64, im2.v_complex64); \
+                break;                                                  \
+              }                                                         \
+            case COMPLEX_SIZE_128:                                      \
+              {                                                         \
+                imm->v_complex128 = complexDiv128(im1.v_complex128, im2.v_complex128); \
+                break;                                                  \
+              }                                                         \
+          }                                                             \
+          break;                                                        \
+        default:                                                        \
+          DO_FOLD(/, false, false);                                     \
+          break;                                                        \
+      }
+
+#define DO_FOLDMUL()                                                    \
+      switch (imm->const_kind) {                                        \
+        case NUM_KIND_COMPLEX:                                          \
+          switch (imm->num_index) {                                     \
+            case COMPLEX_SIZE_64:                                       \
+              {                                                         \
+                imm->v_complex64 = complexMul64(im1.v_complex64, im2.v_complex64); \
+                break;                                                  \
+              }                                                         \
+            case COMPLEX_SIZE_128:                                      \
+              {                                                         \
+                imm->v_complex128 = complexMul128(im1.v_complex128, im2.v_complex128); \
+                break;                                                  \
+              }                                                         \
+          }                                                             \
+          break;                                                        \
+        default:                                                        \
+          DO_FOLD(*, false, false);                                     \
+          break;                                                        \
+      }
+
 static void doFoldSqrt(chpl::Context* context,
                        Immediate &im1, /* input */
                        Immediate *imm  /* output */) {
@@ -657,6 +699,27 @@ static void doFoldGetImag(chpl::Context* context,
           break;
         case COMPLEX_SIZE_128:
           imm->v_float64 = im1.v_complex128.i;
+          break;
+        default: CHPL_ASSERT(false && "Unhandled case in switch statement");
+      }
+      break;
+  }
+}
+
+static void doFoldBuildComplex(chpl::Context* context,
+                               Immediate &im1, /* input */
+                               Immediate &im2, /* input */
+                               Immediate *imm  /* output */) {
+  switch (imm->const_kind) {
+    case NUM_KIND_COMPLEX:
+      switch (imm->num_index) {
+        case COMPLEX_SIZE_64:
+          imm->v_complex64.r = im1.v_float32;
+          imm->v_complex64.i = im2.v_float32;
+          break;
+        case COMPLEX_SIZE_128:
+          imm->v_complex128.r = im1.v_float64;
+          imm->v_complex128.i = im2.v_float64;
           break;
         default: CHPL_ASSERT(false && "Unhandled case in switch statement");
       }
@@ -1084,6 +1147,20 @@ fold_constant(chpl::Context* context, int op,
         imm->num_index = im1.num_index;
       }
       break;
+    case P_prim_build_complex:
+      if ((im1.const_kind == NUM_KIND_REAL || im1.const_kind == NUM_KIND_IMAG) &&
+          (im2.const_kind == NUM_KIND_REAL || im2.const_kind == NUM_KIND_IMAG)) {
+        imm->const_kind = NUM_KIND_COMPLEX;
+        if (im1.num_index == FLOAT_SIZE_32 && im2.num_index == FLOAT_SIZE_32)
+          imm->num_index = COMPLEX_SIZE_64;
+        else if (im1.num_index == FLOAT_SIZE_64 && im2.num_index == FLOAT_SIZE_64)
+          imm->num_index = COMPLEX_SIZE_128;
+        else
+          CHPL_ASSERT(false && "build_complex numeric kind not supported");
+      } else {
+        CHPL_ASSERT(false && "build_complex numeric kind not supported");
+      }
+      break;
   }
   if (coerce.const_kind) {
     coerce_immediate(context, &im1, &coerce);
@@ -1095,8 +1172,8 @@ fold_constant(chpl::Context* context, int op,
   }
   switch (op) {
     default: CHPL_ASSERT(false && "fold constant op not supported"); break;
-    case P_prim_mult: DO_FOLD(*, false, false); break;
-    case P_prim_div: DO_FOLD(/, false, false); break;
+    case P_prim_mult: DO_FOLDMUL(); break;
+    case P_prim_div: DO_FOLDDIV(); break;
     case P_prim_mod: DO_FOLDI(%); break;
     case P_prim_add: DO_FOLD(+, true, false); break;
     case P_prim_subtract: DO_FOLD(-, false, true); break;
@@ -1135,6 +1212,10 @@ fold_constant(chpl::Context* context, int op,
     }
     case P_prim_get_real: {
       doFoldGetReal(context, im1, imm);
+      break;
+    }
+    case P_prim_build_complex: {
+      doFoldBuildComplex(context, im1, im2, imm);
       break;
     }
   }

--- a/frontend/lib/immediates/prim_data.h
+++ b/frontend/lib/immediates/prim_data.h
@@ -51,5 +51,6 @@
 #define P_prim_sqrt           chpl::uast::primtags::PRIM_SQRT
 #define P_prim_get_imag       chpl::uast::primtags::PRIM_GET_IMAG
 #define P_prim_get_real       chpl::uast::primtags::PRIM_GET_REAL
+#define P_prim_build_complex  chpl::uast::primtags::PRIM_BUILD_COMPLEX
 
 #endif

--- a/frontend/lib/resolution/prims.cpp
+++ b/frontend/lib/resolution/prims.cpp
@@ -1073,6 +1073,26 @@ primComplexGetComponent(Context* context, const CallInfo& ci) {
   return ret;
 }
 
+/* for complex primitives */
+static QualifiedType
+primBuildComplex(Context* context, const CallInfo& ci) {
+  QualifiedType ret = QualifiedType();
+
+  if (ci.numActuals() != 2) return ret;
+
+  auto actual0R = ci.actual(0).type().type()->toRealType();
+  auto actual1R = ci.actual(1).type().type()->toRealType();
+  auto actual0I = ci.actual(0).type().type()->toImagType();
+  auto actual1I = ci.actual(1).type().type()->toImagType();
+  auto actual0BW = actual0R ? actual0R->bitwidth() : (actual0I ? actual0I->bitwidth() : 0);
+  auto actual1BW = actual1R ? actual1R->bitwidth() : (actual1I ? actual1I->bitwidth() : 0);
+  if (actual0BW != 0 && actual1BW != 0 && actual0BW == actual1BW) {
+    int BW = actual0BW * 2;
+    ret = QualifiedType(QualifiedType::REF, ComplexType::get(context, BW));
+  }
+  return ret;
+}
+
 /* for abs */
 static QualifiedType
 primAbsGetType(Context* context, const CallInfo& ci) {
@@ -1925,6 +1945,10 @@ CallResolutionResult resolvePrimCall(ResolutionContext* rc,
     case PRIM_GET_IMAG:
       // TODO: get the real/imag component from a param complex
       type = primComplexGetComponent(context, ci);
+      break;
+    /* primitives to build complex numbers */
+    case PRIM_BUILD_COMPLEX:
+      type = primBuildComplex(context, ci);
       break;
     /* other math primitives */
     case PRIM_ABS:

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -736,11 +736,23 @@ module ChapelBase {
   inline operator *(param a: imag(32), param b: imag(32)) param do return __primitive("*", -a, b) : real(32);
   inline operator *(param a: imag(64), param b: imag(64)) param do return __primitive("*", -a, b) : real(64);
 
+  inline operator *(param a: complex(64), param b: complex(64)) param do return __primitive("*", a, b);
+  inline operator *(param a: complex(128), param b: complex(128)) param do return __primitive("*", a, b);
+
   inline operator *(param a: real(32), param b: imag(32)) param do return __primitive("*", a, b : real(32)) : imag(32);
   inline operator *(param a: real(64), param b: imag(64)) param do return __primitive("*", a, b : real(64)) : imag(64);
-
   inline operator *(param a: imag(32), param b: real(32)) param do return __primitive("*", a : real(32), b) : imag(32);
   inline operator *(param a: imag(64), param b: real(64)) param do return __primitive("*", a : real(64), b) : imag(64);
+
+  inline operator *(param a: real(32), param b: complex(64)) param do return __primitive("build_complex", a*b.re, a*b.im) : complex(64);
+  inline operator *(param a: complex(64), param b: real(32)) param do return __primitive("build_complex", a.re*b, a.im*b) : complex(64);
+  inline operator *(param a: real(64), param b: complex(128)) param do return __primitive("build_complex", a*b.re, a*b.im) : complex(128);
+  inline operator *(param a: complex(128), param b: real(64)) param do return __primitive("build_complex", a.re*b, a.im*b) : complex(128);
+
+  inline operator *(param a: imag(32), param b: complex(64)) param do return __primitive("build_complex", -_i2r(a)*b.im, _i2r(a)*b.re) : complex(64);
+  inline operator *(param a: complex(64), param b: imag(32)) param do return __primitive("build_complex", -a.im*_i2r(b), a.re*_i2r(b)) : complex(64);
+  inline operator *(param a: imag(64), param b: complex(128)) param do return __primitive("build_complex", -_i2r(a)*b.im, _i2r(a)*b.re) : complex(128);
+  inline operator *(param a: complex(128), param b: imag(64)) param do return __primitive("build_complex", -a.im*_i2r(b), a.re*_i2r(b)) : complex(128);
 
   inline operator /(param a: int(8), param b: int(8)) param {
     if b == 0 then compilerError("Attempt to divide by zero");
@@ -782,12 +794,36 @@ module ChapelBase {
   inline operator /(param a: imag(32), param b: imag(32)) param do return __primitive("/", a, b) : real(32);
   inline operator /(param a: imag(64), param b: imag(64)) param do return __primitive("/", a, b) : real(64);
 
+  inline operator /(param a: complex(64), param b: complex(64)) param do return __primitive("/", a, b);
+  inline operator /(param a: complex(128), param b: complex(128)) param do return __primitive("/", a, b);
+
+
   inline operator /(param a: real(32), param b: imag(32)) param do return __primitive("/", -a, b : real(32)) : imag(32);
   inline operator /(param a: real(64), param b: imag(64)) param do return __primitive("/", -a, b : real(64)) : imag(64);
-
   inline operator /(param a: imag(32), param b: real(32)) param do return __primitive("/", a : real(32), b) : imag(32);
   inline operator /(param a: imag(64), param b: real(64)) param do return __primitive("/", a : real(64), b) : imag(64);
 
+  inline operator /(param a: real(32), param b: complex(64)) param {
+    param d = abs(b);
+    return __primitive("build_complex", (a/d)*(b.re/d), (-a/d)*(b.im/d)):complex(64);
+  }
+  inline operator /(param a: complex(64), param b: real(32)) param do return __primitive("build_complex", a.re/b, a.im/b) : complex(64);
+  inline operator /(param a: real(64), param b: complex(128)) param {
+    param d = abs(b);
+    return __primitive("build_complex", (a/d)*(b.re/d), (-a/d)*(b.im/d)):complex(128);
+  }
+  inline operator /(param a: complex(128), param b: real(64)) param do return __primitive("build_complex", a.re/b, a.im/b) : complex(128);
+
+  inline operator /(param a: imag(32), param b: complex(64)) param {
+    param d = abs(b);
+    return __primitive("build_complex", (_i2r(a)/d)*(b.im/d), (_i2r(a)/d)*(b.re/d)):complex(64);
+  }
+  inline operator /(param a: complex(64), param b: imag(32)) param do return __primitive("build_complex", a.im/_i2r(b), -a.re/_i2r(b)) : complex(64);
+  inline operator /(param a: imag(64), param b: complex(128)) param {
+    param d = abs(b);
+    return __primitive("build_complex", (_i2r(a)/d)*(b.im/d), (_i2r(a)/d)*(b.re/d)):complex(128);
+  }
+  inline operator /(param a: complex(128), param b: imag(64)) param do return __primitive("build_complex", a.im/_i2r(b), -a.re/_i2r(b)) : complex(128);
 
   //
   // % on primitive types
@@ -1079,10 +1115,22 @@ module ChapelBase {
   operator **(param a: real(?w), param b: integral) param do return __primitive("**", a, b:real(w));
 
   @edition(first="preview")
-  operator **(param a: real(32), param b: real(32)) param do return __primitive("**", a, b:real(32));
+  operator **(param a: real(32), param b: real(32)) param do return __primitive("**", a, b);
 
   @edition(first="preview")
-  operator **(param a: real(64), param b: real(64)) param do return __primitive("**", a, b:real(64));
+  operator **(param a: real(64), param b: real(64)) param do return __primitive("**", a, b);
+
+  @edition(first="preview")
+  operator **(param a: complex(?w), param b: integral) param where _canOptimizeExp(b) do return _expHelpParam(a, b);
+
+  @edition(first="preview")
+  operator **(param a: complex(?w), param b: integral) param do return __primitive("**", a, b:complex(w));
+
+  @edition(first="preview")
+  operator **(param a: complex(64), param b: complex(64)) param do return __primitive("**", a, b);
+
+  @edition(first="preview")
+  operator **(param a: complex(128), param b: complex(128)) param do return __primitive("**", a, b);
 
   //
   // `param real **` overloads marked unstable for the 2.0 edition
@@ -1098,7 +1146,7 @@ module ChapelBase {
 
   @edition(last="2.0")
   @unstable("The '**' operator on `param real` values is currently unstable and will be stabilized in a future edition")
-  operator **(param a: real(32), param b: real(32)) param do return __primitive("**", a, b:real(32));
+  operator **(param a: real(32), param b: real(32)) param do return __primitive("**", a, b);
 
   @edition(last="2.0")
   @unstable("The '**' operator on `param real` values is currently unstable and will be stabilized in a future edition")
@@ -1516,6 +1564,8 @@ module ChapelBase {
   //
   inline proc _i2r(a: imag(?w)) do return __primitive("cast", real(w), a);
   inline proc _r2i(a: real(?w)) do return __primitive("cast", imag(w), a);
+  inline proc _i2r(param a: imag(?w)) param do return a:real(w);
+  inline proc _r2i(param a: real(?w)) param do return a:imag(w);
 
   //
   // More primitive funs

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1115,22 +1115,10 @@ module ChapelBase {
   operator **(param a: real(?w), param b: integral) param do return __primitive("**", a, b:real(w));
 
   @edition(first="preview")
-  operator **(param a: real(32), param b: real(32)) param do return __primitive("**", a, b);
+  operator **(param a: real(32), param b: real(32)) param do return __primitive("**", a, b:real(32));
 
   @edition(first="preview")
-  operator **(param a: real(64), param b: real(64)) param do return __primitive("**", a, b);
-
-  @edition(first="preview")
-  operator **(param a: complex(?w), param b: integral) param where _canOptimizeExp(b) do return _expHelpParam(a, b);
-
-  @edition(first="preview")
-  operator **(param a: complex(?w), param b: integral) param do return __primitive("**", a, b:complex(w));
-
-  @edition(first="preview")
-  operator **(param a: complex(64), param b: complex(64)) param do return __primitive("**", a, b);
-
-  @edition(first="preview")
-  operator **(param a: complex(128), param b: complex(128)) param do return __primitive("**", a, b);
+  operator **(param a: real(64), param b: real(64)) param do return __primitive("**", a, b:real(64));
 
   //
   // `param real **` overloads marked unstable for the 2.0 edition
@@ -1146,7 +1134,7 @@ module ChapelBase {
 
   @edition(last="2.0")
   @unstable("The '**' operator on `param real` values is currently unstable and will be stabilized in a future edition")
-  operator **(param a: real(32), param b: real(32)) param do return __primitive("**", a, b);
+  operator **(param a: real(32), param b: real(32)) param do return __primitive("**", a, b:real(32));
 
   @edition(last="2.0")
   @unstable("The '**' operator on `param real` values is currently unstable and will be stabilized in a future edition")

--- a/test/expressions/paramComplexOps.chpl
+++ b/test/expressions/paramComplexOps.chpl
@@ -1,0 +1,116 @@
+config const verbose = false;
+config param width = 32;
+type types = (real(width), imag(width), complex(width*2));
+
+inline proc vals(param idx) param {
+  select idx {
+    when 0 do return 0.0;
+    when 1 do return 1.0;
+    when 2 do return -2.0;
+    when 3 do return 4.0;
+    when 4 do return -8.0;
+    when 5 do return 0.5;
+    when 6 do return 0.125;
+    when 7 do return 16.0;
+    otherwise compilerError("Invalid index");
+  }
+}
+param vals_size = 8;
+inline proc nonzero(param idx) param {
+  if idx == 0 then return 1.0;
+  else return vals(idx);
+}
+
+inline proc cvals(param idx) param {
+  select idx {
+    when 0 do return 0.0 + 0.0i;
+    when 1 do return 1.0 + 1.0i;
+    when 2 do return -1.0 + 2.0i;
+    when 3 do return 2.0 - 0.5i;
+    when 4 do return -0.5 + 4.0i;
+    when 5 do return 0.25 - 0.125i;
+    when 6 do return -8.0 - 16.0i;
+    when 7 do return 4.0 + 0.5i;
+    otherwise compilerError("Invalid index");
+  }
+}
+param cvals_size = 8;
+inline proc cnonzero(param idx) param {
+  if idx == 0 then return 1.0 + 1.0i;
+  else return cvals(idx);
+}
+
+for param i in 0..<types.size {
+  for param j in 0..<types.size {
+    type aT = types(i);
+    type bT = types(j);
+
+    for param m in 0..<vals_size {
+      for param n in 0..<vals_size {
+        param a = vals(m):aT;
+        param b = vals(n):bT;
+        param bnonzero = nonzero(n):bT;
+        {
+          // mul(a, b);
+          param c1 = a * b;
+          var aa = a, bb = b, c2 = aa * bb;
+          if verbose then
+            writeln(a.type:string, " X ", b.type:string, ": ",
+                    a, " * ", b, " = ", c1, " == ", c2);
+          if c1 != c2 then
+            writeln("FAILED: a: ", a.type:string, " b: ", b.type:string,
+                    " c1: ", c1.type:string, " c2: ", c2.type:string);
+        }
+
+        {
+          // div(a, bnonzero);
+          param c1 = a / bnonzero;
+          var aa = a, bb = bnonzero, c2 = aa / bb;
+          if verbose then
+            writeln(a.type:string, " / ", bnonzero.type:string, ": ",
+                    a, " / ", bnonzero, " = ", c1, " == ", c2);
+          if c1 != c2 then
+            writeln("FAILED: a: ", a.type:string, " b: ", bnonzero.type:string,
+                    " c1: ", c1.type:string, " c2: ", c2.type:string);
+        }
+
+        if m < cvals_size && n < cvals_size {
+          param a = if isComplexType(aT) then cvals(m):aT
+                    else if isImagType(aT) then cvals(m).im:aT
+                    else cvals(m).re:aT;
+          param b = if isComplexType(bT) then cvals(n):bT
+                    else if isImagType(bT) then cvals(n).im:bT
+                    else cvals(n).re:bT;
+          param bnonzero = if isComplexType(bT) then cnonzero(m):bT
+                          else if isImagType(bT) then cnonzero(m).re:bT
+                          else cnonzero(m).re:bT;
+
+          {
+            // mul(a, b);
+            param c1 = a * b;
+            var aa = a, bb = b, c2 = aa * bb;
+            if verbose then
+              writeln(a.type:string, " * ", b.type:string, ": ",
+                      a, " * ", b, " = ", c1, " == ", c2);
+            if c1 != c2 then
+              writeln("FAILED: a: ", a.type:string, " b: ", b.type:string,
+                      " c1: ", c1.type:string, " c2: ", c2.type:string);
+          }
+
+          {
+            // div(a, bnonzero);
+            param c1 = a / bnonzero;
+            var aa = a, bb = bnonzero, c2 = aa / bb;
+            if verbose then
+              writeln(a.type:string, " / ", bnonzero.type:string, ": ",
+                      a, " / ", bnonzero, " = ", c1, " == ", c2);
+            if c1 != c2 then
+              writeln("FAILED: a: ", a.type:string, " b: ", bnonzero.type:string,
+                      " c1: ", c1.type:string, " c2: ", c2.type:string);
+          }
+        }
+      }
+    }
+
+  }
+}

--- a/test/expressions/paramComplexOps.compopts
+++ b/test/expressions/paramComplexOps.compopts
@@ -1,0 +1,2 @@
+--set width=32
+--set width=64

--- a/test/types/tuple/errors/genericArrayAsTupleSize.good
+++ b/test/types/tuple/errors/genericArrayAsTupleSize.good
@@ -6,4 +6,4 @@ $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note: is passed to formal 'a: 
 genericArrayAsTupleSize.chpl:3: note: other candidates are:
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   *(a: int(16), b: int(16))
 $CHPL_HOME/modules/internal/ChapelBase.chpl:nnnn: note:   *(a: int(32), b: int(32))
-note: and 58 other candidates, use --print-all-candidates to see them
+note: and 68 other candidates, use --print-all-candidates to see them


### PR DESCRIPTION
Adds the missing `*` and `/` at compile-time for params

I originally started to implement `**` for param's per https://github.com/chapel-lang/chapel/issues/28898, but then quickly found that `*` and `/` were missing. This seems to have been left as future work from https://github.com/chapel-lang/chapel/pull/12386.

I also noticed that several other operations were missing, which I noted in https://github.com/chapel-lang/chapel/issues/29051

- [x] paratest


[Reviewed by @benharsh]