### PR TITLE
Avoid overflow by using a saturating add

### DIFF
--- a/runtime/include/chpl-rt-math.h
+++ b/runtime/include/chpl-rt-math.h
@@ -30,7 +30,7 @@
   * res, x, and y should be plain identifers of type __stype
   * __utype should be the unsigned version of __stype
   * __smax should be the maximum representable value in __stype
-  
+
   __builtin_elementwise_add_sat is a clang extension, use that if available.
   Its more efficent to use __builtin_add_overflow (gcc/clang) but if not available
   the fall back is OK.
@@ -51,7 +51,7 @@
             } \
           } while (0)
     #endif
-  #endif 
+  #endif
 #endif
 #ifndef CHPL_SAT_SADD
   #define CHPL_SAT_SADD(__res, __x, __y, __stype, __utype, __smax) \

--- a/runtime/include/chpl-rt-math.h
+++ b/runtime/include/chpl-rt-math.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020-2026 Hewlett Packard Enterprise Development LP
+ * Copyright 2004-2019 Cray Inc.
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/*
+  Contains a number of helpers to support low-level math routines that the
+  runtime might need, for example saturating addition.
+*/
+
+
+/*
+  Define a saturating add on signed arithmetic.
+  * res, x, and y should be plain identifers of type __stype
+  * __utype should be the unsigned version of __stype
+  * __smax should be the maximum representable value in __stype
+  
+  __builtin_elementwise_add_sat is a clang extension, use that if available.
+  Its more efficent to use __builtin_add_overflow (gcc/clang) but if not available
+  the fall back is OK.
+*/
+#ifdef __has_builtin
+  #if __has_builtin (__builtin_elementwise_add_sat)
+    #define CHPL_SAT_SADD(__res, __x, __y, __stype, __utype, __smax) \
+      do { \
+        __res = __builtin_elementwise_add_sat(__x, __y); \
+      } while (0)
+  #endif
+  #ifndef CHPL_SAT_SADD
+      #if __has_builtin (__builtin_add_overflow)
+        #define CHPL_SAT_SADD(__res, __x, __y, __stype, __utype, __smax) \
+          do { \
+            if (__builtin_add_overflow(__x, __y, &__res)) { \
+              __res = (__stype)((((__utype)__x) >> (sizeof(__stype)*8-1)) + ((__utype)__smax)); \
+            } \
+          } while (0)
+    #endif
+  #endif 
+#endif
+#ifndef CHPL_SAT_SADD
+  #define CHPL_SAT_SADD(__res, __x, __y, __stype, __utype, __smax) \
+  do { \
+    __utype __ux  = (__utype)__x;
+    __utype __uy  = (__utype)__y;
+    __utype __ures = __ux + __uy;
+    __utype __sat = (__ux >> (sizeof(__stype)*8-1)) + (__utype)__smax;
+    __utype __overflow = (__ures ^ __ux) & (__ures ^ __uy);
+    __utype __max = (__utype)0 - (__overflow >> (sizeof(__stype)*8-1));
+    __res = (__stype)((__ures & ~__max) | (__sat & __max));
+  } \
+  while (0)
+#endif

--- a/runtime/src/qio/qio.c
+++ b/runtime/src/qio/qio.c
@@ -41,6 +41,7 @@
 #include "qio_plugin_api.h"
 
 #include "chpl-error.h"
