### PR TITLE
Make nightly smarter about cloning the mason deps

### DIFF
--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -613,7 +613,10 @@ if ($build == 1) {
     #   $CHPL_HOME/test, which includes mason tests so we need the mason deps
     # * if testdirs is not empty but does contain mason, then mason will be
     #   tested and we need the mason deps
-    if ($testdirs eq "" || $testdirs =~ /mason/) {
+    # no matter what, if performance testing is being done, we don't need to
+    # clone the mason deps
+    if (($testdirs eq "" || $testdirs =~ /mason/) &&
+        ($performance == 0 || $compperformance == 0)) {
       print "Cloning mason dependencies\n";
       mysystem("cd $chplhomedir && $make -j$num_procs mason-deps", "cloning mason dependencies", $exitOnError);
     } else {

--- a/util/cron/nightly
+++ b/util/cron/nightly
@@ -608,8 +608,17 @@ if ($build == 1) {
     # if not building mason, just clone the mason deps so certain mason unit tests
     # that run without building mason can still run without needing to
     # download dependencies themselves (which they do for paratest)
-    print "Cloning mason dependencies\n";
-    mysystem("cd $chplhomedir && $make -j$num_procs mason-deps", "cloning mason dependencies", $exitOnError);
+    # we only do this in two cases to avoid excessive network requests
+    # * if testdirs is empty, then we're testing everything in
+    #   $CHPL_HOME/test, which includes mason tests so we need the mason deps
+    # * if testdirs is not empty but does contain mason, then mason will be
+    #   tested and we need the mason deps
+    if ($testdirs eq "" || $testdirs =~ /mason/) {
+      print "Cloning mason dependencies\n";
+      mysystem("cd $chplhomedir && $make -j$num_procs mason-deps", "cloning mason dependencies", $exitOnError);
+    } else {
+      print "Skipping cloning mason dependencies since mason is not being tested\n";
+    }
   }
 
   # Build the protobuf Chapel plugin


### PR DESCRIPTION
Makes nightly testing smarter about when to clone the mason deps, to avoid too much network traffic

[Reviewed by @benharsh]