### PR TITLE
Make `make mason` use same command as other `make`

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -602,8 +602,8 @@ if ($build == 1) {
 
   # Build mason
   if ($mason_build == 1) {
-    print "Making mason\n";
-    mysystem("cd $chplhomedir && $make -j$num_procs mason", "making mason", $exitOnError);
+    print "Making $make_vars_opt mason\n";
+    mysystem("cd $chplhomedir && $make -j$num_procs $make_vars_opt mason", "making mason", $exitOnError);
   } else {
     # if not building mason, just clone the mason deps so certain mason unit tests
     # that run without building mason can still run without needing to


### PR DESCRIPTION
Ensure that `make mason` uses the same command as other `make` invocations, to avoid rebuilding things.

[Not reviewed]