### PR TITLE
Make CI image git safe.directory setting system-wide

### DIFF
--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -43,4 +43,4 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     update-locale LANG=en_US.UTF-8
 
 # Work around GitHub Actions git "dubious ownership" error
-RUN git config --global --add safe.directory "*"
+RUN git config --system --add safe.directory "*"


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/29132, which was inadequate as `--global` config lives in `HOME` and GA overwrites `HOME` within the running container.

[trivial, not reviewed]

Testing:
- [x] in local run, `git config --list` shows the value even after changing `HOME`