### PR TITLE
Codegen line information as a 32 bit int

### DIFF
--- a/compiler/AST/type.cpp
+++ b/compiler/AST/type.cpp
@@ -1053,7 +1053,7 @@ FunctionType::Formal FunctionType::constructErrorHandlingFormal() {
 std::array<FunctionType::Formal, 2>
 FunctionType::constructLineFileInfoFormals() {
   std::array<Formal, 2> ret = {{
-    Formal(QUAL_CONST_VAL, dtInt[INT_SIZE_DEFAULT], INTENT_CONST_IN, astr__ln, 0),
+    Formal(QUAL_CONST_VAL, dtInt[INT_SIZE_32], INTENT_CONST_IN, astr__ln, 0),
     Formal(QUAL_CONST_VAL, dtInt[INT_SIZE_32], INTENT_CONST_IN, astr__fn, 0),
   }};
 

--- a/compiler/codegen/cg-expr.cpp
+++ b/compiler/codegen/cg-expr.cpp
@@ -5132,7 +5132,7 @@ DEFINE_PRIM(UNORDERED_ASSIGN) {
     // chpl_gen_comm_get_unordered(void *dst,
     //   c_nodeid_t src_locale, void* src_raddr,
     //   size_t size, int32_t commID,
-    //   int ln, int32_t fn);
+    //   int32_t ln, int32_t fn);
 
     dst = codegenValuePtr(dst);
     if (dstRef)
@@ -5150,7 +5150,7 @@ DEFINE_PRIM(UNORDERED_ASSIGN) {
     // chpl_gen_comm_put_unordered(void *src,
     //   c_nodeid_t dst_locale, void* dst_raddr,
     //   size_t size, int32_t commID,
-    //   int ln, int32_t fn);
+    //   int32_t ln, int32_t fn);
 
     src = codegenValuePtr(src);
     if (srcRef)
@@ -5169,7 +5169,7 @@ DEFINE_PRIM(UNORDERED_ASSIGN) {
     //   c_nodeid_t dst_locale, void* dst_raddr,
     //   c_nodeid_t src_locale, void* src_raddr,
     //   size_t size, int32_t commID,
-    //   int ln, int32_t fn);
+    //   int32_t ln, int32_t fn);
     codegenCall("chpl_gen_comm_getput_unordered",
                 codegenRnode(dst),
                 codegenRaddr(dst),

--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -87,17 +87,17 @@ void chpl_cache_exit(void);
 // If release is set, waits on any pending puts in the cache.
 // If acquire is set, sets this task's last acquire fence to
 // the cache's current request number.
-void chpl_cache_fence(int acquire, int release, int ln, int32_t fn);
+void chpl_cache_fence(int acquire, int release, int32_t ln, int32_t fn);
 
 // "acquire" barrier or fence -> discard pre-fetched GET values
 static inline
-void chpl_cache_acquire(int ln, int32_t fn)
+void chpl_cache_acquire(int32_t ln, int32_t fn)
 {
   if (chpl_cache_enabled()) chpl_cache_fence(1, 0, ln, fn);
 }
 // "release" barrier or fence -> complete pending PUTs
 static inline
-void chpl_cache_release(int ln, int32_t fn)
+void chpl_cache_release(int32_t ln, int32_t fn)
 {
   if (chpl_cache_enabled()) chpl_cache_fence(0, 1, ln, fn);
 }
@@ -106,27 +106,27 @@ void chpl_cache_release(int ln, int32_t fn)
 // These are the functions that the generated code should be eventually
 // calling on a put or a get.
 void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                         size_t size, int32_t commID, int ln, int32_t fn);
+                         size_t size, int32_t commID, int32_t ln, int32_t fn);
 void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                         size_t size, int32_t commID, int ln, int32_t fn);
+                         size_t size, int32_t commID, int32_t ln, int32_t fn);
 void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
-                              size_t size, int32_t commID, int ln, int32_t fn);
+                              size_t size, int32_t commID, int32_t ln, int32_t fn);
 void  chpl_cache_comm_get_strd(
                    void *addr, void *dststr, c_nodeid_t node, void *raddr,
                    void *srcstr, void *count, int32_t strlevels,
-                   size_t elemSize, int32_t commID, int ln, int32_t fn);
+                   size_t elemSize, int32_t commID, int32_t ln, int32_t fn);
 void  chpl_cache_comm_put_strd(
                       void *addr, void *dststr, c_nodeid_t node, void *raddr,
                       void *srcstr, void *count, int32_t strlevels,
-                      size_t elemSize, int32_t commID, int ln, int32_t fn);
+                      size_t elemSize, int32_t commID, int32_t ln, int32_t fn);
 void chpl_cache_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
-                                   size_t size, int32_t commID, int ln, int32_t fn);
+                                   size_t size, int32_t commID, int32_t ln, int32_t fn);
 void chpl_cache_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
-                                   size_t size, int32_t commID, int ln, int32_t fn);
+                                   size_t size, int32_t commID, int32_t ln, int32_t fn);
 void chpl_cache_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
                                       c_nodeid_t srcnode, void* srcaddr,
                                       size_t size, int32_t commID,
-                                      int ln, int32_t fn);
+                                      int32_t ln, int32_t fn);
 void chpl_cache_comm_getput_unordered_task_fence(void);
 
 int chpl_cache_pagesize(void);
@@ -139,7 +139,7 @@ void chpl_cache_print_stats(void);
 // returns 1 if the data was cached
 int chpl_cache_mock_get(c_nodeid_t node, uint64_t raddr, size_t size);
 void chpl_cache_invalidate(c_nodeid_t node, void* raddr, size_t size,
-                           int ln, int32_t fn);
+                           int32_t ln, int32_t fn);
 
 #ifdef __cplusplus
 }

--- a/runtime/include/chpl-comm-callbacks.h
+++ b/runtime/include/chpl-comm-callbacks.h
@@ -138,7 +138,7 @@ typedef struct {
       void *raddr;               // Destination address
       size_t size;               // Size of communication
       int32_t commID;            // unique identifier for this get/put
-      int lineno;                // source line of communication
+      int32_t lineno;                // source line of communication
       int32_t filename;          // source file of communication
     } comm;
 
@@ -152,7 +152,7 @@ typedef struct {
       int32_t stridelevels;
       size_t elemSize;
       int32_t commID;           // unique identifier for this get/put
-      int lineno;               // source line of communication
+      int32_t lineno;               // source line of communication
       int32_t filename;         // source file of communication
     } comm_strd;
 
@@ -161,7 +161,7 @@ typedef struct {
       chpl_fn_int_t fid;        //  Function ID
       void *arg;                //  Function arg pointer
       size_t arg_size;          //  Function arg size
-      int lineno;               // source line of communication
+      int32_t lineno;               // source line of communication
       int32_t filename;         // source file of communication
     } executeOn;
 

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -59,7 +59,7 @@ static ___always_inline int chpl_rt_is_cache_enabled_fast(void) {
 
 static ___always_inline
 void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                       size_t size, int32_t commID, int ln, int32_t fn)
+                       size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   if (chpl_nodeID == node) {
     memmove(addr, raddr, size);
@@ -75,7 +75,7 @@ void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
 static inline
 void chpl_gen_comm_get_from_subloc(void *addr, c_nodeid_t src_node,
                                    c_sublocid_t src_subloc, void* raddr,
-                                   size_t size, int32_t commID, int ln,
+                                   size_t size, int32_t commID, int32_t ln,
                                    int32_t fn)
 {
   c_sublocid_t dst_subloc = chpl_task_getRequestedSubloc();
@@ -97,7 +97,7 @@ void chpl_gen_comm_get_from_subloc(void *addr, c_nodeid_t src_node,
 
 static inline
 void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
-                            size_t size, int32_t commID, int ln, int32_t fn)
+                            size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   const size_t MAX_BYTES_LOCAL_PREFETCH = 1024;
   size_t offset;
@@ -123,7 +123,7 @@ void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
 
 static ___always_inline
 void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                       size_t size, int32_t commID, int ln, int32_t fn)
+                       size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   if (chpl_nodeID == node) {
     memmove(raddr, addr, size);
@@ -140,7 +140,7 @@ static inline
 void chpl_gen_comm_put_to_subloc(void* addr,
                                  c_nodeid_t dst_node, c_sublocid_t dst_subloc,
                                  void* raddr, size_t size, int32_t commID,
-                                 int ln, int32_t fn)
+                                 int32_t ln, int32_t fn)
 {
 
   c_sublocid_t src_subloc = chpl_task_getRequestedSubloc();
@@ -163,7 +163,7 @@ void chpl_gen_comm_put_to_subloc(void* addr,
 static inline
 void chpl_gen_comm_get_strd(void *addr, void *dststr, c_nodeid_t node, c_sublocid_t src_subloc, void *raddr,
                        void *srcstr, void *count, int32_t strlevels,
-                       size_t elemSize, int32_t commID, int ln, int32_t fn)
+                       size_t elemSize, int32_t commID, int32_t ln, int32_t fn)
 {
 #ifdef HAS_GPU_LOCALE
   c_sublocid_t dst_subloc = chpl_task_getRequestedSubloc();
@@ -188,7 +188,7 @@ void chpl_gen_comm_get_strd(void *addr, void *dststr, c_nodeid_t node, c_subloci
 static inline
 void chpl_gen_comm_put_strd(void *addr, void *dststr, c_nodeid_t node, c_sublocid_t dst_subloc, void *raddr,
                        void *srcstr, void *count, int32_t strlevels,
-                       size_t elemSize, int32_t commID, int ln, int32_t fn)
+                       size_t elemSize, int32_t commID, int32_t ln, int32_t fn)
 {
 #ifdef HAS_GPU_LOCALE
   c_sublocid_t src_subloc = chpl_task_getRequestedSubloc();
@@ -213,7 +213,7 @@ void chpl_gen_comm_put_strd(void *addr, void *dststr, c_nodeid_t node, c_subloci
 
 static inline
 void chpl_gen_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
-                                 size_t size, int32_t commID, int ln, int32_t fn)
+                                 size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS
@@ -227,7 +227,7 @@ void chpl_gen_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
 
 static inline
 void chpl_gen_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
-                                 size_t size, int32_t commID, int ln, int32_t fn)
+                                 size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS
@@ -243,7 +243,7 @@ static inline
 void chpl_gen_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
                                     c_nodeid_t srcnode, void* srcaddr,
                                     size_t size, int32_t commID,
-                                    int ln, int32_t fn)
+                                    int32_t ln, int32_t fn)
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS

--- a/runtime/include/chpl-comm-internal.h
+++ b/runtime/include/chpl-comm-internal.h
@@ -129,7 +129,7 @@ void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg,
                                   chpl_fn_int_t fid,
                                   chpl_comm_on_bundle_t *arg,
                                   size_t arg_size,
-                                  int ln,
+                                  int32_t ln,
                                   int32_t fn);
 
 // Per comm layer implementation.
@@ -139,7 +139,7 @@ void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg,
                                        chpl_fn_int_t fid,
                                        chpl_comm_on_bundle_t *arg,
                                        size_t arg_size,
-                                       int ln,
+                                       int32_t ln,
                                        int32_t fn);
 
 // Per comm layer implementation.
@@ -149,7 +149,7 @@ void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg,
                                      chpl_fn_int_t fid,
                                      chpl_comm_on_bundle_t *arg,
                                      size_t arg_size,
-                                     int ln,
+                                     int32_t ln,
                                      int32_t fn);
 
 #ifdef __cplusplus

