### PR TITLE
Fix `release-tarball-smoke-test` only building `main`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -387,6 +387,9 @@ jobs:
       with:
         sparse-checkout: |
           util
+    - name: list branches
+      run: |
+        git ls-remote origin
     - name: set vars to make tarball from correct branch
       run: |
         {

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -389,14 +389,11 @@ jobs:
           util
     - name: list branches
       run: |
-        set -x
-        git ls-remote origin
         git branch
     - name: set vars to make tarball from correct branch
       run: |
         {
           echo "CHPL_HOME_REPOSITORY=$PWD"
-          echo "CHPL_GEN_RELEASE_BRANCH=${{ github.ref }}"
           echo "CHPL_GEN_RELEASE_COMMIT=${{ github.sha }}"
         } >> "$GITHUB_ENV"
     - name: create release tarball

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -383,9 +383,6 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - name: list branches
-      run: |
-        git branch
     - name: set vars to make tarball from correct branch
       run: |
         {

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -395,7 +395,7 @@ jobs:
     - name: set vars to make tarball from correct branch
       run: |
         {
-          echo "CHPL_HOME_REPOSITORY=${{ github.server_url }}/${{ github.repository }}"
+          echo "CHPL_HOME_REPOSITORY=$PWD"
           echo "CHPL_GEN_RELEASE_BRANCH=${{ github.ref }}"
         } >> "$GITHUB_ENV"
     - name: create release tarball

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -397,6 +397,7 @@ jobs:
         {
           echo "CHPL_HOME_REPOSITORY=$PWD"
           echo "CHPL_GEN_RELEASE_BRANCH=${{ github.ref }}"
+          echo "CHPL_GEN_RELEASE_COMMIT=${{ github.sha }}"
         } >> "$GITHUB_ENV"
     - name: create release tarball
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -382,7 +382,11 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: sparse check out ./util
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        sparse-checkout: |
+          util
     - name: create release tarball
       run: |
         export CHPL_TEST_RELEASE_NORECURSE=1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -389,7 +389,9 @@ jobs:
           util
     - name: list branches
       run: |
+        set -x
         git ls-remote origin
+        git branch
     - name: set vars to make tarball from correct branch
       run: |
         {

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -382,11 +382,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
     steps:
-    - name: sparse check out ./util
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        sparse-checkout: |
-          util
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: list branches
       run: |
         git branch

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -394,7 +394,7 @@ jobs:
       run: |
         {
           echo "CHPL_HOME_REPOSITORY=${{ github.server_url }}/${{ github.repository }}"
-          echo "CHPL_GEN_RELEASE_BRANCH=${{ github.ref_name }}"
+          echo "CHPL_GEN_RELEASE_BRANCH=${{ github.ref }}"
         } >> "$GITHUB_ENV"
     - name: create release tarball
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -391,7 +391,7 @@ jobs:
       run: |
         {
           echo "CHPL_HOME_REPOSITORY=${{ github.server_url }}/${{ github.repository }}"
-          echo "CHPL_GEN_RELEASE_BRANCH=${{ github.sha }}"
+          echo "CHPL_GEN_RELEASE_BRANCH=${{ github.ref_name }}"
         } >> "$GITHUB_ENV"
     - name: create release tarball
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -390,7 +390,7 @@ jobs:
     - name: set vars to make tarball from correct branch
       run: |
         {
-          echo "CHPL_HOME_REPOSITORY=${{ github.repositoryUrl }}"
+          echo "CHPL_HOME_REPOSITORY=${{ github.server_url }}/${{ github.repository }}"
           echo "CHPL_GEN_RELEASE_BRANCH=${{ github.sha }}"
         } >> "$GITHUB_ENV"
     - name: create release tarball

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -387,6 +387,12 @@ jobs:
       with:
         sparse-checkout: |
           util
+    - name: set vars to make tarball from correct branch
+      run: |
+        {
+          echo "CHPL_HOME_REPOSITORY=${{ github.repositoryUrl }}"
+          echo "CHPL_GEN_RELEASE_BRANCH=${{ github.sha }}"
+        } >> "$GITHUB_ENV"
     - name: create release tarball
       run: |
         export CHPL_TEST_RELEASE_NORECURSE=1

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -156,20 +156,19 @@ def make_tarball(chplhome, basetmpdir, tmpdir, reldir):
         git_url = os.getenv(
             "CHPL_HOME_REPOSITORY", "https://github.com/chapel-lang/chapel"
         )
-        git_branch = os.getenv("CHPL_GEN_RELEASE_BRANCH", "main")
+        git_branch = os.getenv("CHPL_GEN_RELEASE_BRANCH", None)
         repo_cache_path = os.getenv("REPO_CACHE_PATH", "/missing")
         git_commit = os.getenv("CHPL_GEN_RELEASE_COMMIT", None)
 
-        log(f"Cloning the sources (repo: {git_url} branch: {git_branch})...")
+        log(f"Cloning the sources (repo: {git_url}{f', branch: {git_branch}' if git_branch else ''})...")
         cmd = (
             [
                 "git",
                 "clone",
                 "--reference-if-able",
                 f"{repo_cache_path}/chapel.git",
-                "--branch",
-                git_branch,
             ]
+            + (["--branch", git_branch] if git_branch else [])
             + (["--depth", "1"] if git_commit is None else [])
             + [
                 git_url,

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -160,7 +160,8 @@ def make_tarball(chplhome, basetmpdir, tmpdir, reldir):
         repo_cache_path = os.getenv("REPO_CACHE_PATH", "/missing")
         git_commit = os.getenv("CHPL_GEN_RELEASE_COMMIT", None)
 
-        log(f"Cloning the sources (repo: {git_url}{f', branch: {git_branch}' if git_branch else ''})...")
+        branch_log_str = f', branch: {git_branch}' if git_branch else ''
+        log(f"Cloning the sources (repo: {git_url}{branch_log_str})...")
         cmd = (
             [
                 "git",

--- a/util/buildRelease/gen_release
+++ b/util/buildRelease/gen_release
@@ -160,7 +160,7 @@ def make_tarball(chplhome, basetmpdir, tmpdir, reldir):
         repo_cache_path = os.getenv("REPO_CACHE_PATH", "/missing")
         git_commit = os.getenv("CHPL_GEN_RELEASE_COMMIT", None)
 
-        branch_log_str = f', branch: {git_branch}' if git_branch else ''
+        branch_log_str = f", branch: {git_branch}" if git_branch else ""
         log(f"Cloning the sources (repo: {git_url}{branch_log_str})...")
         cmd = (
             [


### PR DESCRIPTION
Fix an issue with the `release-tarball-smoke-test` GA job in which it would only build and test the tip of `main`, rather than the actual PR commit it appears to run against.

Fixed by setting `CHPL_HOME_REPOSITORY` and `CHPL_GEN_RELEASE_COMMIT` to the repo and SHA the workflow is running on, rather than letting `gen_release` default to working from https://github.com/chapel-lang/chapel `main`.

Implementation notes:
- This approach is taken over setting `CHPL_GEN_RELEASE_NO_CLONE` and just using the default checkout from `actions/checkout` because it exercises the path actually taken in building the release tarball.
- To build off of exactly the same sources that any other job running on a workflow triggered by a `pull_request` event would get, we check out `github.sha`, per https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context. This is a SHA and not a branch name; the corresponding ref name `github.ref` does not appear to be a branch either, and in any case a SHA is unambiguous.
  - Previously, `gen_release` would always specify `--branch` when cloning, using either the value of `CHPL_GEN_RELEASE_COMMIT` or `main` if there was none. There is no obvious branch to clone in this case (and `main` does not exist in the clone made by `actions/checkout`), so `gen_release` is modified to not set `--branch` by default, accepting the remote's default branch.
- There's no way around cloning the repository twice in this approach, once to get the required `util` scripts, and once by `gen_release`.
  - To clone faster, and to make sure the desired merged ref is available, the second clone is a local clone from the first.
  - This means we can't make the first clone a sparse-checkout even though all it needs (immediately) is `util`, because otherwise cloning from it errors.

Thanks @jabraham17 for catching this.

Note to reviewer: Best reviewed as a whole patch.

[reviewed by @jabraham17 , thanks!]