### PR TITLE
Prevent passing nullptr to memove

### DIFF
--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -61,6 +61,7 @@ static ___always_inline
 void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
                        size_t size, int32_t commID, int ln, int32_t fn)
 {
+  if (size == 0) return;
   if (chpl_nodeID == node) {
     memmove(addr, raddr, size);
 #ifdef HAS_CHPL_CACHE_FNS
@@ -125,6 +126,7 @@ static ___always_inline
 void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
                        size_t size, int32_t commID, int ln, int32_t fn)
 {
+  if (size == 0) return;
   if (chpl_nodeID == node) {
     memmove(raddr, addr, size);
 #ifdef HAS_CHPL_CACHE_FNS


### PR DESCRIPTION
Adjusts some get/put wrappers (which can be called with null ptrs/0 length memory) to avoid doing any work in that case. This is especially important, since `memmove` cannot be called with NULL

[Reviewed by @arifthpe]