### PR TITLE
Resolve more UB in QIO code

### DIFF
--- a/runtime/include/qio/qio.h
+++ b/runtime/include/qio/qio.h
@@ -850,8 +850,12 @@ qioerr qio_channel_read(const int threadsafe, qio_channel_t* restrict ch, void* 
     }
   }
 
-  // Is there room in our fast path buffer?
-  if( qio_space_in_ptr_diff(len, ch->cached_end, ch->cached_cur) ) {
+
+  if (len == 0) {
+    *amt_read = 0;
+    err = 0;
+  } else if (qio_space_in_ptr_diff(len, ch->cached_end, ch->cached_cur)) {
+    // Is there room in our fast path buffer?
     qio_memcpy( ptr, ch->cached_cur, len );
     ch->cached_cur = qio_ptr_add(ch->cached_cur, len);
     *amt_read = len;

--- a/test/io/ferguson/ctests/qio_bits_test.test.c
+++ b/test/io/ferguson/ctests/qio_bits_test.test.c
@@ -172,8 +172,7 @@ void check_write_read_pat(int width, int num, int pat, qio_chtype_t type, qio_hi
   char filename[128];
   int fd = -1;
   uint64_t one = 1;
-  uint64_t mask = (one << width) - 1;
-  if( width == 64 ) mask = -1;
+  uint64_t mask = width == 64 ? -1 : (one << width) - 1;
 
   strcpy(filename,"/tmp/qio_bits_testXXXXXX");
 

--- a/test/io/ferguson/ctests/qio_formatted_test.test.c
+++ b/test/io/ferguson/ctests/qio_formatted_test.test.c
@@ -102,6 +102,7 @@ void test_readwriteint(void)
   int sizes[] = {1, -1, 2, -2, 4, -4, 8, -8, 0};
   int byteorder[] = {QIO_NATIVE, QIO_BIG, QIO_LITTLE, 0};
   char got[16];
+  char tempdata[16];
   int i,j,k;
 
   if( verbose ) printf("Testing binary integer I/O\n");
@@ -113,22 +114,18 @@ void test_readwriteint(void)
   for( i = 0; testdata[i]; i++ ) {
     for( j = 0; sizes[j]; j++ ) {
       for( k = 0; byteorder[k]; k++ ) {
-        const char* data = testdata[i];
         int sz = sizes[j];
         int b_order = byteorder[k];
-        int len;
+        int len = sz < 0 ? -sz : sz;
 
-        len = sz;
-        if( len < 0 ) len = - sz;
-
-
+        memcpy(tempdata, testdata + i, len);
         memset(got, 0, sizeof(got));
 
         // Create a "write to file" channel.
         err = qio_channel_create(&writing, f, QIO_CH_BUFFERED, 0, 1, 0, INT64_MAX, NULL, 0);
         assert(!err);
 
-        err = qio_channel_write_int(true, b_order, writing, data, len, sz < 0);
+        err = qio_channel_write_int(true, b_order, writing, tempdata, len, sz < 0);
         assert(!err);
 
         qio_channel_release(writing);
@@ -143,7 +140,7 @@ void test_readwriteint(void)
         assert(!err);
 
         // Check that we read back what we wrote.
-        assert( 0 == memcmp(got, data, len) );
+        assert( 0 == memcmp(got, tempdata, len) );
 
         qio_channel_release(reading);
         reading = NULL;


### PR DESCRIPTION
Resolves more UB found in QIO code

Most of this PR is test-only changes, but I also fixed UB when calling `read` with len=0, which results in UB (passing NULL to memcpy)

[Reviewed by @benharsh]