### PR TITLE
Prevent overflow in test

### DIFF
--- a/test/functions/deitz/test_lit_int1.chpl
+++ b/test/functions/deitz/test_lit_int1.chpl
@@ -5,7 +5,7 @@ proc foo(x : int) do
   return -1;
 
 var y : int = 2;
-for i in 1..10 do
+for i in 1..6 do
   y = y * y;
 
 writeln(foo(1));


### PR DESCRIPTION
Prevent overflow in test by reducing iterations

The test does not actually care what the value of `y` is, so there is no reason for overflow

[Reviewed by @benharsh]