### PR TITLE
Filter 'pkgconf' out of mason search test output

### DIFF
--- a/test/mason/mason-system/search.prediff
+++ b/test/mason/mason-system/search.prediff
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+OUTFILE=$2
+
+sed -e '/^pkgconf/d' -e '/^pkg-config/d' $OUTFILE > $OUTFILE.tmp
+mv $OUTFILE.tmp $OUTFILE


### PR DESCRIPTION
It would seem that a recent update to pkgconf causes pkgconf and pkg-config to always be listed, despite our having set PKG_CONFIG_PATH. This PR just adds a prediff that filters out these entries.

Testing:
- [x] tested on darwin
- [x] tested on personal macos laptop