### PR TITLE
Add a GA job running test-c2chapel

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -426,6 +426,7 @@ jobs:
       - release-tarball-smoke-test
       - chapel-code-smoke-test
       - test-homebrew
+      - test-c2chapel
     steps:
       - name: Fail
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -386,6 +386,19 @@ jobs:
             ./util/cron/test-homebrew-linux.bash
           fi
 
+  test-c2chapel:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: run test-c2chapel.bash
+      run: |
+        ./util/cron/test-c2chapel.bash
+
   # This job exists to have a single check for which failure means merging
   # should be blocked, for GH required status checks purposes.
   # It runs (and fails) if any of the jobs listed in its `needs` ran and


### PR DESCRIPTION
Add a required GitHub Actions job which runs `util/cron/test-c2chapel.bash`.

[trivial, not reviewed]