### PR TITLE
Install curl in GA CI container

### DIFF
--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     clang-19 \
     cmake \
     cscope \
+    curl \
     doxygen \
     g++ \
     gcc \


### PR DESCRIPTION
Install `curl` in our GitHub Actions CI container, for use in https://github.com/chapel-lang/chapel/pull/29151 and future jobs.

[trivial, not reviewed]