### PR TITLE
Add Linux and macOS test-homebrew GA job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -373,6 +373,26 @@ jobs:
 
           ./util/buildRelease/smokeTest
 
+  test-homebrew:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: print config info
+        run: |
+          echo "${{ matrix.os }}"
+          echo "${{ matrix.config }}"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: run homebrew testing
+        run: |
+          if [[ "${{ matrix.os }}" == "macos"* ]] ; then
+            ./util/cron/test-homebrew.bash
+          else
+            ./util/cron/test-homebrew-linux.bash
+          fi
+
   # This job exists to have a single check for which failure means merging
   # should be blocked, for GH required status checks purposes.
   # It runs (and fails) if any of the jobs listed in its `needs` ran and

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -419,6 +419,7 @@ jobs:
       - test_chpl_language_server
       - release-tarball-smoke-test
       - chapel-code-smoke-test
+      - test-homebrew
     steps:
       - name: Fail
         run: |


### PR DESCRIPTION
Add a job to our CI checks which runs our homebrew testing scripts on Linux and macOS.

[reviewed by @jabraham17 , thanks!]