### PR TITLE
Prevent overflow when resolving enums

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10527,7 +10527,7 @@ void ensureEnumTypeResolved(EnumType* etype) {
         }
       }
       if (foundInit) {
-        v++;
+        if (v < INT64_MAX) v++;
         uv++;
       }
     }


### PR DESCRIPTION
Prevents overflow when resolving enums near the boundary of max(int(64))

Fixes overflow when resolving `test/types/enum/ferguson/enum-overflow.chpl`

[Reviewed by @arifthpe]