### PR TITLE
Bundle of dyno resolver fixes

### DIFF
--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3283,7 +3283,9 @@ bool Resolver::resolveSpecialOpCall(const Call* call) {
 
     if (auto lhsTuple = op->lhs()->toTuple()) {
       auto rhsQt = byPostorder.byAst(op->rhs()).type();
-      if (auto rhsTupleType = rhsQt.type()->toTupleType()) {
+      if (!rhsQt.isType()) {
+        // TODO: if its not a tuple, its probably should be an error?
+      } else if (auto rhsTupleType = rhsQt.type()->toTupleType()) {
         if (lhsTuple->numActuals() != rhsTupleType->numElements()) {
           byPostorder.byAst(call).setType(RESOLVER_TYPE_ERROR(
               *this, TupleDeclAssignMismatchedElems, op, rhsTupleType));

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3283,9 +3283,10 @@ bool Resolver::resolveSpecialOpCall(const Call* call) {
 
     if (auto lhsTuple = op->lhs()->toTuple()) {
       auto rhsQt = byPostorder.byAst(op->rhs()).type();
-      if (!rhsQt.isType()) {
-        // TODO: if its not a tuple, its probably should be an error?
-      } else if (auto rhsTupleType = rhsQt.type()->toTupleType()) {
+      auto rhsTy = rhsQt.type();
+      if (!rhsTy) {
+        // TODO: if it has no valid type, it probably should be an error?
+      } else if (auto rhsTupleType = rhsTy->toTupleType()) {
         if (lhsTuple->numActuals() != rhsTupleType->numElements()) {
           byPostorder.byAst(call).setType(RESOLVER_TYPE_ERROR(
               *this, TupleDeclAssignMismatchedElems, op, rhsTupleType));

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -803,12 +803,14 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
       auto badPass = fa.byFormalIdx(candidate.formalIdx());
       auto formalDecl = badPass.formal();
       const uast::AstNode* actualExpr = nullptr;
+      const uast::VarLikeDecl* offendingActualDecl = nullptr;
       bool badSplitInit = false;
 
       // Can be -1 if the candidate is a method which we tried because
       // of a freestanding call 'foo()' in a method context.
       if (candidate.actualIdx() != -1) {
         actualExpr = getActual(candidate.actualIdx());
+        offendingActualDecl = actualDecls.at(printCount);
 
         // at this time, 'getActual' may not be total. In particular, it might
         // return nullptr for the call receiver, since it's relatively
@@ -881,9 +883,11 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
         auto actualName = "'" + actualExpr->toIdentifier()->name().str() + "'";
 
         if (explainedSplitInitsForActuals.insert(candidate.actualIdx()).second) {
-          wr.note(actualExpr->id(), "The actual ", actualName,
-                     " expects to be split-initialized because it is declared with a generic type and no initialization expression here:");
-          wr.codeForDef(actualExpr);
+          if (offendingActualDecl) {
+            wr.note(offendingActualDecl->id(), "The actual ", actualName,
+                      " expects to be split-initialized because it is declared with a generic type and no initialization expression here:");
+            wr.codeForDef(offendingActualDecl);
+          }
           wr.note(actualExpr, "The call to '", ci.name() ,"' occurs before any valid initialization points:");
           wr.code(actualExpr, { actualExpr });
           actualPrinted = true;

--- a/frontend/lib/resolution/resolution-error-classes-list.cpp
+++ b/frontend/lib/resolution/resolution-error-classes-list.cpp
@@ -843,7 +843,6 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
         formalName = "'" + buildTupleDeclName(formalDecl->toTupleDecl()) + "'";
       }
       bool actualPrinted = false;
-      const uast::VarLikeDecl* offendingActual = actualDecls.at(printCount);
       if (candidate.formalReason() == resolution::FAIL_VARARG_TQ_MISMATCH) {
         // a single vararg formal with a type query (like `x: ?t`) was used
         // to pass actuals of different types. Collect all applicable types.
@@ -882,9 +881,9 @@ static void printRejectedCandidates(ErrorWriterBase& wr,
         auto actualName = "'" + actualExpr->toIdentifier()->name().str() + "'";
 
         if (explainedSplitInitsForActuals.insert(candidate.actualIdx()).second) {
-          wr.note(offendingActual->id(), "The actual ", actualName,
+          wr.note(actualExpr->id(), "The actual ", actualName,
                      " expects to be split-initialized because it is declared with a generic type and no initialization expression here:");
-          wr.codeForDef(offendingActual);
+          wr.codeForDef(actualExpr);
           wr.note(actualExpr, "The call to '", ci.name() ,"' occurs before any valid initialization points:");
           wr.code(actualExpr, { actualExpr });
           actualPrinted = true;

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -7164,6 +7164,7 @@ bool addExistingSubstitutionsAsActuals(Context* context,
     if (!ct->instantiatedFromCompositeType()) break;
 
     for (auto& [id, qt] : ct->substitutions()) {
+      if (id.isEmpty()) continue;
       auto fieldAst = parsing::idToAst(context, id)->toVarLikeDecl();
       if (fieldAst->storageKind() == QualifiedType::TYPE ||
           fieldAst->storageKind() == QualifiedType::PARAM) {


### PR DESCRIPTION
Fixes a few issues with the dyno resolver that caused the language server to crash while resolving arkouda

On my machine after this PR, I can resolve all of arkouda without crashing

* avoids two segfaults when values are not valid. its not clear to me why these functions end up with invalid values, but its likely an issue elsewhere results in invalid input to these functions. regardless, these functions should be hardened
* fixes an actual-formal indexing mismatch due to method calls

[Reviewed by @arifthpe]