### PR TITLE
Add required GA job testing over matrix of Python versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -410,7 +410,7 @@ jobs:
           make -j$num_procs
           make test-venv
 
-          start_test test/release/examples
+          start_test test/release/examples test/library/packages/Python test/interop/python
 
   release-tarball-smoke-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -365,7 +365,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     steps:
       - name: Install Python

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -365,7 +365,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python_version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     steps:
       - name: Install Python

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -378,6 +378,15 @@ jobs:
           set -exuo pipefail
           source util/cron/common-python.bash
           check_python_version "${{ matrix.python_version }}"
+      - name: Install LLVM dependency
+        run: |
+          sudo apt install \
+            clang \
+            libclang-dev \
+            libclang-cpp-dev \
+            libedit-dev \
+            llvm \
+            llvm-dev
       - name: Compile Chapel and run example tests
         run: |
           source util/setchplenv.bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -372,12 +372,12 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python_version }}
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Check desired Python version is default
         run: |
           set -exuo pipefail
           source util/cron/common-python.bash
           set_and_check_python_version "${{ matrix.python_version }}"
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Compile Chapel and run example tests
         run: |
           source util/setchplenv.bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -365,7 +365,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14]
+        python_version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ubuntu-latest
     steps:
       - name: Install Python

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -371,7 +371,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          version: ${{ matrix.python_version }}
+          python-version: ${{ matrix.python_version }}
       - name: Check desired Python version is default
         run: |
           set -exuo pipefail

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -361,6 +361,35 @@ jobs:
 
           start_test test/release/examples
 
+  python-version-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          version: ${{ matrix.python_version }}
+      - name: Check desired Python version is default
+        run: |
+          set -exuo pipefail
+          source util/cron/common-python.bash
+          set_and_check_python_version "${{ matrix.python_version }}"
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Compile Chapel and run example tests
+        run: |
+          source util/setchplenv.bash
+
+          export CHPL_LAUNCHER=none
+
+          num_procs=$(./util/buildRelease/chpl-make-cpu_count)
+          make -j$num_procs
+          make test-venv
+
+          start_test test/release/examples
+
   release-tarball-smoke-test:
     runs-on: ubuntu-latest
     container:
@@ -489,6 +518,7 @@ jobs:
       - check-format
       - test_chpl_language_server
       - gcc-version-tests
+      - python-version-tests
       - release-tarball-smoke-test
       - chapel-code-smoke-test
       - test-homebrew

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -377,7 +377,7 @@ jobs:
         run: |
           set -exuo pipefail
           source util/cron/common-python.bash
-          set_and_check_python_version "${{ matrix.python_version }}"
+          check_python_version "${{ matrix.python_version }}"
       - name: Compile Chapel and run example tests
         run: |
           source util/setchplenv.bash

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import unittest
+import tomllib
 
 try:
     # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12

--- a/util/chplenv/utils.py
+++ b/util/chplenv/utils.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import sys
 import unittest
-import tomllib
 
 try:
     # Module `distutils` is deprecated in Python 3.10 and will be removed in Python 3.12


### PR DESCRIPTION
Add testing of examples, Python interop, and Python module, over Python versions from 3.10 through 3.14 (latest patch version).

Uses [actions/setup-python](https://github.com/actions/setup-python) to install Python. Currently Chapel claims support for Python >= 3.5 per https://chapel-lang.org/docs/usingchapel/prereqs.html, but only 3.8 and newer are available to install via this action, and only 3.10 and newer work for `chpldoc` and `start_test`. Since versions older than 3.10 are currently EOL per https://devguide.python.org/versions/, I have taken the simple option of only testing >=3.10.

Modeled after https://github.com/chapel-lang/chapel/pull/29076 (GCC versions testing).

[reviewed by @jabraham17 , thanks!]