### PR TITLE
Install GNU Time in GA CI container

### DIFF
--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3-dev \
     python3-pip \
     python3-venv \
+    time \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Install `time` in our GitHub CI container, for use in https://github.com/chapel-lang/chapel/pull/29146 and future tests.

[trivial, not reviewed]