### PR TITLE
Avoid clang issue with CHPL_SAT_SADD

### DIFF
--- a/runtime/include/chpl-rt-math.h
+++ b/runtime/include/chpl-rt-math.h
@@ -34,9 +34,19 @@
   __builtin_elementwise_add_sat is a clang extension, use that if available.
   Its more efficent to use __builtin_add_overflow (gcc/clang) but if not available
   the fall back is OK.
+
+  Note: on clang before 21, __builtin_elementwise_add_sat applied the usual
+  integer promotions to scalar arguments, so for types narrower than 'int'
+  (e.g. int8_t/int16_t) the saturating add was computed at 'int' width and then
+  truncated back, which silently wraps instead of saturating (e.g. int8_t
+  127 + 1 yields -128 instead of 127). This was fixed by LLVM PR #119423
+  ("Restrict the use of scalar types in vector builtins"), which first shipped
+  in clang 21. Only use the builtin on clang >= 21; older clang falls through to
+  the promotion-safe __builtin_add_overflow branch below.
 */
 #ifdef __has_builtin
-  #if __has_builtin (__builtin_elementwise_add_sat) && !defined(CHPL_RT_MATH_NO_BUILTIN_SAT)
+  #if __has_builtin (__builtin_elementwise_add_sat) && !defined(CHPL_RT_MATH_NO_BUILTIN_SAT) && \
+      defined(__clang_major__) && __clang_major__ >= 21
     #define CHPL_SAT_SADD(__res, __x, __y, __stype, __utype, __smax) \
       do { \
         __res = __builtin_elementwise_add_sat(__x, __y); \

--- a/test/runtime/math/sat_sadd.test.c
+++ b/test/runtime/math/sat_sadd.test.c
@@ -11,8 +11,8 @@
     stype _res; \
     CHPL_SAT_SADD(_res, (stype)(x), (stype)(y), stype, utype, smax); \
     if (_res != (stype)(expected)) { \
-      printf("SADD failed: %lld + %lld = %lld, expected %lld\n", \
-             (long long)(x), (long long)(y), (long long)_res, (long long)(expected)); \
+      printf("SADD on %s failed: %lld + %lld = %lld, expected %lld\n", \
+              #stype, (long long)(x), (long long)(y), (long long)_res, (long long)(expected)); \
     } \
   } while (0)
 


### PR DESCRIPTION
Avoids an issue with older clang (pre clang 21) where `__builtin_elementwise_add_sat` would promote its arguments to `int`. This makes a saturating add incorrect.

This behavior was changed in https://github.com/llvm/llvm-project/pull/119423, so clang 21+ does not have this problem.

Technically, this did not affect our actual usage of `CHPL_SAT_SADD`, since we only use it in the runtime with int64. But our tests caught this issue with int8 and int16

[Reviewed by @benharsh]