--- a/runtime/include/chpl-comm-native-atomics.h
+++ b/runtime/include/chpl-comm-native-atomics.h
@@ -47,7 +47,7 @@ extern "C" {
 #define DECL_CHPL_COMM_ATOMIC_WRITE(type)                               \
   void chpl_comm_atomic_write_ ## type                                  \
          (void* desired, c_nodeid_t node, void* object,                 \
-          chpl_memory_order order, int ln, int32_t fn);
+          chpl_memory_order order, int32_t ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_WRITE(int8)
 DECL_CHPL_COMM_ATOMIC_WRITE(int16)
@@ -70,7 +70,7 @@ DECL_CHPL_COMM_ATOMIC_WRITE(real64)
 #define DECL_CHPL_COMM_ATOMIC_READ(type)                                \
   void chpl_comm_atomic_read_ ## type                                   \
          (void* result, c_nodeid_t node, void* object,                  \
-          chpl_memory_order order, int ln, int32_t fn);
+          chpl_memory_order order, int32_t ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_READ(int8)
 DECL_CHPL_COMM_ATOMIC_READ(int16)
@@ -92,7 +92,7 @@ DECL_CHPL_COMM_ATOMIC_READ(real64)
 #define DECL_CHPL_COMM_ATOMIC_XCHG(type)                                \
   void chpl_comm_atomic_xchg_ ## type                                   \
          (void* desired, c_nodeid_t node, void* object, void* result,   \
-          chpl_memory_order order, int ln, int32_t fn);
+          chpl_memory_order order, int32_t ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_XCHG(int8)
 DECL_CHPL_COMM_ATOMIC_XCHG(int16)
@@ -117,7 +117,7 @@ DECL_CHPL_COMM_ATOMIC_XCHG(real64)
   void chpl_comm_atomic_cmpxchg_ ## type                                \
          (void* expected, void* desired, c_nodeid_t node, void* object, \
           chpl_bool32* result, chpl_memory_order succ, chpl_memory_order fail,    \
-          int ln, int32_t fn);
+          int32_t ln, int32_t fn);
 
 DECL_CHPL_COMM_ATOMIC_CMPXCHG(int8)
 DECL_CHPL_COMM_ATOMIC_CMPXCHG(int16)
@@ -143,15 +143,15 @@ DECL_CHPL_COMM_ATOMIC_CMPXCHG(real64)
 #define DECL_CHPL_COMM_ATOMIC_NONFETCH_BINARY(op, type)                 \
   void chpl_comm_atomic_ ## op ## _ ## type                             \
          (void* operand, c_nodeid_t node, void* object,                 \
-          chpl_memory_order order, int ln, int32_t fn);
+          chpl_memory_order order, int32_t ln, int32_t fn);
 #define DECL_CHPL_COMM_ATOMIC_NONFETCH_UNORDERED_BINARY(op, type)       \
   void chpl_comm_atomic_ ## op ## _unordered_ ## type                   \
          (void* operand, c_nodeid_t node, void* object,                 \
-          int ln, int32_t fn);
+          int32_t ln, int32_t fn);
 #define DECL_CHPL_COMM_ATOMIC_FETCH_BINARY(op, type)                    \
   void chpl_comm_atomic_fetch_ ## op ## _ ## type                       \
          (void* operand, c_nodeid_t node, void* object, void* result,   \
-          chpl_memory_order order, int ln, int32_t fn);
+          chpl_memory_order order, int32_t ln, int32_t fn);
 #define DECL_CHPL_COMM_ATOMIC_BINARY(op, type)                          \
   DECL_CHPL_COMM_ATOMIC_NONFETCH_BINARY(op, type)                       \
   DECL_CHPL_COMM_ATOMIC_NONFETCH_UNORDERED_BINARY(op, type)             \

--- a/runtime/include/chpl-comm-strd-xfer.h
+++ b/runtime/include/chpl-comm-strd-xfer.h
@@ -72,13 +72,13 @@ static inline
 void strd_nb_helper(chpl_comm_nb_handle_t (*xferFn)(void*, int32_t, void*,
                                                     size_t,
                                                     int32_t,
-                                                    int, int32_t),
+                                                    int32_t, int32_t),
                     void* localAddr, int32_t remoteLocale, void* remoteAddr,
                     size_t cnt,
                     chpl_comm_nb_handle_t* handles, size_t* pCurrHandles,
                     size_t maxOutstandingXfers,
                     void (yieldFn)(void),
-                    int32_t commID, int ln, int32_t fn)
+                    int32_t commID, int32_t ln, int32_t fn)
 {
   size_t currHandles = *pCurrHandles;
 
@@ -140,7 +140,7 @@ void put_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t dstlocale,
                      void* srcaddr_arg, size_t* srcstrides,
                      size_t* count, int32_t stridelevels, size_t elemSize,
                      size_t maxOutstandingXfers, void (yieldFn)(void),
-                     int32_t commID, int ln, int32_t fn) {
+                     int32_t commID, int32_t ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
   // allocate arrays with at least 1 element to avoid zero-length arrays
   // if strlvls is 0, these arrays will not be used
@@ -289,7 +289,7 @@ void get_strd_common(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
                      void* srcaddr_arg, size_t* srcstrides,
                      size_t* count, int32_t stridelevels, size_t elemSize,
                      size_t maxOutstandingXfers, void (yieldFn)(void),
-                     int32_t commID, int ln, int32_t fn) {
+                     int32_t commID, int32_t ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
   // allocate arrays with at least 1 element to avoid zero-length arrays
   // if strlvls is 0, these arrays will not be used
@@ -447,7 +447,7 @@ void strd_common_call(void* dstaddr_arg, size_t* dststrides, int32_t srclocale,
                                       /* ctx */ void*,
                                       /* commID */ int32_t,
                                       /* ln */ int, /* fn */ int32_t),
-                      int32_t commID, int ln, int32_t fn) {
+                      int32_t commID, int32_t ln, int32_t fn) {
   const size_t strlvls=(size_t)stridelevels;
   // allocate arrays with at least 1 element to avoid zero-length arrays
   // if strlvls is 0, these arrays will not be used

--- a/runtime/include/chpl-comm.h
+++ b/runtime/include/chpl-comm.h
@@ -99,7 +99,7 @@ void chpl_rt_comm_task_ftable_call(
                       chpl_comm_on_bundle_t* arg,   // function arg
                       size_t arg_size,              // length of arg in bytes
                       c_sublocid_t subloc,          // desired sublocale
-                      int lineno,                   // source line
+                      int32_t lineno,                   // source line
                       int32_t filename) {           // source filename
     arg->kind = CHPL_ARG_BUNDLE_KIND_COMM;
     chpl_rt_task_task_ftable_call(prg, fid, arg, arg_size, subloc,
@@ -140,14 +140,14 @@ void chpl_rt_comm_bundle_ftable_call(chpl_comm_on_bundle_t* bundle) {
 // before the request completes (after waiting on the returned handle)
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t commID,
-                                       int ln, int32_t fn);
+                                       int32_t ln, int32_t fn);
 
 // Do a PUT in a nonblocking fashion, returning a handle which can be used to
 // wait for the PUT to complete. The source buffer must not be modified before
 // the request completes (after waiting on the returned handle)
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t commID,
-                                       int ln, int32_t fn);
+                                       int32_t ln, int32_t fn);
 
 // Returns nonzero iff the handle has already been waited for and has
 // been cleared out in a call to chpl_comm_{wait,try}_some.
@@ -327,7 +327,7 @@ size_t chpl_comm_regMemAllocThreshold(void) {
 #endif
 static inline
 void* chpl_comm_regMemAlloc(size_t size,
-                            chpl_mem_descInt_t desc, int ln, int32_t fn) {
+                            chpl_mem_descInt_t desc, int32_t ln, int32_t fn) {
   return CHPL_COMM_IMPL_REG_MEM_ALLOC(size, desc, ln, fn);
 }
 
@@ -344,7 +344,7 @@ void chpl_comm_regMemPostAlloc(void* p, size_t size) {
 #endif
 static inline
 void* chpl_comm_regMemRealloc(void* p, size_t oldSize, size_t newSize,
-                              chpl_mem_descInt_t desc, int ln, int32_t fn) {
+                              chpl_mem_descInt_t desc, int32_t ln, int32_t fn) {
   return CHPL_COMM_IMPL_REG_MEM_REALLOC(p, oldSize, newSize, desc, ln, fn);
 }
 
@@ -477,7 +477,7 @@ void chpl_comm_exit(int all, int status);
 //   size and locale are part of p
 //
 void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                   size_t size, int32_t commID, int ln, int32_t fn);
+                   size_t size, int32_t commID, int32_t ln, int32_t fn);
 
 //
 // get 'size' bytes of remote data at 'raddr' on locale 'locale' to
@@ -487,7 +487,7 @@ void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
 //   size and locale are part of p
 //
 void chpl_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t commID, int ln, int32_t fn);
+                    size_t size, int32_t commID, int32_t ln, int32_t fn);
 
 //
 // put the number of elements pointed out by count array, with strides pointed
@@ -504,7 +504,7 @@ void chpl_comm_get(void *addr, c_nodeid_t node, void* raddr,
 void chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode,
                         void* srcaddr, size_t* srcstrides, size_t* count,
                         int32_t stridelevels, size_t elemSize, int32_t commID,
-                        int ln, int32_t fn);
+                        int32_t ln, int32_t fn);
 
 //
 // same as chpl_comm_puts(), but do get instead
@@ -512,22 +512,22 @@ void chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode,
 void chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode,
                         void* srcaddr, size_t* srcstrides, size_t* count,
                         int32_t stridelevels, size_t elemSize, int32_t commID,
-                        int ln, int32_t fn);
+                        int32_t ln, int32_t fn);
 
 
 //
 // Unordered ops
 //
 void chpl_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn);
+                             size_t size, int32_t commID, int32_t ln, int32_t fn);
 
 void chpl_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn);
+                             size_t size, int32_t commID, int32_t ln, int32_t fn);
 
 void chpl_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
                                 c_nodeid_t srcnode, void* srcaddr,
                                 size_t size, int32_t commID,
-                                int ln, int32_t fn);
+                                int32_t ln, int32_t fn);
 
 void chpl_comm_getput_unordered_task_fence(void);
 
@@ -546,7 +546,7 @@ void chpl_rt_comm_execute_on(chpl_rt_prginfo* prg, c_nodeid_t node,
                              chpl_fn_int_t fid,
                              chpl_comm_on_bundle_t *arg,
                              size_t arg_size,
-                             int ln,
+                             int32_t ln,
                              int32_t fn);
 
 //
@@ -558,7 +558,7 @@ void chpl_rt_comm_execute_on_nb(chpl_rt_prginfo* prg, c_nodeid_t node,
                                 chpl_fn_int_t fid,
                                 chpl_comm_on_bundle_t *arg,
                                 size_t arg_size,
-                                int ln,
+                                int32_t ln,
                                 int32_t fn);
 
 //
@@ -570,7 +570,7 @@ void chpl_rt_comm_execute_on_fast(chpl_rt_prginfo* prg, c_nodeid_t node,
                                   chpl_fn_int_t fid,
                                   chpl_comm_on_bundle_t *arg,
                                   size_t arg_size,
-                                  int ln,
+                                  int32_t ln,
                                   int32_t fn);
 
 //

--- a/runtime/include/chpl-gen-includes.h
+++ b/runtime/include/chpl-gen-includes.h
@@ -66,7 +66,7 @@ chpl_localeID_t id_rt2pub(c_localeid_t i)
 {
   return chpl_rt_buildLocaleID(i >> 32, i & 0xffffffff);
 }
-extern void chpl_getLocaleID (chpl_localeID_t* localeID,  int64_t _ln, int32_t _fn);
+extern void chpl_getLocaleID (chpl_localeID_t* localeID, int32_t _ln, int32_t _fn);
 static inline
 chpl_localeID_t chpl_gen_getLocaleID(void)
 {

--- a/runtime/include/chpl-gpu.h
+++ b/runtime/include/chpl-gpu.h
@@ -93,13 +93,13 @@ void chpl_gpu_support_module_finished_initializing(void);
 
 void* chpl_gpu_init_kernel_cfg(const char* fn_name, int64_t num_threads,
                                int blk_dim, int n_params, int n_pids,
-                               int n_redbufs, int n_hostreg_vars, int ln,
+                               int n_redbufs, int n_hostreg_vars, int32_t ln,
                                int32_t fn);
 void* chpl_gpu_init_kernel_cfg_3d(const char* fn_name,
                                   int grd_dim_x, int grd_dim_y, int grd_dim_z,
                                   int blk_dim_x, int blk_dim_y, int blk_dim_z,
                                   int n_params, int n_pids, int n_redbufs,
-                                  int n_hostreg_vars, int ln, int32_t fn);
+                                  int n_hostreg_vars, int32_t ln, int32_t fn);
 
 void chpl_gpu_deinit_kernel_cfg(void* cfg);
 void chpl_gpu_arg_offload(void* cfg, void* arg, size_t size);
