### PR TITLE
Clone mason deps in `nightly`

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -604,6 +604,12 @@ if ($build == 1) {
   if ($mason_build == 1) {
     print "Making mason\n";
     mysystem("cd $chplhomedir && $make -j$num_procs mason", "making mason", $exitOnError);
+  } else {
+    # if not building mason, just clone the mason deps so certain mason unit tests
+    # that run without building mason can still run without needing to
+    # download dependencies themselves (which they do for paratest)
+    print "Cloning mason dependencies\n";
+    mysystem("cd $chplhomedir && $make -j$num_procs mason-deps", "cloning mason dependencies", $exitOnError);
   }
 
   # Build the protobuf Chapel plugin


### PR DESCRIPTION
Adjusts `nightly` to clone the mason deps if mason will not be built

This should help testing avoiding having to redownload the mason deps over and over in a PRETEST, which we have seen resulting in rate limiting from github.

[Not reviewed - will get post merge review]