### PR TITLE
Remove workarounds for GA git "dubious ownership" errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,8 +32,6 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: make check
       run: |
-        env
-        git config --list
         ./util/buildRelease/smokeTest chpl
 
   make_doc:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,8 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: make check
       run: |
+        env
+        git config --list
         ./util/buildRelease/smokeTest chpl
 
   make_doc:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -135,9 +135,6 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 100000
-    - name: set git repo safe directory
-      run: |
-        git config --global --add safe.directory $PWD
     - name: find bad runtime calls
       run: |
         ./util/devel/lookForBadRTCalls
@@ -310,9 +307,6 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - name: set git repo safe directory
-      run: |
-        git config --global --add safe.directory $PWD
     - name: create release tarball
       run: |
         export CHPL_TEST_RELEASE_NORECURSE=1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -283,7 +283,6 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-      options: --user 1001
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,17 +352,6 @@ if ((CHPL_HOME STREQUAL CMAKE_BINARY_DIR) OR
   message(FATAL_ERROR "It won't work to run cmake from the Chapel source directory. Please run 'rm CMakeCache.txt' and then cd to a different directory before running cmake.")
 endif()
 
-# TODO: This is a hack to get past the safe directory failure from git
-# when running in github CI. It looks like this same command is executed
-# as part of the github workflow, but I'm not sure why it doesn't seem
-# to be taking effect when cmake calls the python script to generate
-# the git-version file.
-if (DEFINED ENV{GITHUB_ACTIONS})
-  if($ENV{GITHUB_ACTIONS} STREQUAL "true")
-    message(STATUS "Running in GitHub Actions - set safe.directory")
-    execute_process(COMMAND git config --global --add safe.directory ${CHPL_HOME})
-  endif()
-endif()
 set(CHPL_CMAKE_PYTHON $ENV{CHPL_MAKE_PYTHON})
 message(STATUS "Using Python: ${CHPL_CMAKE_PYTHON}")
 # message(DEBUG "${CHPL_HOST_BUNDLED_LINK_ARGS} ${CHPL_HOST_SYSTEM_LINK_ARGS}")

--- a/util/buildRelease/smokeTest
+++ b/util/buildRelease/smokeTest
@@ -145,12 +145,6 @@ if [ $LINT -eq 1 ]; then
     # done with lint checks
 fi
 
-# Source common.bash, which sets up a bunch of environment variables that are
-# required for nightly testing.
-if [ "$GITHUB_ACTIONS" != "true" ]; then
-  source $CHPL_HOME/util/cron/common.bash
-fi
-
 # mason currently requires CHPL_COMM=none -- https://github.com/chapel-lang/chapel/issues/12626
 COMM=`$CHPL_HOME/util/chplenv/chpl_comm.py`
 if [ "$COMM" != "none" ]; then


### PR DESCRIPTION
Remove some workarounds for the git "dubious ownership" errors when running GitHub Actions containerized workflows.

These are no longer needed now that we work around this in our CI container image itself (https://github.com/chapel-lang/chapel/pull/29135).

Removes:
- Special casing when `GITHUB_ACTIONS` is set in the environment, in `CMakeLists.txt` and `util/buildRelease/smokeTest`.
- All workarounds for this issue in our workflows.

[reviewed by @jabraham17 , thanks!]