@@ -128,40 +128,40 @@ void chpl_gpu_hostmem_register(void *memAlloc, size_t size);
 
 void chpl_gpu_memcpy(c_sublocid_t dst_subloc, void* dst,
                      c_sublocid_t src_subloc, const void* src,
-                     size_t n, int32_t commID, int ln, int32_t fn);
+                     size_t n, int32_t commID, int32_t ln, int32_t fn);
 void chpl_gpu_comm_put(c_nodeid_t dst_node, c_sublocid_t dst_subloc, void *dst,
                        c_sublocid_t src_subloc, void *src,
-                       size_t size, int32_t commID, int ln, int32_t fn);
+                       size_t size, int32_t commID, int32_t ln, int32_t fn);
 
 void chpl_gpu_comm_get(c_sublocid_t dst_subloc, void *dst,
                        c_nodeid_t src_node, c_sublocid_t src_subloc, void *src,
-                       size_t size, int32_t commID, int ln, int32_t fn);
+                       size_t size, int32_t commID, int32_t ln, int32_t fn);
 
 void chpl_gpu_comm_get_strd(c_sublocid_t dst_subloc,
                             void* dstaddr_arg, size_t* dststrides,
                             c_nodeid_t srclocale, c_sublocid_t src_subloc,
                             void* srcaddr_arg, size_t* srcstrides,
                             size_t* count, int32_t strlevels, size_t elemSize,
-                            int32_t commID, int ln, int32_t fn);
+                            int32_t commID, int32_t ln, int32_t fn);
 
 void chpl_gpu_comm_put_strd(c_sublocid_t src_subloc,
                           void* dstaddr_arg, size_t* dststrides,
                           c_nodeid_t dstlocale, c_sublocid_t dst_subloc,
                           void* srcaddr_arg, size_t* srcstrides,
                           size_t* count, int32_t stridelevels, size_t elemSize,
-                          int32_t commID, int ln, int32_t fn);
+                          int32_t commID, int32_t ln, int32_t fn);
 
 
 void* chpl_gpu_memset(void* addr, const uint8_t val, size_t n);
 void chpl_gpu_copy_device_to_host(void* dst, c_sublocid_t src_dev,
                                   const void* src, size_t n, int32_t commID,
-                                  int ln, int32_t fn);
+                                  int32_t ln, int32_t fn);
 void chpl_gpu_copy_host_to_device(c_sublocid_t dst_dev, void* dst,
                                   const void* src, size_t n, int32_t commID,
-                                  int ln, int32_t fn);
+                                  int32_t ln, int32_t fn);
 void chpl_gpu_copy_device_to_device(c_sublocid_t dst_dev, void* dst,
                                     c_sublocid_t src_dev, const void* src,
-                                    size_t n, int32_t commID, int ln,
+                                    size_t n, int32_t commID, int32_t ln,
                                     int32_t fn);
 void* chpl_gpu_comm_async(void *dst, void *src, size_t n);
 void chpl_gpu_comm_wait(void *stream);

