### PR TITLE
Add missing comparison functions for imaginary numbers

### DIFF
--- a/doc/rst/technotes/editions.rst
+++ b/doc/rst/technotes/editions.rst
@@ -181,3 +181,6 @@ remain in the preview until they are deemed sufficiently complete.
   are defined using tertiary methods.  In such cases, a default
   comparison operator will now be available in scopes that do not have
   access to the tertiary method.
+
+- The ``isFinite()``, ``isInf()``, and ``isNan()`` functions are now defined
+  for ``imag`` values, in addition to ``real`` values.

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -321,6 +321,10 @@ module ChapelBase {
   inline operator <=(a: uint(64), b: uint(64)) do return __primitive("<=", a, b);
   inline operator <=(a: real(32), b: real(32)) do return __primitive("<=", a, b);
   inline operator <=(a: real(64), b: real(64)) do return __primitive("<=", a, b);
+  inline operator <=(a: imag(32), b: imag(32)) do return __primitive("<=", _i2r(a), _i2r(b));
+  inline operator <=(a: imag(64), b: imag(64)) do return __primitive("<=", _i2r(a), _i2r(b));
+  inline operator <=(a: complex(64), b: complex(64)) do compilerError("ordered comparison of complex numbers is not supported");
+  inline operator <=(a: complex(128), b: complex(128)) do compilerError("ordered comparison of complex numbers is not supported");
   operator <=(a: enum, b: enum) where (a.type == b.type) do
     return __primitive("<=", chpl__enumToOrder(a), chpl__enumToOrder(b));
   pragma "last resort"
@@ -339,6 +343,10 @@ module ChapelBase {
   inline operator >=(a: uint(64), b: uint(64)) do return __primitive(">=", a, b);
   inline operator >=(a: real(32), b: real(32)) do return __primitive(">=", a, b);
   inline operator >=(a: real(64), b: real(64)) do return __primitive(">=", a, b);
+  inline operator >=(a: imag(32), b: imag(32)) do return __primitive(">=", _i2r(a), _i2r(b));
+  inline operator >=(a: imag(64), b: imag(64)) do return __primitive(">=", _i2r(a), _i2r(b));
+  inline operator >=(a: complex(64), b: complex(64)) do compilerError("ordered comparison of complex numbers is not supported");
+  inline operator >=(a: complex(128), b: complex(128)) do compilerError("ordered comparison of complex numbers is not supported");
   operator >=(a: enum, b: enum) where (a.type == b.type) do
     return __primitive(">=", chpl__enumToOrder(a), chpl__enumToOrder(b));
   pragma "last resort"
@@ -357,6 +365,10 @@ module ChapelBase {
   inline operator <(a: uint(64), b: uint(64)) do return __primitive("<", a, b);
   inline operator <(a: real(32), b: real(32)) do return __primitive("<", a, b);
   inline operator <(a: real(64), b: real(64)) do return __primitive("<", a, b);
+  inline operator <(a: imag(32), b: imag(32)) do return __primitive("<", _i2r(a), _i2r(b));
+  inline operator <(a: imag(64), b: imag(64)) do return __primitive("<", _i2r(a), _i2r(b));
+  inline operator <(a: complex(64), b: complex(64)) do compilerError("ordered comparison of complex numbers is not supported");
+  inline operator <(a: complex(128), b: complex(128)) do compilerError("ordered comparison of complex numbers is not supported");
   operator <(a: enum, b: enum) where (a.type == b.type) do
     return __primitive("<", chpl__enumToOrder(a), chpl__enumToOrder(b));
   pragma "last resort"
@@ -375,6 +387,10 @@ module ChapelBase {
   inline operator >(a: uint(64), b: uint(64)) do return __primitive(">", a, b);
   inline operator >(a: real(32), b: real(32)) do return __primitive(">", a, b);
   inline operator >(a: real(64), b: real(64)) do return __primitive(">", a, b);
+  inline operator >(a: imag(32), b: imag(32)) do return __primitive(">", _i2r(a), _i2r(b));
+  inline operator >(a: imag(64), b: imag(64)) do return __primitive(">", _i2r(a), _i2r(b));
+  inline operator >(a: complex(64), b: complex(64)) do compilerError("ordered comparison of complex numbers is not supported");
+  inline operator >(a: complex(128), b: complex(128)) do compilerError("ordered comparison of complex numbers is not supported");
   operator >(a: enum, b: enum) where (a.type == b.type) do
     return __primitive(">", chpl__enumToOrder(a), chpl__enumToOrder(b));
   pragma "last resort"
@@ -394,6 +410,10 @@ module ChapelBase {
   inline operator <=(param a: enum, param b: enum) param where (a.type == b.type) do return __primitive("<=", chpl__enumToOrder(a), chpl__enumToOrder(b));
   inline operator <=(param a: real(32), param b: real(32)) param do return __primitive("<=", a, b);
   inline operator <=(param a: real(64), param b: real(64)) param do return __primitive("<=", a, b);
+  inline operator <=(param a: imag(32), param b: imag(32)) param do return __primitive("<=", _i2r(a), _i2r(b));
+  inline operator <=(param a: imag(64), param b: imag(64)) param do return __primitive("<=", _i2r(a), _i2r(b));
+  inline operator <=(param a: complex(64), param b: complex(64)) param do compilerError("ordered comparison of complex numbers is not supported");
+  inline operator <=(param a: complex(128), param b: complex(128)) param do compilerError("ordered comparison of complex numbers is not supported");
 
   inline operator >=(param a: int(8), param b: int(8)) param do return __primitive(">=", a, b);
   inline operator >=(param a: int(16), param b: int(16)) param do return __primitive(">=", a, b);
@@ -406,6 +426,10 @@ module ChapelBase {
   inline operator >=(param a: enum, param b: enum) param where (a.type == b.type) do return __primitive(">=", chpl__enumToOrder(a), chpl__enumToOrder(b));
   inline operator >=(param a: real(32), param b: real(32)) param do return __primitive(">=", a, b);
   inline operator >=(param a: real(64), param b: real(64)) param do return __primitive(">=", a, b);
+  inline operator >=(param a: imag(32), param b: imag(32)) param do return __primitive(">=", _i2r(a), _i2r(b));
+  inline operator >=(param a: imag(64), param b: imag(64)) param do return __primitive(">=", _i2r(a), _i2r(b));
+  inline operator >=(param a: complex(64), param b: complex(64)) param do compilerError("ordered comparison of complex numbers is not supported");
+  inline operator >=(param a: complex(128), param b: complex(128)) param do compilerError("ordered comparison of complex numbers is not supported");
 
   inline operator <(param a: int(8), param b: int(8)) param do return __primitive("<", a, b);
   inline operator <(param a: int(16), param b: int(16)) param do return __primitive("<", a, b);
@@ -418,6 +442,10 @@ module ChapelBase {
   inline operator <(param a: enum, param b: enum) param where (a.type == b.type) do return __primitive("<", chpl__enumToOrder(a), chpl__enumToOrder(b));
   inline operator <(param a: real(32), param b: real(32)) param do return __primitive("<", a, b);
   inline operator <(param a: real(64), param b: real(64)) param do return __primitive("<", a, b);
+  inline operator <(param a: imag(32), param b: imag(32)) param do return __primitive("<", _i2r(a), _i2r(b));
+  inline operator <(param a: imag(64), param b: imag(64)) param do return __primitive("<", _i2r(a), _i2r(b));
+  inline operator <(param a: complex(64), param b: complex(64)) param do compilerError("ordered comparison of complex numbers is not supported");
+  inline operator <(param a: complex(128), param b: complex(128)) param do compilerError("ordered comparison of complex numbers is not supported");
 
   inline operator >(param a: int(8), param b: int(8)) param do return __primitive(">", a, b);
   inline operator >(param a: int(16), param b: int(16)) param do return __primitive(">", a, b);
@@ -430,6 +458,10 @@ module ChapelBase {
   inline operator >(param a: enum, param b: enum) param where (a.type == b.type) do return __primitive(">", chpl__enumToOrder(a), chpl__enumToOrder(b));
   inline operator >(param a: real(32), param b: real(32)) param do return __primitive(">", a, b);
   inline operator >(param a: real(64), param b: real(64)) param do return __primitive(">", a, b);
+  inline operator >(param a: imag(32), param b: imag(32)) param do return __primitive(">", _i2r(a), _i2r(b));
+  inline operator >(param a: imag(64), param b: imag(64)) param do return __primitive(">", _i2r(a), _i2r(b));
+  inline operator >(param a: complex(64), param b: complex(64)) param do compilerError("ordered comparison of complex numbers is not supported");
+  inline operator >(param a: complex(128), param b: complex(128)) param do compilerError("ordered comparison of complex numbers is not supported");
 
   //
   // unary + and - on primitive types

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -297,10 +297,24 @@ module AutoMath {
 
   /* Returns `true` if the argument `x` is a representation of a finite value;
      `false` otherwise. */
+  @edition(first="preview")
   inline proc isFinite(x: imag(64)): bool do return isFinite(x:real(64));
 
   /* Returns `true` if the argument `x` is a representation of a finite value;
      `false` otherwise. */
+  @edition(first="preview")
+  inline proc isFinite(x: imag(32)): bool do return isFinite(x:real(32));
+
+  /* Returns `true` if the argument `x` is a representation of a finite value;
+     `false` otherwise. */
+  @edition(last="2.0")
+  @unstable("isFinite is unstable pending review and will be stabilized in a future edition")
+  inline proc isFinite(x: imag(64)): bool do return isFinite(x:real(64));
+
+  /* Returns `true` if the argument `x` is a representation of a finite value;
+     `false` otherwise. */
+  @edition(last="2.0")
+  @unstable("isFinite is unstable pending review and will be stabilized in a future edition")
   inline proc isFinite(x: imag(32)): bool do return isFinite(x:real(32));
 
   /* Returns `true` if the argument `x` is a representation of *infinity*;
@@ -313,10 +327,24 @@ module AutoMath {
 
   /* Returns `true` if the argument `x` is a representation of *infinity*;
      `false` otherwise. */
+  @edition(first="preview")
   inline proc isInf(x: imag(64)): bool do return isInf(x:real(64));
 
   /* Returns `true` if the argument `x` is a representation of *infinity*;
      `false` otherwise. */
+  @edition(first="preview")
+  inline proc isInf(x: imag(32)): bool do return isInf(x:real(32));
+
+  /* Returns `true` if the argument `x` is a representation of *infinity*;
+     `false` otherwise. */
+  @edition(last="2.0")
+  @unstable("isInf is unstable pending review and will be stabilized in a future edition")
+  inline proc isInf(x: imag(64)): bool do return isInf(x:real(64));
+
+  /* Returns `true` if the argument `x` is a representation of *infinity*;
+     `false` otherwise. */
+  @edition(last="2.0")
+  @unstable("isInf is unstable pending review and will be stabilized in a future edition")
   inline proc isInf(x: imag(32)): bool do return isInf(x:real(32));
 
   /* Returns `true` if the argument `x` does not represent a valid number;
@@ -329,10 +357,24 @@ module AutoMath {
 
   /* Returns `true` if the argument `x` does not represent a valid number;
      `false` otherwise. */
+  @edition(first="preview")
   inline proc isNan(x: imag(64)): bool do return isNan(x:real(64));
 
   /* Returns `true` if the argument `x` does not represent a valid number;
      `false` otherwise. */
+  @edition(first="preview")
+  inline proc isNan(x: imag(32)): bool do return isNan(x:real(32));
+
+  /* Returns `true` if the argument `x` does not represent a valid number;
+     `false` otherwise. */
+  @edition(last="2.0")
+  @unstable("isNan is unstable pending review and will be stabilized in a future edition")
+  inline proc isNan(x: imag(64)): bool do return isNan(x:real(64));
+
+  /* Returns `true` if the argument `x` does not represent a valid number;
+     `false` otherwise. */
+  @edition(last="2.0")
+  @unstable("isNan is unstable pending review and will be stabilized in a future edition")
   inline proc isNan(x: imag(32)): bool do return isNan(x:real(32));
 
   //
@@ -419,7 +461,7 @@ module AutoMath {
     return if x > y then x else y;
   }
 
-  pragma "last resort"
+  // pragma "last resort"
   @chpldoc.nodoc
   inline proc max(param x: numeric, param y: numeric) param
     where isComplex(x) || isComplex(y) do
@@ -507,7 +549,7 @@ module AutoMath {
     return if x < y then x else y;
   }
 
-  pragma "last resort"
+  // pragma "last resort"
   @chpldoc.nodoc
   inline proc min(param x: numeric, param y: numeric) param
     where isComplex(x) || isComplex(y) do

--- a/modules/standard/AutoMath.chpl
+++ b/modules/standard/AutoMath.chpl
@@ -295,6 +295,14 @@ module AutoMath {
      `false` otherwise. */
   inline proc isFinite(x: real(32)): bool do return chpl_macro_float_isfinite(x):bool;
 
+  /* Returns `true` if the argument `x` is a representation of a finite value;
+     `false` otherwise. */
+  inline proc isFinite(x: imag(64)): bool do return isFinite(x:real(64));
+
+  /* Returns `true` if the argument `x` is a representation of a finite value;
+     `false` otherwise. */
+  inline proc isFinite(x: imag(32)): bool do return isFinite(x:real(32));
+
   /* Returns `true` if the argument `x` is a representation of *infinity*;
      `false` otherwise. */
   inline proc isInf(x: real(64)): bool do return chpl_macro_double_isinf(x):bool;
@@ -303,6 +311,14 @@ module AutoMath {
      `false` otherwise. */
   inline proc isInf(x: real(32)): bool do return chpl_macro_float_isinf(x):bool;
 
+  /* Returns `true` if the argument `x` is a representation of *infinity*;
+     `false` otherwise. */
+  inline proc isInf(x: imag(64)): bool do return isInf(x:real(64));
+
+  /* Returns `true` if the argument `x` is a representation of *infinity*;
+     `false` otherwise. */
+  inline proc isInf(x: imag(32)): bool do return isInf(x:real(32));
+
   /* Returns `true` if the argument `x` does not represent a valid number;
      `false` otherwise. */
   inline proc isNan(x: real(64)): bool do return chpl_macro_double_isnan(x):bool;
@@ -310,6 +326,14 @@ module AutoMath {
   /* Returns `true` if the argument `x` does not represent a valid number;
      `false` otherwise. */
   inline proc isNan(x: real(32)): bool do return chpl_macro_float_isnan(x):bool;
+
+  /* Returns `true` if the argument `x` does not represent a valid number;
+     `false` otherwise. */
+  inline proc isNan(x: imag(64)): bool do return isNan(x:real(64));
+
+  /* Returns `true` if the argument `x` does not represent a valid number;
+     `false` otherwise. */
+  inline proc isNan(x: imag(32)): bool do return isNan(x:real(32));
 
   //
   // min and max
@@ -339,6 +363,11 @@ module AutoMath {
   inline proc max(x: real(64), y: real(64)) do return if (x > y) || isNan(x) then x else y;
 
   @chpldoc.nodoc
+  inline proc max(x: imag(32), y: imag(32)) do return if (x > y) || isNan(x) then x else y;
+  @chpldoc.nodoc
+  inline proc max(x: imag(64), y: imag(64)) do return if (x > y) || isNan(x) then x else y;
+
+  @chpldoc.nodoc
   inline proc max(x: int(8), y: uint(8)) do return if x > y then x : uint(8) else y;
   @chpldoc.nodoc
   inline proc max(x: int(16), y: uint(16)) do return if x > y then x : uint(16) else y;
@@ -362,6 +391,11 @@ module AutoMath {
     compilerError("min() and max() are not supported for atomic arguments - apply read() to those arguments first");
   }
 
+  pragma "last resort"
+  @chpldoc.nodoc
+  proc max(x, y) where isComplexType(x.type) || isComplexType(y.type) do
+    compilerError("min() and max() are not supported for complex arguments");
+
   /* Returns the maximum value of two arguments using the ``>`` operator
      for comparison.
      If one of the arguments is :proc:`Math.nan`, the result is also nan.
@@ -384,6 +418,12 @@ module AutoMath {
     where !(isComplex(x) || isComplex(y)) {
     return if x > y then x else y;
   }
+
+  pragma "last resort"
+  @chpldoc.nodoc
+  inline proc max(param x: numeric, param y: numeric) param
+    where isComplex(x) || isComplex(y) do
+    compilerError("min() and max() are not supported for complex arguments");
 
   @chpldoc.nodoc
   inline proc min(x: int(8), y: int(8)) do return if x < y then x else y;
@@ -409,6 +449,11 @@ module AutoMath {
   inline proc min(x: real(64), y: real(64)) do return if (x < y) || isNan(x) then x else y;
 
   @chpldoc.nodoc
+  inline proc min(x: imag(32), y: imag(32)) do return if (x < y) || isNan(x) then x else y;
+  @chpldoc.nodoc
+  inline proc min(x: imag(64), y: imag(64)) do return if (x < y) || isNan(x) then x else y;
+
+  @chpldoc.nodoc
   inline proc min(x: int(8), y: uint(8)) do return if x < y then x else y : int(8);
   @chpldoc.nodoc
   inline proc min(x: int(16), y: uint(16)) do return if x < y then x else y : int(16);
@@ -431,6 +476,11 @@ module AutoMath {
   proc min(x, y) where isAtomicType(x.type) || isAtomicType(y.type) {
     compilerError("min() and max() are not supported for atomic arguments - apply read() to those arguments first");
   }
+
+  pragma "last resort"
+  @chpldoc.nodoc
+  proc min(x, y) where isComplexType(x.type) || isComplexType(y.type) do
+    compilerError("min() and max() are not supported for complex arguments");
 
 
   /* Returns the minimum value of two arguments using the ``<`` operator
@@ -456,6 +506,12 @@ module AutoMath {
     where !(isComplex(x) || isComplex(y)) {
     return if x < y then x else y;
   }
+
+  pragma "last resort"
+  @chpldoc.nodoc
+  inline proc min(param x: numeric, param y: numeric) param
+    where isComplex(x) || isComplex(y) do
+    compilerError("min() and max() are not supported for complex arguments");
 
   /* Computes the mod operator on the two arguments, defined as
      ``mod(x,y) = x - y * floor(x / y)``.

--- a/test/expressions/complexOrderedCompareErrors.chpl
+++ b/test/expressions/complexOrderedCompareErrors.chpl
@@ -1,0 +1,27 @@
+enum testCases {
+  compare,
+  compareParam,
+  min,
+  maxParam
+}
+config param testCase = testCases.compare;
+
+if testCase == testCases.compare {
+  const x: complex = 1.0 + 2.0i;
+  const y: complex = 4.0 + 3.0i;
+  writeln("x < y: ", x < y);
+} else if testCase == testCases.compareParam {
+  param x: complex = 1.0 + 2.0i;
+  param y: complex = 4.0 + 3.0i;
+  param z = x >= y;
+  writeln("x >= y: ", z);
+} else if testCase == testCases.min {
+  const x: complex = 1.0 + 2.0i;
+  const y: complex = 4.0 + 3.0i;
+  writeln("min(x, y): ", min(x, y));
+} else if testCase == testCases.maxParam {
+  param x: complex = 1.0 + 2.0i;
+  param y: complex = 4.0 + 3.0i;
+  param z = max(x, y);
+  writeln("max(x, y): ", z);
+}

--- a/test/expressions/complexOrderedCompareErrors.compare.good
+++ b/test/expressions/complexOrderedCompareErrors.compare.good
@@ -1,0 +1,1 @@
+complexOrderedCompareErrors.chpl:12: error: ordered comparison of complex numbers is not supported

--- a/test/expressions/complexOrderedCompareErrors.compareParam.good
+++ b/test/expressions/complexOrderedCompareErrors.compareParam.good
@@ -1,0 +1,1 @@
+complexOrderedCompareErrors.chpl:16: error: ordered comparison of complex numbers is not supported

--- a/test/expressions/complexOrderedCompareErrors.compopts
+++ b/test/expressions/complexOrderedCompareErrors.compopts
@@ -1,0 +1,4 @@
+-stestCase=testCases.compare # complexOrderedCompareErrors.compare.good
+-stestCase=testCases.compareParam # complexOrderedCompareErrors.compareParam.good
+-stestCase=testCases.min # complexOrderedCompareErrors.min.good
+-stestCase=testCases.maxParam # complexOrderedCompareErrors.maxParam.good

--- a/test/expressions/complexOrderedCompareErrors.maxParam.good
+++ b/test/expressions/complexOrderedCompareErrors.maxParam.good
@@ -1,0 +1,1 @@
+complexOrderedCompareErrors.chpl:25: error: min() and max() are not supported for complex arguments

--- a/test/expressions/complexOrderedCompareErrors.min.good
+++ b/test/expressions/complexOrderedCompareErrors.min.good
@@ -1,0 +1,1 @@
+complexOrderedCompareErrors.chpl:21: error: min() and max() are not supported for complex arguments

--- a/test/expressions/imagOrderedCompare.chpl
+++ b/test/expressions/imagOrderedCompare.chpl
@@ -1,0 +1,96 @@
+config const verbose = false;
+type types = (imag(32), imag(64));
+
+inline proc vals(param idx) param {
+  select idx {
+    when 0 do return 0.0i;
+    when 1 do return 1.0i;
+    when 2 do return -2.0i;
+    when 3 do return 4.0i;
+    when 4 do return -8.0i;
+    when 5 do return 0.5i;
+    when 6 do return 0.125i;
+    when 7 do return 16.0i;
+    otherwise compilerError("Invalid index");
+  }
+}
+param vals_size = 8;
+
+
+for param i in 0..<types.size {
+  type t = types(i);
+
+  for param m in 0..<vals_size {
+    for param n in 0..<vals_size {
+      param a = vals(m):t;
+      param b = vals(n):t;
+
+      param lt = a < b;
+      param gt = a > b;
+      param le = a <= b;
+      param ge = a >= b;
+      param eq = a == b;
+      param ne = a != b;
+      param minVal = min(a, b);
+      param maxVal = max(a, b);
+
+      const aa = a;
+      const bb = b;
+      const lt2 = aa < bb;
+      const gt2 = aa > bb;
+      const le2 = aa <= bb;
+      const ge2 = aa >= bb;
+      const eq2 = aa == bb;
+      const ne2 = aa != bb;
+      const minVal2 = min(aa, bb);
+      const maxVal2 = max(aa, bb);
+
+      if verbose then
+        writeln(a, " X ", b, ": ",
+                "a < b = ", lt, ", ",
+                "a > b = ", gt, ", ",
+                "a <= b = ", le, ", ",
+                "a >= b = ", ge, ", ",
+                "a == b = ", eq, ", ",
+                "a != b = ", ne, ", ",
+                "min(a, b) = ", minVal, ", ",
+                "max(a, b) = ", maxVal);
+
+      // check for consistency between param and non-param versions of the comparisons
+      if lt != lt2 then
+        writeln("ERROR: ", a, " < ", b, " = ", lt, " != ", lt2);
+      if gt != gt2 then
+        writeln("ERROR: ", a, " > ", b, " = ", gt, " != ", gt2);
+      if le != le2 then
+        writeln("ERROR: ", a, " <= ", b, " = ", le, " != ", le2);
+      if ge != ge2 then
+        writeln("ERROR: ", a, " >= ", b, " = ", ge, " != ", ge2);
+      if eq != eq2 then
+        writeln("ERROR: ", a, " == ", b, " = ", eq, " != ", eq2);
+      if ne != ne2 then
+        writeln("ERROR: ", a, " != ", b, " = ", ne, " != ", ne2);
+      if minVal != minVal2 then
+        writeln("ERROR: min(", a, ", ", b, ") = ", minVal, " != ", minVal2);
+      if maxVal != maxVal2 then
+        writeln("ERROR: max(", a, ", ", b, ") = ", maxVal, " != ", maxVal2);
+
+      // check that the values are correct by casting to real and comparing to the real values
+      if lt != (a:real < b:real) then
+        writeln("ERROR: ", a, " < ", b, " = ", lt, " != ", (a:real < b:real));
+      if gt != (a:real > b:real) then
+        writeln("ERROR: ", a, " > ", b, " = ", gt, " != ", (a:real > b:real));
+      if le != (a:real <= b:real) then
+        writeln("ERROR: ", a, " <= ", b, " = ", le, " != ", (a:real <= b:real));
+      if ge != (a:real >= b:real) then
+        writeln("ERROR: ", a, " >= ", b, " = ", ge, " != ", (a:real >= b:real));
+      if eq != (a:real == b:real) then
+        writeln("ERROR: ", a, " == ", b, " = ", eq, " != ", (a:real == b:real));
+      if ne != (a:real != b:real) then
+        writeln("ERROR: ", a, " != ", b, " = ", ne, " != ", (a:real != b:real));
+      if minVal:real != min(a:real, b:real) then
+        writeln("ERROR: min(", a, ", ", b, ") = ", minVal, " != ", min(a:real, b:real));
+      if maxVal:real != max(a:real, b:real) then
+        writeln("ERROR: max(", a, ", ", b, ") = ", maxVal, " != ", max(a:real, b:real));
+    }
+  }
+}

--- a/test/library/standard/Math/imagInfinity.chpl
+++ b/test/library/standard/Math/imagInfinity.chpl
@@ -1,0 +1,32 @@
+var x = inf:imag(64);
+var y = -inf:imag(64);
+var z = nan:imag(64);
+var x32 = inf: imag(32);
+var y32 = -inf: imag(32);
+var z32 = nan: imag(32);
+
+if (isInf(x)) then writeln("inf okay.");
+if (isFinite(x)) then writeln("inf not okay.");
+if (isNan(x)) then writeln("inf not okay.");
+
+if (isInf(y)) then writeln("-inf okay.");
+if (isFinite(y)) then writeln("-inf not okay.");
+if (isNan(y)) then writeln("-inf not okay.");
+
+if (isInf(z)) then writeln("nan not okay.");
+if (isFinite(z)) then writeln("nan not okay.");
+if (isNan(z)) then writeln("nan okay.");
+
+if (isInf(x32)) then writeln("inf32 okay.");
+if (isFinite(x32)) then writeln("inf32 not okay.");
+if (isNan(x32)) then writeln("inf32 not okay.");
+
+if (isInf(y32)) then writeln("-inf32 okay.");
+if (isFinite(y32)) then writeln("-inf32 not okay.");
+if (isNan(y32)) then writeln("-inf32 not okay.");
+
+if (isInf(z32)) then writeln("nan32 not okay.");
+if (isFinite(z32)) then writeln("nan32 not okay.");
+if (isNan(z32)) then writeln("nan32 okay.");
+
+if (isFinite(12345i)) then writeln("Finite test passes.");

--- a/test/library/standard/Math/imagInfinity.compopts
+++ b/test/library/standard/Math/imagInfinity.compopts
@@ -1,0 +1,3 @@
+ # imagInfinity.good
+--warn-unstable # imagInfinity.unstable.good
+--warn-unstable --edition=preview # imagInfinity.good

--- a/test/library/standard/Math/imagInfinity.good
+++ b/test/library/standard/Math/imagInfinity.good
@@ -1,0 +1,7 @@
+inf okay.
+-inf okay.
+nan okay.
+inf32 okay.
+-inf32 okay.
+nan32 okay.
+Finite test passes.

--- a/test/library/standard/Math/imagInfinity.unstable.good
+++ b/test/library/standard/Math/imagInfinity.unstable.good
@@ -1,0 +1,26 @@
+imagInfinity.chpl:8: warning: isInf is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:9: warning: isFinite is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:10: warning: isNan is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:12: warning: isInf is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:13: warning: isFinite is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:14: warning: isNan is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:16: warning: isInf is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:17: warning: isFinite is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:18: warning: isNan is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:20: warning: isInf is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:21: warning: isFinite is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:22: warning: isNan is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:24: warning: isInf is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:25: warning: isFinite is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:26: warning: isNan is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:28: warning: isInf is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:29: warning: isFinite is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:30: warning: isNan is unstable pending review and will be stabilized in a future edition
+imagInfinity.chpl:32: warning: isFinite is unstable pending review and will be stabilized in a future edition
+inf okay.
+-inf okay.
+nan okay.
+inf32 okay.
+-inf32 okay.
+nan32 okay.
+Finite test passes.


### PR DESCRIPTION
Adds missing comparison numbers for imaginary numbers, both at runtime and compile time

Also makes sure to implement min/max for imaginary numbers (at runtime and compile time), as well as `isFinite`, `isInf`, and `isNan`

Built on https://github.com/chapel-lang/chapel/pull/29081

Resolves https://github.com/chapel-lang/chapel/issues/29051

- [x] paratest

[Reviewed by @benharsh]