### PR TITLE
Update prereqs to note LLVM 14 dropped

### DIFF
--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -37,8 +37,8 @@ for using Chapel:
   * CMake is available and ``cmake`` runs version 3.20 or later.
 
   * The LLVM backend is now the default and it is easiest to use it with a
-    system-wide installation of LLVM and clang. LLVM versions 15 through 21 are
-    currently supported. If a system-wide installation of LLVM and clang with
+    system-wide installation of LLVM and Clang. LLVM versions 15 through 21 are
+    currently supported. If a system-wide installation of LLVM and Clang with
     one of those versions is not available, you can use the bundled LLVM or
     disable LLVM support (see :ref:`readme-chplenv.CHPL_LLVM`).
 

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -37,7 +37,7 @@ for using Chapel:
   * CMake is available and ``cmake`` runs version 3.20 or later.
 
   * The LLVM backend is now the default and it is easiest to use it with a
-    system-wide installation of LLVM and clang. LLVM versions 14 through 21 are
+    system-wide installation of LLVM and clang. LLVM versions 15 through 21 are
     currently supported. If a system-wide installation of LLVM and clang with
     one of those versions is not available, you can use the bundled LLVM or
     disable LLVM support (see :ref:`readme-chplenv.CHPL_LLVM`).


### PR DESCRIPTION
Update prereqs docs to note LLVM 15 as the minimum version (as of https://github.com/chapel-lang/chapel/pull/28995).

While here, also capitalize "Clang" in the same paragraph.

[reviewed by @jabraham17 , thanks!]