--- a/runtime/include/chpl-mem-consistency.h
+++ b/runtime/include/chpl-mem-consistency.h
@@ -65,7 +65,7 @@ extern "C" {
 // task.
 
 static inline
-void chpl_rmem_consist_release(int ln, int32_t fn)
+void chpl_rmem_consist_release(int32_t ln, int32_t fn)
 {
 #ifdef HAS_CHPL_CACHE_FNS
   chpl_cache_release(ln, fn);
@@ -76,7 +76,7 @@ void chpl_rmem_consist_release(int ln, int32_t fn)
 }
 
 static inline
-void chpl_rmem_consist_acquire(int ln, int32_t fn)
+void chpl_rmem_consist_acquire(int32_t ln, int32_t fn)
 {
 #ifdef HAS_CHPL_CACHE_FNS
   chpl_cache_acquire(ln, fn);
@@ -92,8 +92,8 @@ void chpl_rmem_consist_acquire(int ln, int32_t fn)
 // operations/fences.
 
 static inline
-//void chpl_atomic_rmem_fence_pre(chpl_memory_order order, int ln, int32_t fn) {
-void chpl_rmem_consist_maybe_release(chpl_memory_order order, int ln, int32_t fn) {
+//void chpl_atomic_rmem_fence_pre(chpl_memory_order order, int32_t ln, int32_t fn) {
+void chpl_rmem_consist_maybe_release(chpl_memory_order order, int32_t ln, int32_t fn) {
   if(order==chpl_memory_order_acquire || order==chpl_memory_order_relaxed) {
     // do nothing
   } else {
@@ -102,8 +102,8 @@ void chpl_rmem_consist_maybe_release(chpl_memory_order order, int ln, int32_t fn
   }
 }
 static inline
-//void chpl_atomic_rmem_fence_post(chpl_memory_order order, int ln, int32_t fn) {
-void chpl_rmem_consist_maybe_acquire(chpl_memory_order order, int ln, int32_t fn) {
+//void chpl_atomic_rmem_fence_post(chpl_memory_order order, int32_t ln, int32_t fn) {
+void chpl_rmem_consist_maybe_acquire(chpl_memory_order order, int32_t ln, int32_t fn) {
   if(order==chpl_memory_order_release || order==chpl_memory_order_relaxed) {
     // do nothing
   } else {
@@ -113,8 +113,8 @@ void chpl_rmem_consist_maybe_acquire(chpl_memory_order order, int ln, int32_t fn
 }
 
 static inline
-//void chpl_atomic_rmem_fence(chpl_memory_order order, int ln, int32_t fn) {
-void chpl_rmem_consist_fence(chpl_memory_order order, int ln, int32_t fn) {
+//void chpl_atomic_rmem_fence(chpl_memory_order order, int32_t ln, int32_t fn) {
+void chpl_rmem_consist_fence(chpl_memory_order order, int32_t ln, int32_t fn) {
   if(order==chpl_memory_order_relaxed) {
     // do nothing
   } else {

--- a/runtime/include/chpl-prginfo-data-macro.h
+++ b/runtime/include/chpl-prginfo-data-macro.h
@@ -105,18 +105,18 @@ E_CONSTANT_RT(chpl_ftableSize, int64_t)
 /** MODULE-CODE: ChapelLocale.chpl
     Call to increment the task running count.
 */
-E_CALLBACK_RT(chpl_taskRunningCntInc, void, int64_t _ln, int32_t _fn)
+E_CALLBACK_RT(chpl_taskRunningCntInc, void, int32_t _ln, int32_t _fn)
 
 /** MODULE-CODE: ChapelLocale.chpl
     Call to decrement the task running count. Seemingly only invoked
     by the compiler at codegen time (see 'gChplDecRunningTask').
 */
-E_CALLBACK_RT(chpl_taskRunningCntDec, void, int64_t _ln, int32_t _fn)
+E_CALLBACK_RT(chpl_taskRunningCntDec, void, int32_t _ln, int32_t _fn)
 
 /** MODULE-CODE: ChapelLocale.chpl
     Call to reset the task running count.
 */
-E_CALLBACK_RT(chpl_taskRunningCntReset, void, int64_t _ln, int32_t _fn)
+E_CALLBACK_RT(chpl_taskRunningCntReset, void, int32_t _ln, int32_t _fn)
 
 /** CODE-GENERATED
     Function which constructs the config variable table.
@@ -132,17 +132,17 @@ E_CALLBACK_RT(chpl__initStringLiterals, void, void)
     Module initializer which sets initialization flags to false.
     TODO: Why? Won't zero-initialization set these to false?
 */
-E_CALLBACK_RT(chpl__init_preInit, void, int64_t _ln, int32_t _fn)
+E_CALLBACK_RT(chpl__init_preInit, void, int32_t _ln, int32_t _fn)
 
 /** CODE-GENERATED
     Module initializer for the 'PrintModuleInitOrder' module.
 */
-E_CALLBACK_RT(chpl__init_PrintModuleInitOrder, void, int64_t _ln, int32_t _fn)
+E_CALLBACK_RT(chpl__init_PrintModuleInitOrder, void, int32_t _ln, int32_t _fn)
 
 /** CODE-GENERATED
     Module initializer for the 'ChapelStandard' module.
 */
-E_CALLBACK_RT(chpl__init_ChapelStandard, void, int64_t _ln, int32_t _fn)
+E_CALLBACK_RT(chpl__init_ChapelStandard, void, int32_t _ln, int32_t _fn)
 
 /** CODE-GENERATED
     Main entrypoint for this program.

--- a/runtime/include/chpl-tasks-callbacks-internal.h
+++ b/runtime/include/chpl-tasks-callbacks-internal.h
@@ -40,7 +40,7 @@ extern int chpl_task_callback_counts[chpl_task_cb_num_event_kinds];
 void chpl_task_do_callbacks_internal(chpl_task_cb_event_kind_t,
                                      chpl_fn_int_t fid,
                                      int32_t filename,
-                                     int lineno,
+                                     int32_t lineno,
                                      uint64_t id,
                                      int is_executeOn);
 
@@ -56,7 +56,7 @@ static inline
 void chpl_task_do_callbacks(chpl_task_cb_event_kind_t event_kind,
                             chpl_fn_int_t fid,
                             int32_t filename,
-                            int lineno,
+                            int32_t lineno,
                             uint64_t id,
                             int is_executeOn) {
   if (chpl_task_have_callbacks(event_kind))

--- a/runtime/include/chpl-tasks-callbacks.h
+++ b/runtime/include/chpl-tasks-callbacks.h
@@ -146,7 +146,7 @@ typedef struct {
                                 // chpl_task_cb_info_kind_full:
       chpl_fn_int_t fid;        //   number of function to call
       int32_t filename;         //   source file of task definition
-      int lineno;               //   source line of task definition
+      int32_t lineno;               //   source line of task definition
       uint64_t id;              //   unique ID, within locale
       int is_executeOn;         //   !=0: task is for executeOn body
     } full;

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -443,9 +443,9 @@ chpl_bool chpl_task_doTaskReport(void);
 // These are service functions provided to the runtime by the module
 // code.
 //
-extern void chpl_taskRunningCntInc(int64_t _ln, int32_t _fn);
-extern void chpl_taskRunningCntDec(int64_t _ln, int32_t _fn);
-extern void chpl_taskRunningCntReset(int64_t _ln, int32_t _fn);
+extern void chpl_taskRunningCntInc(int32_t _ln, int32_t _fn);
+extern void chpl_taskRunningCntDec(int32_t _ln, int32_t _fn);
+extern void chpl_taskRunningCntReset(int32_t _ln, int32_t _fn);
 
 #ifdef __cplusplus
 } // end extern "C"

--- a/runtime/include/chpl-tasks.h
+++ b/runtime/include/chpl-tasks.h
@@ -74,7 +74,7 @@ typedef struct {
 typedef struct chpl_task_bundle {
   chpl_arg_bundle_kind_t kind;  // 'kind' indicator must be first in any bundle
   chpl_bool is_executeOn;
-  int lineno;
+  int32_t lineno;
   int filename;
   chpl_rt_prginfo* prg;
   c_sublocid_t requestedSubloc;
@@ -209,7 +209,7 @@ void chpl_rt_task_task_ftable_call(chpl_rt_prginfo* prg,
                                    void* arg,           // function arg
                                    size_t arg_size,     // length of arg
                                    c_sublocid_t subloc, // desired sublocale
-                                   int lineno,          // source line
+                                   int32_t lineno,          // source line
                                    int32_t filename);   // source filename
 
 // In some cases, we are not worried about the "function number" (fid)

--- a/runtime/include/chplcast.h
+++ b/runtime/include/chplcast.h
@@ -43,16 +43,16 @@ uint32_t c_string_to_uint32_t_precise(c_string str, int* invalid, char* invalidC
 uint64_t c_string_to_uint64_t_precise(c_string str, int* invalid, char* invalidChar);
 
 /* string to every other primitive type */
-int8_t c_string_to_int8_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
-int16_t c_string_to_int16_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
-int32_t c_string_to_int32_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
-int64_t c_string_to_int64_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
-uint8_t c_string_to_uint8_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
-uint16_t c_string_to_uint16_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
-uint32_t c_string_to_uint32_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
-uint64_t c_string_to_uint64_t(c_string str, chpl_bool* err, int lineno, int32_t filename);
+int8_t c_string_to_int8_t(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+int16_t c_string_to_int16_t(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+int32_t c_string_to_int32_t(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+int64_t c_string_to_int64_t(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+uint8_t c_string_to_uint8_t(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+uint16_t c_string_to_uint16_t(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+uint32_t c_string_to_uint32_t(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+uint64_t c_string_to_uint64_t(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
 
-chpl_bool c_string_to_chpl_bool(c_string str, chpl_bool* err, int lineno, int32_t filename);
+chpl_bool c_string_to_chpl_bool(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
 
 _real32 c_string_to_real32_precise(c_string str, int* invalid, char* invalidCh);
 _real64 c_string_to_real64_precise(c_string str, int* invalid, char* invalidCh);
@@ -61,12 +61,12 @@ _imag64 c_string_to_imag64_precise(c_string str, int* invalid, char* invalidCh);
 _complex64 c_string_to_complex64_precise(c_string str, int* invalid, char* invalidCh);
 _complex128 c_string_to_complex128_precise(c_string str, int* invalid, char* invalidCh);
 
-_real32 c_string_to_real32(c_string str, chpl_bool* err, int lineno, int32_t filename);
-_real64 c_string_to_real64(c_string str, chpl_bool* err, int lineno, int32_t filename);
-_imag32 c_string_to_imag32(c_string str, chpl_bool* err, int lineno, int32_t filename);
-_imag64 c_string_to_imag64(c_string str, chpl_bool* err, int lineno, int32_t filename);
-_complex64 c_string_to_complex64(c_string str, chpl_bool* err, int lineno, int32_t filename);
-_complex128 c_string_to_complex128(c_string str, chpl_bool* err, int lineno, int32_t filename);
+_real32 c_string_to_real32(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+_real64 c_string_to_real64(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+_imag32 c_string_to_imag32(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+_imag64 c_string_to_imag64(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+_complex64 c_string_to_complex64(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
+_complex128 c_string_to_complex128(c_string str, chpl_bool* err, int32_t lineno, int32_t filename);
 
 
 /* every other primitive type to string */

--- a/runtime/include/chpltypes.h
+++ b/runtime/include/chpltypes.h
@@ -179,7 +179,7 @@ typedef int16_t chpl_fn_int_t;    // int type for ftable indexing
 typedef struct _chpl_fn_info {
   const char *name;
   int fileno;
-  int lineno;
+  int32_t lineno;
 } chpl_fn_info;
 
 // It is tempting to #undef true and false and then #define them just to be sure

--- a/runtime/include/comm/ugni/chpl-comm-impl.h
+++ b/runtime/include/comm/ugni/chpl-comm-impl.h
@@ -48,7 +48,7 @@ size_t chpl_comm_impl_regMemAllocThreshold(void);
 #define CHPL_COMM_IMPL_REG_MEM_ALLOC(size, desc, ln, fn) \
     chpl_comm_impl_regMemAlloc(size, desc, ln, fn)
 void* chpl_comm_impl_regMemAlloc(size_t size,
-                                 chpl_mem_descInt_t desc, int ln, int32_t fn);
+                                 chpl_mem_descInt_t desc, int32_t ln, int32_t fn);
 
 #define CHPL_COMM_IMPL_REG_MEM_POST_ALLOC(p, size) \
   chpl_comm_impl_regMemPostAlloc(p, size)
@@ -58,7 +58,7 @@ void chpl_comm_impl_regMemPostAlloc(void* p, size_t size);
     chpl_comm_impl_regMemRealloc(p, oldSize, newSize, desc, ln, fn)
 void* chpl_comm_impl_regMemRealloc(void* p, size_t oldSize, size_t newSize,
                                    chpl_mem_descInt_t desc,
-                                   int ln, int32_t fn);
+                                   int32_t ln, int32_t fn);
 
 #define CHPL_COMM_IMPL_REG_MEM_POST_REALLOC(oldp, oldSize, newp, newSize) \
     chpl_comm_impl_regMemPostRealloc(oldp, oldSize, newp, newSize)

--- a/runtime/include/gpu/chpl-gpu-gen-common.h
+++ b/runtime/include/gpu/chpl-gpu-gen-common.h
@@ -59,7 +59,7 @@ __device__ static inline c_nodeid_t chpl_rt_sublocFromLocaleID(chpl_localeID_t l
 }
 
 __device__ static inline void chpl_gen_comm_get(void *addr, c_nodeid_t node,
-  void* raddr, size_t size, int32_t commID, int ln, int32_t fn)
+  void* raddr, size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   printf("Warning: chpl_gen_comm_get called inside a GPU kernel. This shouldn't have happened.\n");
   // TODO
@@ -69,14 +69,14 @@ __device__ static inline void chpl_gen_comm_get_unordered(void *addr,
                                                           c_nodeid_t node,
                                                           void* raddr, size_t
                                                           size, int32_t commID,
-                                                          int ln, int32_t fn)
+                                                          int32_t ln, int32_t fn)
 {
   printf("Warning: chpl_gen_comm_get_unordered called inside a GPU kernel. This shouldn't have happened.\n");
   // TODO
 }
 
 __device__ static inline void chpl_gen_comm_put(void* addr, c_nodeid_t node,
-  void* raddr, size_t size, int32_t commID, int ln, int32_t fn)
+  void* raddr, size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   printf("Warning: chpl_gen_comm_put called inside a GPU kernel. This shouldn't have happened.\n");
   // TODO
@@ -86,7 +86,7 @@ __device__ static inline void chpl_gen_comm_put_unordered(void *addr,
                                                           c_nodeid_t node,
                                                           void* raddr, size_t
                                                           size, int32_t commID,
-                                                          int ln, int32_t fn)
+                                                          int32_t ln, int32_t fn)
 {
   printf("Warning: chpl_gen_comm_put_unordered called inside a GPU kernel. This shouldn't have happened.\n");
   // TODO
@@ -96,7 +96,7 @@ __device__ static inline void chpl_gen_comm_getput_unordered(
                                             c_nodeid_t dstnode, void* dstaddr,
                                             c_nodeid_t srcnode, void* srcaddr,
                                             size_t size, int32_t commID,
-                                            int ln, int32_t fn)
+                                            int32_t ln, int32_t fn)
 {
   printf("Warning: chpl_gen_comm_getput_unordered called inside a GPU kernel. This shouldn't have happened.\n");
   // TODO
@@ -197,7 +197,7 @@ __host__ static inline void chpl_gpu_force_warp_sync(unsigned mask) {
 __device__ static inline
 void chpl_gen_comm_get_from_subloc(void *addr, c_nodeid_t src_node,
                                    c_sublocid_t src_subloc, void* raddr,
-                                   size_t size, int32_t commID, int ln,
+                                   size_t size, int32_t commID, int32_t ln,
                                    int32_t fn) {
   printf("Warning: chpl_gen_comm_get_from_subloc called inside a GPU kernel. This shouldn't have happened.\n");
   // TODO
@@ -207,7 +207,7 @@ __device__ static inline
 void chpl_gen_comm_put_to_subloc(void* addr,
                                  c_nodeid_t dst_node, c_sublocid_t dst_subloc,
                                  void* raddr, size_t size, int32_t commID,
-                                 int ln, int32_t fn) {
+                                 int32_t ln, int32_t fn) {
   printf("Warning: chpl_gen_comm_get_from_subloc called inside a GPU kernel. This shouldn't have happened.\n");
   // TODO
 
@@ -222,7 +222,7 @@ void chpl_internal_error(const char* message) {
 __device__ extern int chpl_haltFlag;
 
 __device__ static inline
-void chpl_gpu_halt(int lineno, int32_t filenameIdx) {
+void chpl_gpu_halt(int32_t lineno, int32_t filenameIdx) {
   chpl_haltFlag = 1;
 }
 

--- a/runtime/include/qio/qio_error.h
+++ b/runtime/include/qio/qio_error.h
@@ -40,7 +40,7 @@ struct qio_err_s {
   // for debugging purposes.
   const char* const_fn;
   const char* const_file;
-  int lineno;
+  int32_t lineno;
 };
 // qioerr is meant to store either an error code directly
 // or a pointer to a struct err_s. There are several ways

--- a/runtime/src/arg.c
+++ b/runtime/src/arg.c
@@ -119,7 +119,7 @@ static void parseDashEArgs(int* argc, char* argv[]) {
   const int32_t filename = CHPL_FILE_IDX_COMMAND_LINE_ARG;
 
   for (int i = 1; i < *argc; i++) {
-    int lineno = i;
+    int32_t lineno = i;
     const char* currentArg = argv[i];
 
     if (currentArg[0] == '-' && currentArg[1] == 'E') {
@@ -381,7 +381,7 @@ void parseArgs(chpl_bool isLauncher, chpl_parseArgsMode_t mode,
 
   for (i = 1; i < *argc; i++) {
     const int32_t filename = CHPL_FILE_IDX_COMMAND_LINE_ARG;
-    int lineno = i + (origargc - *argc);
+    int32_t lineno = i + (origargc - *argc);
     int argLength = 0;
     const char* currentArg = argv[i];
     argLength = strlen(currentArg);

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2502,7 +2502,7 @@ int cache_put_in_page(struct rdcache_s* cache,
                       chpl_cache_taskPrvData_t* task_local,
                       unsigned char* addr,
                       c_nodeid_t node, raddr_t raddr, size_t size,
-                      int32_t commID, int ln, int32_t fn)
+                      int32_t commID, int32_t ln, int32_t fn)
 {
   struct cache_entry_s* entry;
   raddr_t ra_page;
@@ -2604,7 +2604,7 @@ int cache_put(struct rdcache_s* cache,
               chpl_cache_taskPrvData_t* task_local,
               unsigned char* addr,
               c_nodeid_t node, raddr_t raddr, size_t size,
-              int32_t commID, int ln, int32_t fn)
+              int32_t commID, int32_t ln, int32_t fn)
 {
   raddr_t ra_first_page;
   raddr_t ra_last_page;
@@ -2677,7 +2677,7 @@ int cache_get(struct rdcache_s* cache,
               unsigned char * addr,
               c_nodeid_t node, raddr_t raddr, size_t size,
               int sequential_readahead_length,
-              int32_t commID, int ln, int32_t fn);
+              int32_t commID, int32_t ln, int32_t fn);
 
 static
 void cache_get_trigger_readahead(struct rdcache_s* cache,
@@ -2688,7 +2688,7 @@ void cache_get_trigger_readahead(struct rdcache_s* cache,
                                  // skip < 0 -> reverse, >0 -> forward
                                  readahead_distance_t skip,
                                  readahead_distance_t len,
-                                 int32_t commID, int ln, int32_t fn)
+                                 int32_t commID, int32_t ln, int32_t fn)
 {
   // Handle prefetching.
   // See http://www.ece.eng.wayne.edu/~sjiang/Tsinghua-2010/linux-readahead.pdf
@@ -2898,7 +2898,7 @@ int cache_get_in_page(struct rdcache_s* cache,
                       c_nodeid_t node, raddr_t raddr, size_t size,
                       raddr_t ra_first_page, raddr_t ra_last_page,
                       int sequential_readahead_length,
-                      int32_t commID, int ln, int32_t fn)
+                      int32_t commID, int32_t ln, int32_t fn)
 {
   struct cache_entry_s* entry;
   raddr_t ra_page;
@@ -3251,7 +3251,7 @@ int cache_get(struct rdcache_s* cache,
               unsigned char * addr,
               c_nodeid_t node, raddr_t raddr, size_t size,
               int sequential_readahead_length,
-              int32_t commID, int ln, int32_t fn)
+              int32_t commID, int32_t ln, int32_t fn)
 {
   raddr_t ra_first_page;
   raddr_t ra_last_page;
@@ -3334,7 +3334,7 @@ int mock_get(struct rdcache_s* cache,
              c_nodeid_t node, raddr_t raddr, size_t size,
              cache_seqn_t last_acquire,
              int sequential_readahead_length,
-             int32_t commID, int ln, int32_t fn)
+             int32_t commID, int32_t ln, int32_t fn)
 {
   struct cache_entry_s* entry;
   struct cache_entry_s* aout_entry;
@@ -3775,7 +3775,7 @@ void chpl_cache_exit(void)
 }
 
 
-void chpl_cache_fence(int acquire, int release, int ln, int32_t fn)
+void chpl_cache_fence(int acquire, int release, int32_t ln, int32_t fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
@@ -3814,7 +3814,7 @@ void chpl_cache_fence(int acquire, int release, int ln, int32_t fn)
 }
 
 void chpl_cache_invalidate(c_nodeid_t node, void* raddr, size_t size,
-                           int ln, int32_t fn)
+                           int32_t ln, int32_t fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
@@ -3841,7 +3841,7 @@ int size_merits_direct_comm(const struct rdcache_s* cache, size_t size)
 }
 
 void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                         size_t size, int32_t commID, int ln, int32_t fn)
+                         size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
@@ -3889,7 +3889,7 @@ void chpl_cache_comm_put(void* addr, c_nodeid_t node, void* raddr,
 }
 
 void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
-                         size_t size, int32_t commID, int ln, int32_t fn)
+                         size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
@@ -3937,7 +3937,7 @@ void chpl_cache_comm_get(void *addr, c_nodeid_t node, void* raddr,
 }
 
 void chpl_cache_comm_prefetch(c_nodeid_t node, void* raddr,
-                              size_t size, int32_t commID, int ln, int32_t fn)
+                              size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
@@ -3969,7 +3969,7 @@ void strd_invalidate_fn(void* addr,
                         size_t size,
                         void* ctxv,
                         int32_t commID,
-                        int ln,
+                        int32_t ln,
                         int32_t fn)
 {
 
@@ -3985,7 +3985,7 @@ static
 void strd_invalidate(void *addr, void *dststr, c_nodeid_t node,
                      void *raddr, void *srcstr, void *count,
                      int32_t strlevels, size_t elemSize,
-                     int32_t commID, int ln, int32_t fn) {
+                     int32_t commID, int32_t ln, int32_t fn) {
 
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
@@ -4006,7 +4006,7 @@ void strd_invalidate(void *addr, void *dststr, c_nodeid_t node,
 void chpl_cache_comm_get_strd(void *addr, void *dststr, c_nodeid_t node,
                               void *raddr, void *srcstr, void *count,
                               int32_t strlevels, size_t elemSize,
-                              int32_t commID, int ln, int32_t fn) {
+                              int32_t commID, int32_t ln, int32_t fn) {
   TRACE_PRINT(("%d: in chpl_cache_comm_get_strd\n", chpl_nodeID));
 
   if (STRIDED_INVALIDATE_ALL) {
@@ -4043,7 +4043,7 @@ void chpl_cache_comm_get_strd(void *addr, void *dststr, c_nodeid_t node,
 void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
                               void *raddr, void *srcstr, void *count,
                               int32_t strlevels, size_t elemSize,
-                              int32_t commID, int ln, int32_t fn) {
+                              int32_t commID, int32_t ln, int32_t fn) {
   TRACE_PRINT(("%d: in chpl_cache_comm_put_strd\n", chpl_nodeID));
 
   if (STRIDED_INVALIDATE_ALL) {
@@ -4083,7 +4083,7 @@ void chpl_cache_comm_put_strd(void *addr, void *dststr, c_nodeid_t node,
 // overlapping regions beforehand.
 //
 void chpl_cache_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
-                                   size_t size, int32_t commID, int ln, int32_t fn)
+                                   size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
@@ -4105,7 +4105,7 @@ void chpl_cache_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
 }
 
 void chpl_cache_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
-                                   size_t size, int32_t commID, int ln, int32_t fn)
+                                   size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();
@@ -4130,7 +4130,7 @@ void chpl_cache_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
 void chpl_cache_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
                                       c_nodeid_t srcnode, void* srcaddr,
                                       size_t size, int32_t commID,
-                                      int ln, int32_t fn)
+                                      int32_t ln, int32_t fn)
 {
   struct rdcache_s* cache = tls_cache_remote_data();
   chpl_cache_taskPrvData_t* task_local = task_private_cache_data();

--- a/runtime/src/chpl-comm.c
+++ b/runtime/src/chpl-comm.c
@@ -194,7 +194,7 @@ static void execute_on_family_common_setup(chpl_rt_prginfo* prg,
                                            chpl_fn_int_t fid,
                                            chpl_comm_on_bundle_t* on_bundle,
                                            size_t arg_size,
-                                           int ln,
+                                           int32_t ln,
                                            int32_t fn) {
   chpl_task_bundle_t* task_bundle = &on_bundle->task_bundle;
 
@@ -218,7 +218,7 @@ void chpl_rt_comm_execute_on(chpl_rt_prginfo* prg, c_nodeid_t node,
                              chpl_fn_int_t fid,
                              chpl_comm_on_bundle_t *arg,
                              size_t arg_size,
-                             int ln,
+                             int32_t ln,
                              int32_t fn) {
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn)) {
     chpl_comm_cb_info_t cb_data =
@@ -242,7 +242,7 @@ void chpl_rt_comm_execute_on_nb(chpl_rt_prginfo* prg, c_nodeid_t node,
                                 chpl_fn_int_t fid,
                                 chpl_comm_on_bundle_t* arg,
                                 size_t arg_size,
-                                int ln,
+                                int32_t ln,
                                 int32_t fn) {
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_nb)) {
     chpl_comm_cb_info_t cb_data =
@@ -266,7 +266,7 @@ void chpl_rt_comm_execute_on_fast(chpl_rt_prginfo* prg, c_nodeid_t node,
                                   chpl_fn_int_t fid,
                                   chpl_comm_on_bundle_t *arg,
                                   size_t arg_size,
-                                  int ln,
+                                  int32_t ln,
                                   int32_t fn) {
   if (chpl_comm_have_callbacks(chpl_comm_cb_event_kind_executeOn_fast)) {
     chpl_comm_cb_info_t cb_data =

--- a/runtime/src/chpl-gpu.c
+++ b/runtime/src/chpl-gpu.c
@@ -351,7 +351,7 @@ typedef struct kernel_cfg_s {
 
 static void cfg_init(kernel_cfg* cfg, const char* fn_name,
                      int n_params, int n_pids, int n_reduce_vars,
-                     int n_host_registered_vars, int ln, int32_t fn) {
+                     int n_host_registered_vars, int32_t ln, int32_t fn) {
 
   cfg->fn_name = fn_name;
 
@@ -679,7 +679,7 @@ static int cfg_get_halt_flag(kernel_cfg* cfg) {
 void* chpl_gpu_init_kernel_cfg(const char* fn_name, int64_t num_threads,
                                int blk_dim, int n_params, int n_pids,
                                int n_reduce_vars, int n_host_registered_vars,
-                               int ln, int32_t fn) {
+                               int32_t ln, int32_t fn) {
   void* ret = chpl_mem_alloc(sizeof(kernel_cfg),
                              CHPL_RT_MD_GPU_KERNEL_PARAM_META, ln, fn);
 
@@ -699,7 +699,7 @@ void* chpl_gpu_init_kernel_cfg_3d(const char* fn_name,
                                   int grd_dim_x, int grd_dim_y, int grd_dim_z,
                                   int blk_dim_x, int blk_dim_y, int blk_dim_z,
                                   int n_params, int n_pids, int n_reduce_vars,
-                                  int n_host_registered_vars, int ln,
+                                  int n_host_registered_vars, int32_t ln,
                                   int32_t fn) {
 
   void* ret = chpl_mem_alloc(sizeof(kernel_cfg),
@@ -965,7 +965,7 @@ extern void chpl_gpu_comm_on_get(c_sublocid_t src_subloc, void* addr,
 
 void chpl_gpu_comm_put(c_nodeid_t dst_node, c_sublocid_t dst_subloc, void *dst,
                        c_sublocid_t src_subloc, void *src,
-                       size_t size, int32_t commID, int ln, int32_t fn)
+                       size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   void* src_data = src;
   c_sublocid_t src_data_subloc = src_subloc;
@@ -997,7 +997,7 @@ void chpl_gpu_comm_put(c_nodeid_t dst_node, c_sublocid_t dst_subloc, void *dst,
 
 void chpl_gpu_comm_get(c_sublocid_t dst_subloc, void *dst,
                        c_nodeid_t src_node, c_sublocid_t src_subloc, void *src,
-                       size_t size, int32_t commID, int ln, int32_t fn)
+                       size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   void* dst_buff = dst;
   c_sublocid_t dst_buff_subloc = dst_subloc;
@@ -1031,7 +1031,7 @@ void chpl_gpu_comm_get_strd(c_sublocid_t dst_subloc,
                           c_nodeid_t srclocale, c_sublocid_t src_subloc,
                           void* srcaddr_arg, size_t* srcstrides,
                           size_t* count, int32_t stridelevels, size_t elemSize,
-                          int32_t commID, int ln, int32_t fn) {
+                          int32_t commID, int32_t ln, int32_t fn) {
   // TODO: Re-use code from chpl-comm-strd-xfer.h instead of copying it here.
   //
   // Note: This function differs from the original in chpl-comm-strd-xfer.h by
@@ -1171,7 +1171,7 @@ void chpl_gpu_comm_put_strd(c_sublocid_t src_subloc,
                           c_nodeid_t dstlocale, c_sublocid_t dst_subloc,
                           void* srcaddr_arg, size_t* srcstrides,
                           size_t* count, int32_t stridelevels, size_t elemSize,
-                          int32_t commID, int ln, int32_t fn) {
+                          int32_t commID, int32_t ln, int32_t fn) {
   // TODO: Re-use code from chpl-comm-strd-xfer.h instead of copying it here.
   //
   // Note: This function differs from the original in chpl-comm-strd-xfer.h by
@@ -1308,7 +1308,7 @@ void chpl_gpu_comm_put_strd(c_sublocid_t src_subloc,
 
 void chpl_gpu_memcpy(c_sublocid_t dst_subloc, void* dst,
                      c_sublocid_t src_subloc, const void* src, size_t n,
-                     int32_t commID, int ln, int32_t fn) {
+                     int32_t commID, int32_t ln, int32_t fn) {
 
   /* This generates just a lot of output
 
@@ -1377,7 +1377,7 @@ void* chpl_gpu_memset(void* addr, const uint8_t val, size_t n) {
 
 void chpl_gpu_copy_device_to_device(c_sublocid_t dst_dev, void* dst,
                                     c_sublocid_t src_dev, const void* src,
-                                    size_t n, int32_t commID, int ln,
+                                    size_t n, int32_t commID, int32_t ln,
                                     int32_t fn) {
   assert(chpl_gpu_is_device_ptr(src));
 
@@ -1405,7 +1405,7 @@ void chpl_gpu_copy_device_to_device(c_sublocid_t dst_dev, void* dst,
 
 void chpl_gpu_copy_device_to_host(void* dst, c_sublocid_t src_dev,
                                   const void* src, size_t n, int32_t commID,
-                                  int ln, int32_t fn) {
+                                  int32_t ln, int32_t fn) {
   assert(chpl_gpu_is_device_ptr(src));
 
 
@@ -1427,7 +1427,7 @@ void chpl_gpu_copy_device_to_host(void* dst, c_sublocid_t src_dev,
 
 void chpl_gpu_copy_host_to_device(c_sublocid_t dst_dev, void* dst,
                                   const void* src, size_t n, int32_t commID,
-                                  int ln, int32_t fn) {
+                                  int32_t ln, int32_t fn) {
   assert(chpl_gpu_is_device_ptr(dst));
 
   CHPL_GPU_DEBUG("Copying %zu bytes from host to device\n", n);

--- a/runtime/src/chpl-tasks-callbacks.c
+++ b/runtime/src/chpl-tasks-callbacks.c
@@ -106,7 +106,7 @@ int chpl_task_uninstall_callback(chpl_task_cb_event_kind_t event_kind,
 void chpl_task_do_callbacks_internal(chpl_task_cb_event_kind_t event_kind,
                                      chpl_fn_int_t fid,
                                      int32_t filename,
-                                     int lineno,
+                                     int32_t lineno,
                                      uint64_t id,
                                      int is_executeOn) {
   struct cb_info* cbp;

--- a/runtime/src/chplcast.c
+++ b/runtime/src/chplcast.c
@@ -127,7 +127,7 @@ _define_string_to_int_precise(uint, 32, 1)
 _define_string_to_int_precise(uint, 64, 1)
 
 
-chpl_bool c_string_to_chpl_bool(c_string str, chpl_bool* err, int lineno, int32_t filename) {
+chpl_bool c_string_to_chpl_bool(c_string str, chpl_bool* err, int32_t lineno, int32_t filename) {
   if (string_compare(str, "true") == 0) {
     return true;
   } else if (string_compare(str, "false") == 0) {
@@ -313,7 +313,7 @@ _define_string_to_complex_precise(complex, 128, "%lf", 64)
 
 #define _define_string_to_int_type(base, width)                             \
   _type(base, width) c_string_to_##base##width##_t(c_string str, chpl_bool* err,\
-                                                   int lineno, int32_t filename) { \
+                                                   int32_t lineno, int32_t filename) { \
     int invalid = 0;                                                    \
     char invalidStr[2] = "\0\0";                                        \
     _type(base, width) val = 0;                                         \
@@ -342,7 +342,7 @@ _define_string_to_int_type(uint, 64)
 
 #define _define_string_to_real_type(base, width)                        \
   _##base##width c_string_to_##base##width(c_string str, chpl_bool* err, \
-                                           int lineno, int32_t filename) { \
+                                           int32_t lineno, int32_t filename) { \
     int invalid = 0;                                                    \
     char invalidStr[2] = "\0\0";                                        \
     _##base##width val = 0.0;                                           \

--- a/runtime/src/comm/gasnet/comm-gasnet-ex.c
+++ b/runtime/src/comm/gasnet/comm-gasnet-ex.c
@@ -629,7 +629,7 @@ static gex_AM_Entry_t ftable[] = {
 //
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t commID,
-                                       int ln, int32_t fn)
+                                       int32_t ln, int32_t fn)
 {
   gex_Event_t ret;
   int remote_in_segment;
@@ -667,7 +667,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
 
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t commID,
-                                       int ln, int32_t fn)
+                                       int32_t ln, int32_t fn)
 {
   gex_Event_t ret;
   int remote_in_segment;
@@ -1376,7 +1376,7 @@ void chpl_comm_exit(int all, int status) {
 }
 
 void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t commID, int ln, int32_t fn) {
+                    size_t size, int32_t commID, int32_t ln, int32_t fn) {
   int remote_in_segment;
 
   if (chpl_nodeID == node) {
@@ -1452,7 +1452,7 @@ void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
 ////GASNET - define GASNET_E_ PUTGET always REMOTE
 ////GASNET - look at GASNET tools at top of README.tools has atomic counters
 void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t commID, int ln, int32_t fn) {
+                    size_t size, int32_t commID, int32_t ln, int32_t fn) {
   int remote_in_segment;
 
   if (chpl_nodeID == node) {
@@ -1575,7 +1575,7 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
 void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_id,
                          void* srcaddr, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t commID,
-                         int ln, int32_t fn) {
+                         int32_t ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
   // Avoid 0-length VLA when stridelevels is 0 (contiguous transfer), gasnet
@@ -1618,7 +1618,7 @@ void  chpl_comm_get_strd(void* dstaddr, size_t* dststrides, c_nodeid_t srcnode_i
 void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_id,
                          void* srcaddr, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t commID,
-                         int ln, int32_t fn) {
+                         int32_t ln, int32_t fn) {
   int i;
   const size_t strlvls = (size_t)stridelevels;
   // Avoid 0-length VLA when stridelevels is 0 (contiguous transfer), gasnet
@@ -1661,7 +1661,7 @@ void  chpl_comm_put_strd(void* dstaddr, size_t* dststrides, c_nodeid_t dstnode_i
 void chpl_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
                                 c_nodeid_t srcnode, void* srcaddr,
                                 size_t size, int32_t commID,
-                                int ln, int32_t fn) {
+                                int32_t ln, int32_t fn) {
   assert(dstaddr != NULL);
   assert(srcaddr != NULL);
 
@@ -1694,12 +1694,12 @@ void chpl_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
 }
 
 void chpl_comm_get_unordered(void* addr, c_nodeid_t node, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn) {
+                             size_t size, int32_t commID, int32_t ln, int32_t fn) {
   chpl_comm_get(addr, node, raddr, size, commID, ln, fn);
 }
 
 void chpl_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn) {
+                             size_t size, int32_t commID, int32_t ln, int32_t fn) {
   chpl_comm_put(addr, node, raddr, size, commID, ln, fn);
 }
 
@@ -1834,7 +1834,7 @@ void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                   chpl_fn_int_t fid,
                                   chpl_comm_on_bundle_t *arg,
                                   size_t arg_size,
-                                  int ln,
+                                  int32_t ln,
                                   int32_t fn) {
   if (chpl_nodeID == node) {
     assert(0);
@@ -1850,7 +1850,7 @@ void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                      chpl_fn_int_t fid,
                                      chpl_comm_on_bundle_t *arg,
                                      size_t arg_size,
-                                     int ln,
+                                     int32_t ln,
                                      int32_t fn) {
   if (chpl_nodeID == node) {
     assert(0); // locale model code should prevent this...
@@ -1867,7 +1867,7 @@ void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                        chpl_fn_int_t fid,
                                        chpl_comm_on_bundle_t *arg,
                                        size_t arg_size,
-                                       int ln,
+                                       int32_t ln,
                                        int32_t fn) {
   if (chpl_nodeID == node) {
     assert(0);

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -49,7 +49,7 @@
 // Chapel interface
 chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t commID,
-                                       int ln, int32_t fn)
+                                       int32_t ln, int32_t fn)
 {
   assert(node == 0);
   memmove(raddr, addr, size);
@@ -58,7 +58,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void *addr, c_nodeid_t node, void* raddr,
 
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node, void* raddr,
                                        size_t size, int32_t commID,
-                                       int ln, int32_t fn)
+                                       int32_t ln, int32_t fn)
 {
   assert(node == 0);
   memmove(addr, raddr, size);
@@ -259,14 +259,14 @@ void chpl_comm_pre_task_exit(int all) { }
 void chpl_comm_exit(int all, int status) { }
 
 void  chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t commID, int ln, int32_t fn) {
+                    size_t size, int32_t commID, int32_t ln, int32_t fn) {
   assert(node==0);
 
   memmove(raddr, addr, size);
 }
 
 void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
-                    size_t size, int32_t commID, int ln, int32_t fn) {
+                    size_t size, int32_t commID, int32_t ln, int32_t fn) {
   assert(node==0);
 
   memmove(addr, raddr, size);
@@ -275,7 +275,7 @@ void  chpl_comm_get(void* addr, c_nodeid_t node, void* raddr,
 void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t dstnode,
                          void* srcaddr_arg, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t commID,
-                         int ln, int32_t fn)
+                         int32_t ln, int32_t fn)
 {
   assert(dstnode==0);
   put_strd_common(dstaddr_arg, dststrides, dstnode,
@@ -288,7 +288,7 @@ void  chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t dstno
 void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t srcnode,
                          void* srcaddr_arg, size_t* srcstrides, size_t* count,
                          int32_t stridelevels, size_t elemSize, int32_t commID,
-                         int ln, int32_t fn)
+                         int32_t ln, int32_t fn)
 {
   assert(srcnode==0);
   get_strd_common(dstaddr_arg, dststrides, srcnode,
@@ -301,7 +301,7 @@ void  chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides, c_nodeid_t srcno
 void chpl_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
                                 c_nodeid_t srcnode, void* srcaddr,
                                 size_t size, int32_t commID,
-                                int ln, int32_t fn)
+                                int32_t ln, int32_t fn)
 {
   assert(srcnode==0);
   assert(dstnode==0);
@@ -309,14 +309,14 @@ void chpl_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
 }
 
 void chpl_comm_get_unordered(void* addr, c_nodeid_t node, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn)
+                             size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   assert(node == 0);
   memmove(addr, raddr, size);
 }
 
 void chpl_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn)
+                             size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   assert(node == 0);
   memmove(raddr, addr, size);
@@ -335,7 +335,7 @@ void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                   chpl_fn_int_t fid,
                                   chpl_comm_on_bundle_t *arg,
                                   size_t arg_size,
-                                  int ln,
+                                  int32_t ln,
                                   int32_t fn) {
   assert(node==0);
   chpl_rt_ftable_call(prg, fid, arg);
@@ -346,7 +346,7 @@ void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                      chpl_fn_int_t fid,
                                      chpl_comm_on_bundle_t *arg,
                                      size_t arg_size,
-                                     int ln,
+                                     int32_t ln,
                                      int32_t fn) {
   assert(node==0);
   CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
@@ -361,7 +361,7 @@ void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                        chpl_fn_int_t fid,
                                        chpl_comm_on_bundle_t *arg,
                                        size_t arg_size,
-                                       int ln,
+                                       int32_t ln,
                                        int32_t fn) {
   // Same as chpl_rt_comm_execute_on_impl()
   assert(node==0);

--- a/runtime/src/comm/ofi/comm-ofi.c
+++ b/runtime/src/comm/ofi/comm-ofi.c
@@ -4223,7 +4223,7 @@ void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                   chpl_fn_int_t fid,
                                   chpl_comm_on_bundle_t *arg,
                                   size_t argSize,
-                                  int ln,
+                                  int32_t ln,
                                   int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%d, %d, %d, %p, %zd)", __func__,
@@ -4239,7 +4239,7 @@ void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                      chpl_fn_int_t fid,
                                      chpl_comm_on_bundle_t *arg,
                                      size_t argSize,
-                                     int ln,
+                                     int32_t ln,
                                      int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%d, %d, %d, %p, %zd)", __func__,
@@ -4255,7 +4255,7 @@ void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t node,
                                        chpl_fn_int_t fid,
                                        chpl_comm_on_bundle_t *arg,
                                        size_t argSize,
-                                       int ln,
+                                       int32_t ln,
                                        int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%d, %d, %d, %p, %zd)", __func__,
@@ -5534,7 +5534,7 @@ void nb_handle_destroy(nb_handle_t h) {
  */
 static inline
 chpl_bool put_prologue(void* addr, c_nodeid_t node, void* raddr, size_t size,
-                       int32_t commID, int ln, int32_t fn) {
+                       int32_t commID, int32_t ln, int32_t fn) {
 
   retireDelayedAmDone(false /*taskIsEnding*/);
 
@@ -5579,7 +5579,7 @@ chpl_bool put_prologue(void* addr, c_nodeid_t node, void* raddr, size_t size,
  */
 chpl_comm_nb_handle_t chpl_comm_put_nb(void* addr, c_nodeid_t node,
                                        void* raddr, size_t size,
-                                       int32_t commID, int ln, int32_t fn) {
+                                       int32_t commID, int32_t ln, int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%p, %d, %p, %zd, %d)", __func__,
              addr, (int) node, raddr, size, (int) commID);
@@ -5600,7 +5600,7 @@ chpl_comm_nb_handle_t chpl_comm_put_nb(void* addr, c_nodeid_t node,
  */
 static inline
 chpl_bool get_prologue(void* addr, c_nodeid_t node, void* raddr, size_t size,
-                       int32_t commID, int ln, int32_t fn) {
+                       int32_t commID, int32_t ln, int32_t fn) {
 
   retireDelayedAmDone(false /*taskIsEnding*/);
 
@@ -5633,7 +5633,7 @@ chpl_bool get_prologue(void* addr, c_nodeid_t node, void* raddr, size_t size,
 
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t node,
                                        void* raddr, size_t size,
-                                       int32_t commID, int ln, int32_t fn) {
+                                       int32_t commID, int32_t ln, int32_t fn) {
   nb_handle_t handle = NULL;
   if (get_prologue(addr, node, raddr, size, commID, ln, fn)) {
     handle = ofi_get_nb(handle, addr, node, raddr, size);
@@ -5772,7 +5772,7 @@ void chpl_comm_free_nb_handle(chpl_comm_nb_handle_t h) {
 }
 
 void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
-                   size_t size, int32_t commID, int ln, int32_t fn) {
+                   size_t size, int32_t commID, int32_t ln, int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%p, %d, %p, %zd, %d)", __func__,
              addr, (int) node, raddr, size, (int) commID);
@@ -5784,7 +5784,7 @@ void chpl_comm_put(void* addr, c_nodeid_t node, void* raddr,
 }
 
 void chpl_comm_get(void* addr, int32_t node, void* raddr,
-                   size_t size, int32_t commID, int ln, int32_t fn) {
+                   size_t size, int32_t commID, int32_t ln, int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%p, %d, %p, %zd, %d)", __func__,
              addr, (int) node, raddr, size, (int) commID);
@@ -5800,7 +5800,7 @@ void chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
                         c_nodeid_t dstnode,
                         void* srcaddr_arg, size_t* srcstrides,
                         size_t* count, int32_t stridelevels, size_t elemSize,
-                        int32_t commID, int ln, int32_t fn) {
+                        int32_t commID, int32_t ln, int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%p, %p, %d, %p, %p, %p, %d, %zd, %d)", __func__,
              dstaddr_arg, dststrides, (int) dstnode, srcaddr_arg, srcstrides,
@@ -5819,7 +5819,7 @@ void chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
                         c_nodeid_t srcnode,
                         void* srcaddr_arg, size_t* srcstrides, size_t* count,
                         int32_t stridelevels, size_t elemSize,
-                        int32_t commID, int ln, int32_t fn) {
+                        int32_t commID, int32_t ln, int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%p, %p, %d, %p, %p, %p, %d, %zd, %d)", __func__,
              dstaddr_arg, dststrides, (int) srcnode, srcaddr_arg, srcstrides,
@@ -5837,7 +5837,7 @@ void chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
 void chpl_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
                                 c_nodeid_t srcnode, void* srcaddr,
                                 size_t size, int32_t commID,
-                                int ln, int32_t fn) {
+                                int32_t ln, int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%d, %p, %d, %p, %zd, %d)", __func__,
              (int) dstnode, dstaddr, (int) srcnode, srcaddr, size,
@@ -5877,7 +5877,7 @@ void chpl_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
 
 
 void chpl_comm_get_unordered(void* addr, c_nodeid_t node, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn) {
+                             size_t size, int32_t commID, int32_t ln, int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%p, %d, %p, %zd, %d)", __func__,
              addr, (int) node, raddr, size, (int) commID);
@@ -5915,7 +5915,7 @@ void chpl_comm_get_unordered(void* addr, c_nodeid_t node, void* raddr,
 
 
 void chpl_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn) {
+                             size_t size, int32_t commID, int32_t ln, int32_t fn) {
   DBG_PRINTF(DBG_IFACE,
              "%s(%p, %d, %p, %zd, %d)", __func__,
              addr, (int) node, raddr, size, (int) commID);
@@ -7644,7 +7644,7 @@ static void doAMO(c_nodeid_t, void*, const void*, const void*, void*,
 #define DEFN_CHPL_COMM_ATOMIC_WRITE(fnType, ofiType, Type)              \
   void chpl_comm_atomic_write_##fnType                                  \
          (void* desired, c_nodeid_t node, void* object,                 \
-          chpl_memory_order order, int ln, int32_t fn) {                     \
+          chpl_memory_order order, int32_t ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_IFACE_AMO_WRITE,                                     \
                "%s(%p, %d, %p, %d, %s)", __func__,                      \
                desired, (int) node, object,                             \
@@ -7673,7 +7673,7 @@ DEFN_CHPL_COMM_ATOMIC_WRITE(real64, FI_DOUBLE, _real64)
 #define DEFN_CHPL_COMM_ATOMIC_READ(fnType, ofiType, Type)               \
   void chpl_comm_atomic_read_##fnType                                   \
          (void* result, c_nodeid_t node, void* object,                  \
-          chpl_memory_order order, int ln, int32_t fn) {                     \
+          chpl_memory_order order, int32_t ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_IFACE_AMO_READ,                                      \
                "%s(%p, %d, %p, %d, %s)", __func__,                      \
                result, (int) node, object,                              \
@@ -7699,7 +7699,7 @@ DEFN_CHPL_COMM_ATOMIC_READ(real64, FI_DOUBLE, _real64)
 #define DEFN_CHPL_COMM_ATOMIC_XCHG(fnType, ofiType, Type)               \
   void chpl_comm_atomic_xchg_##fnType                                   \
          (void* desired, c_nodeid_t node, void* object, void* result,   \
-          chpl_memory_order order, int ln, int32_t fn) {                     \
+          chpl_memory_order order, int32_t ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_IFACE_AMO,                                           \
                "%s(%p, %d, %p, %p, %d, %s)", __func__,                  \
                desired, (int) node, object, result,                     \
@@ -7725,7 +7725,7 @@ DEFN_CHPL_COMM_ATOMIC_XCHG(real64, FI_DOUBLE, _real64)
   void chpl_comm_atomic_cmpxchg_##fnType                                \
          (void* expected, void* desired, c_nodeid_t node, void* object, \
           chpl_bool32* result, chpl_memory_order succ, chpl_memory_order fail,    \
-          int ln, int32_t fn) {                                         \
+          int32_t ln, int32_t fn) {                                         \
     DBG_PRINTF(DBG_IFACE_AMO,                                           \
                "%s(%p, %p, %d, %p, %p, %d, %s)", __func__,              \
                expected, desired, (int) node, object, result,           \
@@ -7755,7 +7755,7 @@ DEFN_CHPL_COMM_ATOMIC_CMPXCHG(real64, FI_DOUBLE, _real64)
 #define DEFN_IFACE_AMO_SIMPLE_OP(fnOp, ofiOp, fnType, ofiType, Type)    \
   void chpl_comm_atomic_##fnOp##_##fnType                               \
          (void* opnd, c_nodeid_t node, void* object,                    \
-          chpl_memory_order order, int ln, int32_t fn) {                     \
+          chpl_memory_order order, int32_t ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_IFACE_AMO,                                           \
                "%s(<%s>, %d, %p, %d, %s)", __func__,                    \
                DBG_VAL(opnd, ofiType), (int) node,                      \
@@ -7768,7 +7768,7 @@ DEFN_CHPL_COMM_ATOMIC_CMPXCHG(real64, FI_DOUBLE, _real64)
                                                                         \
   void chpl_comm_atomic_##fnOp##_unordered_##fnType                     \
          (void* opnd, c_nodeid_t node, void* object,                    \
-          int ln, int32_t fn) {                                         \
+          int32_t ln, int32_t fn) {                                         \
     DBG_PRINTF(DBG_IFACE_AMO,                                           \
                "%s(<%s>, %d, %p, %d, %s)", __func__,                    \
                DBG_VAL(opnd, ofiType), (int) node,                      \
@@ -7781,7 +7781,7 @@ DEFN_CHPL_COMM_ATOMIC_CMPXCHG(real64, FI_DOUBLE, _real64)
                                                                         \
   void chpl_comm_atomic_fetch_##fnOp##_##fnType                         \
          (void* opnd, c_nodeid_t node, void* object, void* result,      \
-          chpl_memory_order order, int ln, int32_t fn) {                     \
+          chpl_memory_order order, int32_t ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_IFACE_AMO,                                           \
                "%s(<%s>, %d, %p, %p, %d, %s)", __func__,                \
                DBG_VAL(opnd, ofiType), (int) node,                      \
@@ -7855,7 +7855,7 @@ DEFN_IFACE_AMO_SIMPLE_OP(max, FI_MAX, real64, FI_DOUBLE, _real64)
 #define DEFN_IFACE_AMO_SUB(fnType, ofiType, Type, negate)               \
   void chpl_comm_atomic_sub_##fnType                                    \
          (void* opnd, c_nodeid_t node, void* object,                    \
-          chpl_memory_order order, int ln, int32_t fn) {                     \
+          chpl_memory_order order, int32_t ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_IFACE_AMO,                                           \
                "%s(<%s>, %d, %p, %d, %s)", __func__,                    \
                DBG_VAL(opnd, ofiType), (int) node, object,              \
@@ -7869,7 +7869,7 @@ DEFN_IFACE_AMO_SIMPLE_OP(max, FI_MAX, real64, FI_DOUBLE, _real64)
                                                                         \
   void chpl_comm_atomic_sub_unordered_##fnType                          \
          (void* opnd, c_nodeid_t node, void* object,                    \
-          int ln, int32_t fn) {                                         \
+          int32_t ln, int32_t fn) {                                         \
     DBG_PRINTF(DBG_IFACE_AMO,                                           \
                "%s(<%s>, %d, %p, %d, %s)", __func__,                    \
                DBG_VAL(opnd, ofiType), (int) node, object,              \
@@ -7883,7 +7883,7 @@ DEFN_IFACE_AMO_SIMPLE_OP(max, FI_MAX, real64, FI_DOUBLE, _real64)
                                                                         \
   void chpl_comm_atomic_fetch_sub_##fnType                              \
          (void* opnd, c_nodeid_t node, void* object, void* result,      \
-          chpl_memory_order order, int ln, int32_t fn) {                     \
+          chpl_memory_order order, int32_t ln, int32_t fn) {                     \
     DBG_PRINTF(DBG_IFACE_AMO,                                           \
                "%s(<%s>, %d, %p, %p, %d, %s)", __func__,                \
                DBG_VAL(opnd, ofiType), (int) node, object,              \

--- a/runtime/src/comm/ugni/comm-ugni.c
+++ b/runtime/src/comm/ugni/comm-ugni.c
@@ -3422,7 +3422,7 @@ static void issue_out_of_mem_regions_warning(void)
 }
 
 void* chpl_comm_impl_regMemAlloc(size_t size,
-                                 chpl_mem_descInt_t desc, int ln, int32_t fn)
+                                 chpl_mem_descInt_t desc, int32_t ln, int32_t fn)
 {
   int mr_i;
   mem_region_t* mr;
@@ -3595,7 +3595,7 @@ void chpl_comm_impl_regMemPostAlloc(void* p, size_t size)
 
 void* chpl_comm_impl_regMemRealloc(void* p, size_t oldSize, size_t newSize,
                                    chpl_mem_descInt_t desc,
-                                   int ln, int32_t fn)
+                                   int32_t ln, int32_t fn)
 {
   //
   // If the old allocation isn't separately registered then we just
@@ -5109,7 +5109,7 @@ void consume_all_outstanding_cq_events(int cdi)
 
 
 void chpl_comm_put(void* addr, c_nodeid_t locale, void* raddr,
-                   size_t size, int32_t commID, int ln, int32_t fn)
+                   size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_put(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -5599,7 +5599,7 @@ void do_nic_amo_nf_V(int v_len, uint64_t* opnd1_v, c_nodeid_t* locale_v,
 void chpl_comm_getput_unordered(c_nodeid_t dst_locale, void* dst_addr,
                                 c_nodeid_t src_locale, void* src_addr,
                                 size_t size, int32_t commID,
-                                int ln, int32_t fn)
+                                int32_t ln, int32_t fn)
 {
   assert(dst_addr != NULL);
   assert(src_addr != NULL);
@@ -5635,7 +5635,7 @@ void chpl_comm_getput_unordered(c_nodeid_t dst_locale, void* dst_addr,
 }
 
 void chpl_comm_get_unordered(void* addr, c_nodeid_t locale, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn)
+                             size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_get_unordered(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -5665,7 +5665,7 @@ void chpl_comm_get_unordered(void* addr, c_nodeid_t locale, void* raddr,
 }
 
 void chpl_comm_put_unordered(void* addr, c_nodeid_t locale, void* raddr,
-                             size_t size, int32_t commID, int ln, int32_t fn)
+                             size_t size, int32_t commID, int32_t ln, int32_t fn)
 
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_put_unordered(%p, %d, %p, %zd)",
@@ -5701,7 +5701,7 @@ void chpl_comm_getput_unordered_task_fence(void) {
 
 
 void chpl_comm_get(void* addr, c_nodeid_t locale, void* raddr,
-                   size_t size, int32_t commID, int ln, int32_t fn)
+                   size_t size, int32_t commID, int32_t ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_get(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -6121,7 +6121,7 @@ void chpl_comm_put_strd(void* dstaddr_arg, size_t* dststrides,
                         int32_t dstlocale,
                         void* srcaddr_arg, size_t* srcstrides,
                         size_t* count, int32_t stridelevels, size_t elemSize,
-                        int32_t commID, int ln, int32_t fn)
+                        int32_t commID, int32_t ln, int32_t fn)
 {
   PERFSTATS_INC(put_strd_cnt);
   put_strd_common(dstaddr_arg, dststrides,
@@ -6137,7 +6137,7 @@ void chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
                         int32_t srclocale,
                         void* srcaddr_arg, size_t* srcstrides,
                         size_t* count, int32_t stridelevels, size_t elemSize,
-                        int32_t commID, int ln, int32_t fn)
+                        int32_t commID, int32_t ln, int32_t fn)
 {
   PERFSTATS_INC(get_strd_cnt);
   get_strd_common(dstaddr_arg, dststrides,
@@ -6154,7 +6154,7 @@ void chpl_comm_get_strd(void* dstaddr_arg, size_t* dststrides,
 //
 chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t locale,
                                        void* raddr, size_t size,
-                                       int32_t commID, int ln, int32_t fn)
+                                       int32_t commID, int32_t ln, int32_t fn)
 {
 
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_get_nb(%p, %d, %p, %zd)",
@@ -6167,7 +6167,7 @@ chpl_comm_nb_handle_t chpl_comm_get_nb(void* addr, c_nodeid_t locale,
 
 chpl_comm_nb_handle_t chpl_comm_put_nb(void* addr, c_nodeid_t locale,
                                        void* raddr, size_t size,
-                                       int32_t commID, int ln, int32_t fn)
+                                       int32_t commID, int32_t ln, int32_t fn)
 {
   DBG_P_LP(DBGF_IFACE|DBGF_GETPUT, "IFACE chpl_comm_put_nb(%p, %d, %p, %zd)",
            addr, (int) locale, raddr, size);
@@ -6286,7 +6286,7 @@ int chpl_comm_addr_gettable(c_nodeid_t node, void* start, size_t len)
                                        int32_t loc,                     \
                                        void* obj,                       \
                                        chpl_memory_order order,         \
-                                       int ln, int32_t fn)              \
+                                       int32_t ln, int32_t fn)              \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
@@ -6331,7 +6331,7 @@ DEFINE_CHPL_COMM_ATOMIC_WRITE(real64, put_64, int_least64_t)
                                        int32_t loc,                     \
                                        void* obj,                       \
                                        chpl_memory_order order,              \
-                                       int ln, int32_t fn)              \
+                                       int32_t ln, int32_t fn)              \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           mem_region_t* local_mr;                                       \
@@ -6380,7 +6380,7 @@ DEFINE_CHPL_COMM_ATOMIC_READ(real64, get_64, int_least64_t)
                                         void* obj,                      \
                                         void* res,                      \
                                         chpl_memory_order order,             \
-                                        int ln, int32_t fn)             \
+                                        int32_t ln, int32_t fn)             \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
@@ -6428,7 +6428,7 @@ DEFINE_CHPL_COMM_ATOMIC_XCHG(real64, swap_64, int_least64_t)
                                            chpl_bool32* res,            \
                                            chpl_memory_order succ,           \
                                            chpl_memory_order fail,           \
-                                           int ln, int32_t fn)          \
+                                           int32_t ln, int32_t fn)          \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
@@ -6481,7 +6481,7 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cswap_64, int_least64_t)
                                           int32_t loc,                  \
                                           void* obj,                    \
                                           chpl_memory_order order,           \
-                                          int ln, int32_t fn)           \
+                                          int32_t ln, int32_t fn)           \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
@@ -6507,7 +6507,7 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cswap_64, int_least64_t)
         void chpl_comm_atomic_##_o##_unordered_##_f(void* opnd,         \
                                                int32_t loc,             \
                                                void* obj,               \
-                                               int ln, int32_t fn)      \
+                                               int32_t ln, int32_t fn)      \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
@@ -6535,7 +6535,7 @@ DEFINE_CHPL_COMM_ATOMIC_CMPXCHG(real64, cswap_64, int_least64_t)
                                                 void* obj,              \
                                                 void* res,              \
                                                 chpl_memory_order order,     \
-                                                int ln, int32_t fn)     \
+                                                int32_t ln, int32_t fn)     \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
@@ -6597,7 +6597,7 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
                                        int32_t loc,                     \
                                        void* obj,                       \
                                        chpl_memory_order order,              \
-                                       int ln, int32_t fn)              \
+                                       int32_t ln, int32_t fn)              \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
@@ -6623,7 +6623,7 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
         void chpl_comm_atomic_add_unordered_##_f(void* opnd,            \
                                             int32_t loc,                \
                                             void* obj,                  \
-                                            int ln, int32_t fn)         \
+                                            int32_t ln, int32_t fn)         \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
@@ -6651,7 +6651,7 @@ DEFINE_CHPL_COMM_ATOMIC_INT_OP(uint64, add, add_i64, uint_least64_t)
                                              void* obj,                 \
                                              void* res,                 \
                                              chpl_memory_order order,        \
-                                             int ln, int32_t fn)        \
+                                             int32_t ln, int32_t fn)        \
         {                                                               \
           mem_region_t* remote_mr;                                      \
           DBG_P_LP(DBGF_IFACE|DBGF_AMO,                                 \
@@ -6691,7 +6691,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, _real64)
                                        int32_t loc,                     \
                                        void* obj,                       \
                                        chpl_memory_order order,              \
-                                       int ln, int32_t fn)              \
+                                       int32_t ln, int32_t fn)              \
         {                                                               \
           _t nopnd = _negate(*(_t*) opnd);                              \
                                                                         \
@@ -6707,7 +6707,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, _real64)
         void chpl_comm_atomic_sub_unordered_##_f(void* opnd,            \
                                             int32_t loc,                \
                                             void* obj,                  \
-                                            int ln, int32_t fn)         \
+                                            int32_t ln, int32_t fn)         \
         {                                                               \
           _t nopnd = _negate(*(_t*) opnd);                              \
                                                                         \
@@ -6725,7 +6725,7 @@ DEFINE_CHPL_COMM_ATOMIC_REAL_OP(real64, add_r64, _real64)
                                              void* obj,                 \
                                              void* res,                 \
                                              chpl_memory_order order,        \
-                                             int ln, int32_t fn)        \
+                                             int32_t ln, int32_t fn)        \
         {                                                               \
           _t nopnd = _negate(*(_t*) opnd);                              \
                                                                         \
@@ -6959,7 +6959,7 @@ void chpl_rt_comm_execute_on_impl(chpl_rt_prginfo* prg, c_nodeid_t locale,
                                   chpl_fn_int_t fid,
                                   chpl_comm_on_bundle_t* arg,
                                   size_t arg_size,
-                                  int ln,
+                                  int32_t ln,
                                   int32_t fn) {
   DBG_P_LP(DBGF_IFACE|DBGF_RF,
            "IFACE chpl_comm_execute_on(%d:%d, ftable[%d](%p, %zd))",
@@ -6976,7 +6976,7 @@ void chpl_rt_comm_execute_on_nb_impl(chpl_rt_prginfo* prg, c_nodeid_t locale,
                                      chpl_fn_int_t fid,
                                      chpl_comm_on_bundle_t* arg,
                                      size_t arg_size,
-                                     int ln,
+                                     int32_t ln,
                                      int32_t fn) {
   DBG_P_LP(DBGF_IFACE|DBGF_RF,
            "IFACE chpl_comm_execute_on_nb(%d:%d, ftable[%d](%p, %zd))",
@@ -6993,7 +6993,7 @@ void chpl_rt_comm_execute_on_fast_impl(chpl_rt_prginfo* prg, c_nodeid_t locale,
                                        chpl_fn_int_t fid,
                                        chpl_comm_on_bundle_t* arg,
                                        size_t arg_size,
-                                       int ln,
+                                       int32_t ln,
                                        int32_t fn) {
   DBG_P_LP(DBGF_IFACE|DBGF_RF,
            "IFACE chpl_comm_execute_on_fast(%d:%d, ftable[%d](%p, %zd))",

--- a/runtime/src/tasks/fifo/tasks-fifo.c
+++ b/runtime/src/tasks/fifo/tasks-fifo.c
@@ -103,7 +103,7 @@ static void                    comm_task_wrapper(void*);
 static void                    taskCallBody(chpl_fn_int_t, chpl_fn_p,
                                             void*, size_t,
                                             c_sublocid_t,
-                                            int, int32_t);
+                                            int32_t, int32_t);
 static chpl_taskID_t           get_next_task_id(void);
 static thread_private_data_t*  get_thread_private_data(void);
 static task_pool_p             get_current_ptask(chpl_bool);
@@ -114,7 +114,7 @@ static void                    thread_end(void);
 static void                    maybe_add_thread(void);
 static task_pool_p             add_to_task_pool(chpl_fn_int_t, chpl_fn_p,
                                                 void*, size_t,
-                                                chpl_bool, int, int32_t);
+                                                chpl_bool, int32_t, int32_t);
 
 //
 // Condition variable methods
@@ -494,7 +494,7 @@ void chpl_rt_task_add_task(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
                            chpl_task_bundle_t* arg,
                            size_t arg_size,
                            c_sublocid_t subloc,
-                           int lineno,
+                           int32_t lineno,
                            int32_t filename) {
   assert(subloc == c_sublocid_none);
 
@@ -517,7 +517,7 @@ void chpl_rt_task_task_ftable_call(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
                                    void* arg,
                                    size_t arg_size,
                                    c_sublocid_t subloc,
-                                   int lineno,
+                                   int32_t lineno,
                                    int32_t filename) {
   CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
   taskCallBody(fid, chpl_ftable[fid], arg, arg_size, subloc, lineno, filename);
@@ -528,7 +528,7 @@ static inline
 void taskCallBody(chpl_fn_int_t fid, chpl_fn_p fp,
                   void* arg, size_t arg_size,
                   c_sublocid_t subloc,
-                  int lineno, int32_t filename) {
+                  int32_t lineno, int32_t filename) {
   // begin critical section
   chpl_thread_mutexLock(&threading_lock);
 
@@ -908,7 +908,7 @@ static inline
 task_pool_p add_to_task_pool(chpl_fn_int_t fid, chpl_fn_p fp,
                              void* a, size_t a_size,
                              chpl_bool is_executeOn,
-                             int lineno, int32_t filename) {
+                             int32_t lineno, int32_t filename) {
 
 
   task_pool_p ptask;

--- a/runtime/src/tasks/qthreads/tasks-qthreads.c
+++ b/runtime/src/tasks/qthreads/tasks-qthreads.c
@@ -1003,7 +1003,7 @@ void chpl_rt_task_add_task(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
                            chpl_task_bundle_t *arg,
                            size_t arg_size,
                            c_sublocid_t full_subloc,
-                           int lineno,
+                           int32_t lineno,
                            int32_t filename) {
     CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);
 
@@ -1045,7 +1045,7 @@ void chpl_rt_task_add_task(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
 static inline void taskCallBody(chpl_fn_int_t fid, chpl_fn_p fp,
                                 void *arg, size_t arg_size,
                                 c_sublocid_t full_subloc,
-                                int lineno, int32_t filename)
+                                int32_t lineno, int32_t filename)
 {
     chpl_task_bundle_t *bundle = chpl_argBundleTaskArgBundle(arg);
     c_sublocid_t execution_subloc =
@@ -1077,7 +1077,7 @@ void chpl_rt_task_task_ftable_call(chpl_rt_prginfo* prg, chpl_fn_int_t fid,
                                    void *arg,
                                    size_t arg_size,
                                    c_sublocid_t subloc,
-                                   int lineno,
+                                   int32_t lineno,
                                    int32_t filename) {
     PROFILE_INCR(profile_task_taskCallFTable,1);
     CHPL_RT_PRGINFO_DECLARE(prg, chpl_ftable);

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -1661,13 +1661,13 @@ done:
 }
 
 static
-void chk_err_fn(const char* file, int lineno, const char* what) {
+void chk_err_fn(const char* file, int32_t lineno, const char* what) {
   chpl_internal_error_v("%s:%d: !(%s)", file, lineno, what);
 }
 
 
 static
-void chk_err_errno_fn(const char* file, int lineno, const char* what) {
+void chk_err_errno_fn(const char* file, int32_t lineno, const char* what) {
   chpl_internal_error_v("%s:%d: !(%s): %s", file, lineno, what,
                         strerror(errno));
 }


### PR DESCRIPTION
Adjusts the compile to always codegen line information as a 32 bit int.

https://github.com/chapel-lang/chapel/commit/c0fd17cca0a1c748286cbe8c55159bf8f96b800c changed the compiler to generate _ln as a default sized int, which is int(64). However, almost none of the runtime code was updated (still using int) and was even wrong (using int32_t). In an offline discussion, we determined the best way to fix this mismatch was to codegen line numbers as 32 bit ints and update the runtime to always use in32_t (instead of the generic int).

Previous PR: https://github.com/chapel-lang/chapel/pull/29072

[Reviewed by @dlongnecke-cray]