### PR TITLE
Skip mason in new smoketest job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -347,6 +347,7 @@ jobs:
           fi
 
           export NIGHTLY_TEST_SETTINGS=true
+          export CHPL_SMOKE_SKIP_MAKE_MASON=true
 
           ./util/buildRelease/smokeTest
 


### PR DESCRIPTION
Skip mason testing in new smoketest job, as it already has its own CI

[Not reviewed - trivial]