### PR TITLE
Work around git "dubious ownership" in CI image

### DIFF
--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -41,3 +41,6 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
+
+# Work around GitHub Actions git "dubious ownership" error
+RUN git config --global --add safe.directory "*"


### PR DESCRIPTION
Disable git `safe.directory` check globally within the CI image.

This should avoid the "dubious ownership" errors when working in a container that we currently have to work around elsewhere (see https://github.com/chapel-lang/chapel/pull/29131).

Merging with no real testing as I don't know how I'd replicate the GA runner env easily without just trying it out.

[trivial, not reviewed]