### PR TITLE
Fetch all history in `check_annotations_rt_calls` job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -152,7 +152,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        fetch-depth: 100000
+        fetch-depth: 0 # check_annotations.py uses git history
     - name: find bad runtime calls
       run: |
         ./util/devel/lookForBadRTCalls


### PR DESCRIPTION
Fetch all git history (rather than last 100000 commits) in the `check_annotations_rt_calls` job.

This hardcoded fetch depth was introduced in https://github.com/chapel-lang/chapel/commit/811664da89623c5e641f4f5524b1b0453842eb68 in 2021. At that time it might have seemed like a high enough number that we would never hit it, or maybe there was no way of asking for unlimited history (via `fetch-depth: 0`).

Also add a comment for the reason we need git history in this job (for `check_annotations.py`).

[trivial, not reviewed]