### PR TITLE
Patch stb_image_write to workaround upstream bug

### DIFF
--- a/modules/packages/ImageHelper/stb/README
+++ b/modules/packages/ImageHelper/stb/README
@@ -1,3 +1,22 @@
 # README
 
 Bundled stb headers are pulled from https://github.com/nothings/stb
+
+## Patches
+
+The following patches have been applied to the files bundled here
+
+* Workaround for https://github.com/nothings/stb/issues/1433
+
+```
+--- stb_image_write.h
++++ stb_image_write.h
+@@ -1260,6 +1260,7 @@ static void stbiw__jpg_writeBits(stbi__write_context *s, int *bitBufP, int *bitC
+       if(c == 255) {
+          stbiw__putc(s, 0);
+       }
++      bitBuf &= 0x0000FFFF;
+       bitBuf <<= 8;
+       bitCnt -= 8;
+    }
+```

--- a/modules/packages/ImageHelper/stb/stb_image_write.h
+++ b/modules/packages/ImageHelper/stb/stb_image_write.h
@@ -1260,6 +1260,7 @@ static void stbiw__jpg_writeBits(stbi__write_context *s, int *bitBufP, int *bitC
       if(c == 255) {
          stbiw__putc(s, 0);
       }
+      bitBuf &= 0x0000FFFF;
       bitBuf <<= 8;
       bitCnt -= 8;
    }


### PR DESCRIPTION
Patches the bundled stb_image_write header to workaround an upstream bug: https://github.com/nothings/stb/i…ssues/1433

[Reviewed by @dlongnecke-cray ]