### PR TITLE
Print compilation env vars in `--about`

### DIFF
--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -1380,6 +1380,9 @@ static void genConfigGlobalsAndAbout() {
     restoreDriverTmp(compileCommandFilename, [](std::string_view restoredCommand) {
       compileCommand = astr(restoredCommand);
     });
+    restoreDriverTmp(compileEnvsFilename, [](std::string_view restoredEnvs) {
+      compileEnvs = astr(restoredEnvs);
+    });
   }
 
   genGlobalString("chpl_compileCommand", compileCommand);
@@ -1400,9 +1403,9 @@ static void genConfigGlobalsAndAbout() {
   genGlobalInt("CHPL_CACHE_REMOTE", fCacheRemote, false);
   genGlobalInt("CHPL_INTERLEAVE_MEM", fEnableMemInterleaving, false);
 
-  for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
-    if (env->first != "CHPL_HOME") {
-      genGlobalString(env->first.c_str(), env->second);
+  for (const auto& env: envMap) {
+    if (env.first != "CHPL_HOME") {
+      genGlobalString(env.first.c_str(), env.second);
     }
   }
 
@@ -1434,12 +1437,16 @@ static void genConfigGlobalsAndAbout() {
   }
 
   codegenCallPrintf(astr("Compilation command: ", compileCommand, "\\n"));
+  if (compileEnvs.size() != 0) {
+    codegenCallPrintf("Compilation environment:\\n");
+    codegenCallPrintf(compileEnvs.c_str());
+  }
   codegenCallPrintf(astr("Chapel compiler version: ", compileVersion, "\\n"));
   codegenCallPrintf("Chapel environment:\\n");
   codegenCallPrintf(astr("  CHPL_HOME: ", CHPL_HOME.c_str(), "\\n"));
-  for (std::map<std::string, const char*>::iterator env=envMap.begin(); env!=envMap.end(); ++env) {
-    if (env->first != "CHPL_HOME") {
-      codegenCallPrintf(astr("  ", env->first.c_str(), ": ", env->second, "\\n"));
+  for (const auto& env: envMap) {
+    if (env.first != "CHPL_HOME") {
+      codegenCallPrintf(astr("  ", env.first.c_str(), ": ", env.second, "\\n"));
     }
   }
 

--- a/compiler/codegen/library.cpp
+++ b/compiler/codegen/library.cpp
@@ -124,9 +124,8 @@ void codegen_library_header(std::vector<FnSymbol*> functions) {
 // from compileline
 static std::string getCompilelineOption(std::string option) {
   std::string fullCommand = "";
-  for (std::map<std::string, const char*>::iterator env=envMap.begin();
-       env!=envMap.end(); ++env) {
-    fullCommand += std::string(env->first) + "=\"" + std::string(env->second) +
+  for (const auto& env: envMap) {
+    fullCommand += std::string(env.first) + "=\"" + std::string(env.second) +
       "\" ";
   }
   fullCommand += "$CHPL_HOME/util/config/compileline --" + option;

--- a/compiler/include/arg.h
+++ b/compiler/include/arg.h
@@ -59,6 +59,8 @@ struct ArgumentState
 {
   const char**         file_argument;
   int                  nfile_arguments;
+  const char**         env_argument;
+  int                  nenv_arguments;
 
   const char*          program_name;
   const char*          program_loc;

--- a/compiler/include/driver.h
+++ b/compiler/include/driver.h
@@ -314,6 +314,8 @@ extern char stopAfterPass[128];
 // code generation strings
 extern const char* compileCommandFilename;
 extern const char* compileCommand;
+extern const char* compileEnvsFilename;
+extern std::string compileEnvs;
 extern char compileVersion[64];
 
 // This is where the list of all supported editions goes

--- a/compiler/main/arg.cpp
+++ b/compiler/main/arg.cpp
@@ -366,7 +366,7 @@ Flag types:
   n = --no-... flag, --no version sets to true
 */
 
-static bool ProcessEnvironment(const ArgumentState* state);
+static bool ProcessEnvironment(ArgumentState* state);
 static void ProcessCommandLine(ArgumentState* state, int argc, char* argv[]);
 
 bool process_args(ArgumentState* state, int argc, char* argv[]) {
@@ -392,7 +392,7 @@ static void ApplyValue(const ArgumentState*       state,
                        const char*                value);
 
 
-static bool ProcessEnvironment(const ArgumentState* state) {
+static bool ProcessEnvironment(ArgumentState* state) {
   ArgumentDescription* desc = state->desc;
   bool hadError = false;
 
@@ -403,7 +403,7 @@ static bool ProcessEnvironment(const ArgumentState* state) {
     {
       const char* env = get_envvar_setting(desc[i]);
 
-      if (env != 0)
+      if (env != NULL)
       {
         char sel = desc[i].type[0];
 
@@ -439,6 +439,14 @@ static bool ProcessEnvironment(const ArgumentState* state) {
             break;
           }
         }
+
+        state->env_argument =
+          (const char **)realloc(state->env_argument,
+                                 sizeof(char*) * (state->nenv_arguments + 3));
+
+        state->env_argument[state->nenv_arguments++] = strdup(desc[i].env);
+        state->env_argument[state->nenv_arguments++] = strdup(env);
+        state->env_argument[state->nenv_arguments]   = NULL;
 
         ApplyValue(state, &desc[i], env);
       }

--- a/compiler/main/driver.cpp
+++ b/compiler/main/driver.cpp
@@ -362,6 +362,8 @@ char stopAfterPass[128] = "";
 
 const char* compileCommandFilename = "compileCommand.tmp";
 const char* compileCommand = NULL;
+const char* compileEnvsFilename = "compileEnvs.tmp";
+std::string compileEnvs = "";
 char compileVersion[64];
 
 std::array<std::string, 2> editions ({{"2.0", "preview"}});
@@ -564,7 +566,7 @@ static void setupChplLLVM(void) {
 #endif
 }
 
-static void recordCodeGenStrings(int argc, char* argv[]) {
+static void recordCodeGenStrings(ArgumentState* argState, int argc, char* argv[]) {
   compileCommand = astr("chpl ");
   // WARNING: This does not handle arbitrary sequences of escaped characters
   //  in string arguments
@@ -591,6 +593,11 @@ static void recordCodeGenStrings(int argc, char* argv[]) {
   }
 
   get_version(compileVersion, sizeof(compileVersion));
+
+  for (int i = 0; i < argState->nenv_arguments; i += 2) {
+    compileEnvs += std::string("  ") + argState->env_argument[i] + "=" +
+                                       argState->env_argument[i+1] + "\\n";
+  }
 }
 
 static void setHome(const ArgumentDescription* desc, const char* arg) {
@@ -844,6 +851,7 @@ static void runAsCompilerDriver(int argc, char* argv[]) {
 
   // Save initial compilation command before re-invocations.
   saveDriverTmp(compileCommandFilename, compileCommand);
+  saveDriverTmp(compileEnvsFilename, compileEnvs);
 
   // invoke compilation phase
   if ((status = runDriverCompilationPhase(argc, argv)) != 0) {
@@ -1714,7 +1722,9 @@ static ArgumentDescription arg_desc[] = {
 };
 
 static ArgumentState sArgState = {
+  NULL,
   0,
+  NULL,
   0,
   "program",
   "path",
@@ -2824,7 +2834,7 @@ int main(int argc, char* argv[]) {
 
     initCompilerGlobals(); // must follow argument parsing
 
-    recordCodeGenStrings(argc, argv);
+    recordCodeGenStrings(&sArgState, argc, argv);
   } // astlocMarker scope
 
   // We print things (--help*, --copyright, etc.) before validating

--- a/compiler/util/files.cpp
+++ b/compiler/util/files.cpp
@@ -737,17 +737,16 @@ void genIncludeCommandLineHeaders(FILE* outfile) {
 
 static std::string genMakefileEnvCache() {
   std::string result;
-  std::map<std::string, const char*>::iterator env;
 
-  for (env = envMap.begin(); env != envMap.end(); ++env) {
-    const std::string& key = env->first;
+  for (const auto& env: envMap) {
+    const std::string& key = env.first;
     const char* oldPrefix = "CHPL_";
     const char* newPrefix = "CHPL_MAKE_";
     INT_ASSERT(key.substr(0, strlen(oldPrefix)) == oldPrefix);
     std::string keySuffix = key.substr(strlen(oldPrefix), std::string::npos);
     std::string chpl_make_key = newPrefix + keySuffix;
     result += chpl_make_key + "=";
-    result += std::string(env->second);
+    result += std::string(env.second);
     result += "|";
   }
 

--- a/test/execflags/sungeun/about.prediff
+++ b/test/execflags/sungeun/about.prediff
@@ -23,10 +23,20 @@ with open(outfile, 'r') as ofh:
 
 # fix the output file
 with open(outfile, 'w') as ofh:
+    in_compilation_env = False
     for line in myLines:
+        if in_compilation_env:
+            if line.startswith("  "):
+                continue
+            else:
+                in_compilation_env = False
+
         l = line.rstrip()
         if l.find(compver) == 0:
             ofh.write('%s\n'%(compver))
+        # strip the extra envs, as thats too hard to test for
+        elif "Compilation environment:" in l:
+            in_compilation_env = True
         else:
             ofh.write(line)
 

--- a/tools/chpldoc/chpldoc.cpp
+++ b/tools/chpldoc/chpldoc.cpp
@@ -240,7 +240,9 @@ static void checkProjectVersion(const ArgumentDescription* desc, const char* arg
   {0}
 
 static ArgumentState sArgState = {
+  NULL,
   0,
+  NULL,
   0,
   "program",
   "path",


### PR DESCRIPTION
Adds whatever compilation env vars that were set when compiling the program to `--about`.

`--about` prints the state of the chapel environment when the binary was compiled, including what compilation flags were passed. However, not all compilation flags are passed as flags. Many compilation flags have env variables to set the default (like `CHPL_CC_FLAGS` for `--ccflags`). Those were not included in the `--about` output.

I found myself wanting to know what env variables were set when debugging an issue and thought this would be useful to add to `--about`

[Reviewed by @benharsh]