### PR TITLE
More fixes for dyno resolver crashes

### DIFF
--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -241,10 +241,12 @@ void InitResolver::merge(owned<InitResolver>& A, owned<InitResolver>& B) {
     for (auto i = currentFieldIndex_; i < curMax; i++) {
       auto& id = fieldIdsByOrdinal_[i];
       auto state = fieldStateFromId(id);
+      if (!state) continue;
       auto stateA = A->fieldStateFromId(id);
       auto stateB = B->fieldStateFromId(id);
+      if (!stateA || !stateB) continue;
 
-      assert(stateA->isInitialized && stateB->isInitialized);
+      CHPL_ASSERT(stateA->isInitialized && stateB->isInitialized);
       state->isInitialized = true;
 
       // Below, we issue an error if the resulting types do not compute to
@@ -582,6 +584,7 @@ const Type* InitResolver::computeReceiverTypeConsideringState(void) {
   for (int i = 0; i < rfNoDefaults.numFields(); i++) {
     auto id = rfNoDefaults.fieldDeclId(i);
     auto state = fieldStateFromId(id);
+    if (!state) continue;
     auto qtInitial = rfNoDefaults.fieldType(i);
     bool isInitiallyConcrete = qtInitial.genericity() == Type::CONCRETE;
 
@@ -772,10 +775,14 @@ bool InitResolver::implicitlyResolveFieldType(ID id, const ID initBefore) {
                                  DefaultsPolicy::USE_DEFAULTS,
                                  /* syntaxOnly */ false,
                                  /* fieldTypesOnly */ false);
+  // TODO: we have seen recursion errors result in an empty ResolvedFieldResults,
+  // don't try and use it in that case.
+  if (rr.fieldID().isEmpty()) return false;
   auto& rf = resolvedFieldsFromResults(initResolver_.rc, rr);
   for (int i = 0; i < rf.numFields(); i++) {
     auto id = rf.fieldDeclId(i);
     auto state = fieldStateFromId(id);
+    if (!state) continue;
     CHPL_ASSERT(state);
     CHPL_ASSERT(state->qt.kind() == rf.fieldType(i).kind());
 
@@ -1054,7 +1061,7 @@ bool InitResolver::handleAssignmentToField(const OpCall* node) {
   if (fieldId.isEmpty() || isSuperField) return false;
 
   auto state = fieldStateFromId(fieldId);
-  CHPL_ASSERT(state);
+  if (!state) return false;
 
   bool isAlreadyInitialized = !state->initPointId.isEmpty();
   bool isOutOfOrder = state->ordinalPos < currentFieldIndex_;
@@ -1169,6 +1176,7 @@ bool InitResolver::handleUseOfField(const AstNode* node) {
   if (!isSuperField && isFieldInitialized(id)) return false;
 
   auto state = fieldStateFromId(id);
+  if (!state) return false;
   bool isValidPreInitMention = false;
 
   if (isDescendingIntoAssignment_ && isSuperField == false)

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -1176,7 +1176,6 @@ bool InitResolver::handleUseOfField(const AstNode* node) {
   if (!isSuperField && isFieldInitialized(id)) return false;
 
   auto state = fieldStateFromId(id);
-  if (!state) return false;
   bool isValidPreInitMention = false;
 
   if (isDescendingIntoAssignment_ && isSuperField == false)

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -1040,7 +1040,7 @@ static void helpSetFieldTypes(const CompositeType* ct,
   } else if (auto fwd = ast->toForwardingDecl()) {
     if (auto fwdTo = fwd->expr()) {
       if (fwdTo->isDecl()) {
-        helpSetFieldTypes(ct, fwd->expr(), r, initedInParent, fields, syntaxOnly);
+        helpSetFieldTypes(ct, fwdTo, r, initedInParent, fields, syntaxOnly);
       }
       // If it's a visibility clause, use the type of the symbol rather than
       // the whole clause.
@@ -1178,10 +1178,13 @@ const ResolvedFields& resolveFieldDecl(ResolutionContext* rc,
 
   } else {
     auto& r = resolveFieldResults(rc, ct, fieldId, defaultsPolicy, syntaxOnly);
-
-    // Invoke other query to eliminate duplicate error messages from the
-    // call to ``validateFieldGenericity``.
-    result = resolvedFieldsFromResults(rc, r);
+    // TODO: we have seen recursion errors result in an empty ResolvedFieldResults,
+    // don't try and use it in that case.
+    if (!r.fieldID().isEmpty()) {
+      // Invoke other query to eliminate duplicate error messages from the
+      // call to ``validateFieldGenericity``.
+      result = resolvedFieldsFromResults(rc, r);
+    }
   }
 
   return CHPL_RESOLUTION_QUERY_END(result);


### PR DESCRIPTION
A bundle of dyno resolver crashes.

These fix issues I found while working on resolving CHAMPS with CLS. They don't fix all the issues, there are more in a similar vein. I found two kinds of issues

* functions expecting previous steps to not result in errors, meaning they get unexpected input and crash
* recurisive query errors result in the computed query result to be returned as the default value, which subsequent queries don't expect and crash from unexpected input. For example, one query computes a fieldID and the subsequent one uses it. If the first query detects a recursive query error, it will clear the ID and use a default empty one. The subsequent query might assume the ID is valid and try and use it to get an AST pointer and dereference it, resulting in a segfault.


Follow up to https://github.com/chapel-lang/chapel/pull/29134

[Reviewed by @arifthpe]