### PR TITLE
Annotate arkouda build time deltas

### DIFF
--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2736,9 +2736,9 @@ arkouda: &arkouda-base
   04/19/26:
     - Make the loop iterating over multiple parquet files parallel (Bears-R-Us/arkouda#5486)
   05/15/26:
-    - Switched system LLVM to 22 causing Arkouda release to need to use LLVM=bundled which is built with better optimizations (#28821)
+    - Switched system LLVM to 22 requiring Arkouda-release to use CHPL_LLVM=bundled which runs faster due to better -O levels (#28821)
   06/30/26:
-    - Updating Arkouda release to Chapel 2.9 enabled the use of system LLVM 22 and restored previous performance (#29033)
+    - Updated Arkouda release to Chapel 2.9 permitting the use of CHPL_LLVM=system again now using LLVM 22 (#29033)
 
 arkouda-string:
   <<: *arkouda-base

--- a/test/ANNOTATIONS.yaml
+++ b/test/ANNOTATIONS.yaml
@@ -2735,6 +2735,10 @@ arkouda: &arkouda-base
     - Fix performance regressions from divide-by-zero check (Bears-R-Us/arkouda#5416)
   04/19/26:
     - Make the loop iterating over multiple parquet files parallel (Bears-R-Us/arkouda#5486)
+  05/15/26:
+    - Switched system LLVM to 22 causing Arkouda release to need to use LLVM=bundled which is built with better optimizations (#28821)
+  06/30/26:
+    - Updating Arkouda release to Chapel 2.9 enabled the use of system LLVM 22 and restored previous performance (#29033)
 
 arkouda-string:
   <<: *arkouda-base


### PR DESCRIPTION
This annotates a recent downtick and uptick we saw in build times when switching to LLVM 22, which wasn't supported by Chapel 2.8, requiring Arkouda-release perf testing to use the bundled version which happens to be built with better optimization levels and therefore runs faster, reducing compile times.  Once Arkouda release testing was updated to 2.9, the system LLVM was used again (albeit version 22 rather than the previous 21), largely restoring the previous times.