### PR TITLE
chplcheck: Fix incorrect indentation bug with `when`

### DIFF
--- a/test/chplcheck/IncorrectIndentation.chpl
+++ b/test/chplcheck/IncorrectIndentation.chpl
@@ -479,4 +479,32 @@ if 1 < 2 {
     bar,
     baz
   }
+
+  select 1 {
+    when 1 {
+      writeln("hi");
+    } when 2 {
+      writeln("hi");
+    } when 3 {
+      writeln("hi");
+        writeln("hi");
+    } otherwise {
+      writeln("hi");
+    }
+  }
+  select 1 {
+    when 1 {
+      writeln("hi");
+    }
+    when 2 {
+      writeln("hi");
+    }
+    when 3 {
+      writeln("hi");
+        writeln("hi");
+    }
+    otherwise {
+      writeln("hi");
+    }
+  }
 }

--- a/test/chplcheck/IncorrectIndentation.good
+++ b/test/chplcheck/IncorrectIndentation.good
@@ -94,4 +94,6 @@ IncorrectIndentation.chpl:459: node violates rule UnusedTaskIntent
 IncorrectIndentation.chpl:469: node violates rule ConsecutiveDecls
 IncorrectIndentation.chpl:474: node violates rule ConsecutiveDecls
 IncorrectIndentation.chpl:474: node violates rule IncorrectIndentation
+IncorrectIndentation.chpl:490: node violates rule IncorrectIndentation
+IncorrectIndentation.chpl:504: node violates rule IncorrectIndentation
 [Success matching fixit for IncorrectIndentation]

--- a/test/chplcheck/IncorrectIndentation.good-fixit
+++ b/test/chplcheck/IncorrectIndentation.good-fixit
@@ -511,4 +511,32 @@ if 1 < 2 {
     bar,
     baz
   }
+
+  select 1 {
+    when 1 {
+      writeln("hi");
+    } when 2 {
+      writeln("hi");
+    } when 3 {
+      writeln("hi");
+        writeln("hi");
+    } otherwise {
+      writeln("hi");
+    }
+  }
+  select 1 {
+    when 1 {
+      writeln("hi");
+    }
+    when 2 {
+      writeln("hi");
+    }
+    when 3 {
+      writeln("hi");
+        writeln("hi");
+    }
+    otherwise {
+      writeln("hi");
+    }
+  }
 }

--- a/tools/chplcheck/src/indentation.py
+++ b/tools/chplcheck/src/indentation.py
@@ -36,7 +36,9 @@ from chapel import (
     On,
     Record,
     SimpleBlockLike,
+    Select,
     Union,
+    When,
 )
 from typing import Optional, List, Tuple, Iterable, Dict
 from functools import cache
@@ -113,6 +115,10 @@ class IndentationCollector:
             return parent
         elif isinstance(parent, Conditional):
             return None if parent.is_expression_level() else parent
+        elif isinstance(parent, When):
+            select = parent.parent()
+            assert isinstance(select, Select)
+            return next(select.when_stmts())
         return node
 
     def _is_block_in_else_if_chain(


### PR DESCRIPTION
Fixes a bug with chplcheck where it would incorrectly flag IncorrectIndentation on `when` clauses

[Reviewed by @dlongnecke-cray]