+#include "chpl-rt-math.h"
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -2024,7 +2025,8 @@ qioerr _buffered_get_memory_file_lock_held(qio_channel_t* ch, int64_t amt, int w
 
 
   start = qbuffer_end_offset(&ch->buf);
-  end = start + amt;
+  CHPL_SAT_SADD(end, start, amt, int64_t, uint64_t, INT64_MAX);
+
 
   // do not exceed end_pos.
   if( end > ch->end_pos ) {
@@ -3467,7 +3469,7 @@ qioerr _qio_channel_put_bytes_unlocked(qio_channel_t* ch, qbytes_t* bytes, int64
   {
     int64_t start, end;
     start = _right_mark_start(ch);
-    end = start + len_bytes;
+    CHPL_SAT_SADD(end, start, len_bytes, int64_t, uint64_t, INT64_MAX);
     if( end > ch->end_pos ) {
       end = ch->end_pos;
     }

--- a/test/runtime/math/sat_sadd.test.c
+++ b/test/runtime/math/sat_sadd.test.c
@@ -1,0 +1,127 @@
+
+#include "chpl-rt-math.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+// Check a single signed saturating add for a given type.
+#define CHECK_SADD(x, y, expected, stype, utype, smax) \
+  do { \
+    stype _res; \
+    CHPL_SAT_SADD(_res, (stype)(x), (stype)(y), stype, utype, smax); \
+    if(_res != (stype)(expected)); { \
+      printf("SADD failed: %lld + %lld = %lld, expected %lld\n", \
+             (long long)(x), (long long)(y), (long long)_res, (long long)(expected)); \
+    } \
+  } while (0)
+
+static void test_int8(void) {
+  const int8_t MAX = INT8_MAX;   // 127
+  const int8_t MIN = INT8_MIN;   // -128
+
+  // normal operation, no overflow
+  CHECK_SADD(0, 0, 0, int8_t, uint8_t, MAX);
+  CHECK_SADD(1, 2, 3, int8_t, uint8_t, MAX);
+  CHECK_SADD(-1, -2, -3, int8_t, uint8_t, MAX);
+  CHECK_SADD(10, -4, 6, int8_t, uint8_t, MAX);
+  CHECK_SADD(-10, 4, -6, int8_t, uint8_t, MAX);
+
+  // identity with zero
+  CHECK_SADD(MAX, 0, MAX, int8_t, uint8_t, MAX);
+  CHECK_SADD(MIN, 0, MIN, int8_t, uint8_t, MAX);
+  CHECK_SADD(0, MAX, MAX, int8_t, uint8_t, MAX);
+  CHECK_SADD(0, MIN, MIN, int8_t, uint8_t, MAX);
+
+  // opposite signs cancel
+  CHECK_SADD(-1, 1, 0, int8_t, uint8_t, MAX);
+  CHECK_SADD(MAX, MIN, -1, int8_t, uint8_t, MAX);
+
+  // boundary, exactly reaches the limit without saturating
+  CHECK_SADD(MAX - 1, 1, MAX, int8_t, uint8_t, MAX);
+  CHECK_SADD(MIN + 1, -1, MIN, int8_t, uint8_t, MAX);
+
+  // positive overflow saturates to MAX
+  CHECK_SADD(MAX, 1, MAX, int8_t, uint8_t, MAX);
+  CHECK_SADD(MAX, MAX, MAX, int8_t, uint8_t, MAX);
+  CHECK_SADD(100, 100, MAX, int8_t, uint8_t, MAX);
+
+  // negative overflow saturates to MIN
+  CHECK_SADD(MIN, -1, MIN, int8_t, uint8_t, MAX);
+  CHECK_SADD(MIN, MIN, MIN, int8_t, uint8_t, MAX);
+  CHECK_SADD(-100, -100, MIN, int8_t, uint8_t, MAX);
+}
+
+static void test_int16(void) {
+  const int16_t MAX = INT16_MAX;
+  const int16_t MIN = INT16_MIN;
+
+  CHECK_SADD(0, 0, 0, int16_t, uint16_t, MAX);
+  CHECK_SADD(1234, 4321, 5555, int16_t, uint16_t, MAX);
+  CHECK_SADD(-1234, -4321, -5555, int16_t, uint16_t, MAX);
+
+  CHECK_SADD(MAX, 0, MAX, int16_t, uint16_t, MAX);
+  CHECK_SADD(MIN, 0, MIN, int16_t, uint16_t, MAX);
+  CHECK_SADD(-1, 1, 0, int16_t, uint16_t, MAX);
+  CHECK_SADD(MAX, MIN, -1, int16_t, uint16_t, MAX);
+
+  CHECK_SADD(MAX - 1, 1, MAX, int16_t, uint16_t, MAX);
+  CHECK_SADD(MIN + 1, -1, MIN, int16_t, uint16_t, MAX);
+
+  CHECK_SADD(MAX, 1, MAX, int16_t, uint16_t, MAX);
+  CHECK_SADD(MAX, MAX, MAX, int16_t, uint16_t, MAX);
+  CHECK_SADD(MIN, -1, MIN, int16_t, uint16_t, MAX);
+  CHECK_SADD(MIN, MIN, MIN, int16_t, uint16_t, MAX);
+}
+
+static void test_int32(void) {
+  const int32_t MAX = INT32_MAX;
+  const int32_t MIN = INT32_MIN;
+
+  CHECK_SADD(0, 0, 0, int32_t, uint32_t, MAX);
+  CHECK_SADD(100000, 23456, 123456, int32_t, uint32_t, MAX);
+  CHECK_SADD(-100000, -23456, -123456, int32_t, uint32_t, MAX);
+
+  CHECK_SADD(MAX, 0, MAX, int32_t, uint32_t, MAX);
+  CHECK_SADD(MIN, 0, MIN, int32_t, uint32_t, MAX);
+  CHECK_SADD(-1, 1, 0, int32_t, uint32_t, MAX);
+  CHECK_SADD(MAX, MIN, -1, int32_t, uint32_t, MAX);
+
+  CHECK_SADD(MAX - 1, 1, MAX, int32_t, uint32_t, MAX);
+  CHECK_SADD(MIN + 1, -1, MIN, int32_t, uint32_t, MAX);
+
+  CHECK_SADD(MAX, 1, MAX, int32_t, uint32_t, MAX);
+  CHECK_SADD(MAX, MAX, MAX, int32_t, uint32_t, MAX);
+  CHECK_SADD(MIN, -1, MIN, int32_t, uint32_t, MAX);
+  CHECK_SADD(MIN, MIN, MIN, int32_t, uint32_t, MAX);
+}
+
+static void test_int64(void) {
+  const int64_t MAX = INT64_MAX;
+  const int64_t MIN = INT64_MIN;
+
+  CHECK_SADD(0, 0, 0, int64_t, uint64_t, MAX);
+  CHECK_SADD(1000000000LL, 7, 1000000007LL, int64_t, uint64_t, MAX);
+  CHECK_SADD(-1000000000LL, -7, -1000000007LL, int64_t, uint64_t, MAX);
+
+  CHECK_SADD(MAX, 0, MAX, int64_t, uint64_t, MAX);
+  CHECK_SADD(MIN, 0, MIN, int64_t, uint64_t, MAX);
+  CHECK_SADD(-1, 1, 0, int64_t, uint64_t, MAX);
+  CHECK_SADD(MAX, MIN, -1, int64_t, uint64_t, MAX);
+
+  CHECK_SADD(MAX - 1, 1, MAX, int64_t, uint64_t, MAX);
+  CHECK_SADD(MIN + 1, -1, MIN, int64_t, uint64_t, MAX);
+
+  CHECK_SADD(MAX, 1, MAX, int64_t, uint64_t, MAX);
+  CHECK_SADD(MAX, MAX, MAX, int64_t, uint64_t, MAX);
+  CHECK_SADD(MIN, -1, MIN, int64_t, uint64_t, MAX);
+  CHECK_SADD(MIN, MIN, MIN, int64_t, uint64_t, MAX);
+}
+
+int main(int argc, char** argv) {
+  test_int8();
+  test_int16();
+  test_int32();
+  test_int64();
+  return 0;
+}

--- a/test/runtime/math/sat_sadd.test.c
+++ b/test/runtime/math/sat_sadd.test.c
@@ -10,7 +10,7 @@
   do { \
     stype _res; \
     CHPL_SAT_SADD(_res, (stype)(x), (stype)(y), stype, utype, smax); \
-    if(_res != (stype)(expected)); { \
+    if (_res != (stype)(expected)) { \
       printf("SADD failed: %lld + %lld = %lld, expected %lld\n", \
              (long long)(x), (long long)(y), (long long)_res, (long long)(expected)); \
     } \


### PR DESCRIPTION
Avoids overflow in the IO runtime by using a saturating add.

[Reviewed by @benharsh]