### PR TITLE
Make dependabot update checks weekly->daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     cooldown:
       default-days: 15
     assignees:


### PR DESCRIPTION
Increase dependabot version updates check frequency from weekly to daily.

I think it's probably better to merge updates as they come in (subject to our cooldown) rather than in batches, since it makes it easier to isolate what caused something to break. I originally set weekly to not spam us too much, but:

1. these are infrequent anyways, and
2. I'm the de-facto person responsible for merging these and I don't find it inconvenient for them to potentially come in in more frequent, smaller batches.

[trivial, skipping review]