### PR TITLE
Add a missing initialization of the active field ID for user-defined init=

### DIFF
--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -3160,9 +3160,10 @@ void AggregateType::discoverParentAndCheck(Expr* storesName,
 }
 
 void AggregateType::setCreationStyle(TypeSymbol* t, FnSymbol* fn) {
-  bool isInit = (strcmp(fn->name, "init")   == 0);
+  bool isInit = (strcmp(fn->name, "init") == 0);
+  bool isInitEquals = (strcmp(fn->name, "init=") == 0);
 
-  if (isInit) {
+  if (isInit || isInitEquals) {
     AggregateType* ct = toAggregateType(t->type);
 
     if (ct == NULL) {
@@ -3182,7 +3183,7 @@ void AggregateType::setCreationStyle(TypeSymbol* t, FnSymbol* fn) {
                                     new_IntSymbol(-1)));
     }
 
-    if (ct->hasUserDefinedInit == false) {
+    if (isInit && ct->hasUserDefinedInit == false) {
       // We hadn't previously seen an initializer definition.
       // Update the field on the type appropriately.
       if (fn->hasFlag(FLAG_METHOD_PRIMARY) == true ||


### PR DESCRIPTION
This is a continuation of #28984 supporting union initializers.  In that PR, I added a default initialization of the union's active field ID for user-defined `init()` procedures.  However, it turns out that the same was needed for user-defined `init=`, as indicated by test/types/union/union-copy-init-3e.chpl on linux64 when compiling with `--baseline`.  I did not determine why it was specific to `--baseline`, but this is definitely the right thing to do in any case.