### PR TITLE
Re-arrange error message for failed compilations that are missing .good files

### DIFF
--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -2313,7 +2313,7 @@ def main():
                         )
                     elif executebin:
                         sys.stdout.write(
-                            f"{futuretest}[Error compilation failed for {test_name}, but could not find {localdir}/{goodfile}]\n"
+                            f"{futuretest}[Error cannot locate output comparison file {localdir}/{goodfile} after compilation failed for {test_name}]\n"
                         )
                     else:
                         sys.stdout.write(


### PR DESCRIPTION
In #28731, I updated sub_test to provide a bit more clarity when a compilation failed and was missing its .good file.  Over time, I've found these errors less easy to parse than ideal, primarily because they don't start with a message about the .good file not being found as in other similar cases.  Here, I'm essentially swapping the two elements of the error message to make the prefix more like other cases.

So where, most recently, the error said:

```
[Error compilation failed for path/to/foo, but could not find path/to/foo.good]
```

it now says:

```
[Error cannot locate output comparison file path/to/foo.good after compilation failed for path/to/foo]
```