### PR TITLE
Add arkouda-smoke-test GA job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: make check
+      shell: bash
       run: |
         source ./util/cron/common.bash
         source ./util/setchplenv.bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,10 +34,11 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - name: install libzmq3-dev
+    - name: install some Arkouda deps
       run: |
         apt update && apt install -y \
-          libzmq3-dev
+          libzmq3-dev \
+          libcurl4-openssl-dev
     - name: run Arkouda smoke testing
       run: |
         source ./util/cron/common.bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,10 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: install libzmq3-dev
+      run: |
+        apt update && apt install -y \
+          libzmq3-dev
     - name: run Arkouda smoke testing
       shell: bash
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
         password: ${{ secrets.github_token }}
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - name: make check
+    - name: run Arkouda smoke testing
       shell: bash
       run: |
         source ./util/cron/common.bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,6 @@ jobs:
         apt update && apt install -y \
           libzmq3-dev
     - name: run Arkouda smoke testing
-      shell: bash
       run: |
         source ./util/cron/common.bash
         source ./util/setchplenv.bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,31 @@ env:
 #   [3] https://github.com/actions/starter-workflows/issues/162
 
 jobs:
+  arkouda-smoke-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: make check
+      run: |
+        source ./util/cron/common.bash
+        source ./util/setchplenv.bash
+        export CHPL_TEST_ARKOUDA_PERF=false
+        source ./util/cron/common-arkouda.bash
+
+        export NIGHTLY_TEST_SETTINGS=true
+        export CHPL_SMOKE_SKIP_DOC=true
+        export CHPL_SMOKE_SKIP_MAKE_MASON=true
+        export ARKOUDA_SMOKE_TEST=true
+        ./util/buildRelease/smokeTest
+        make test-venv
+
+        start_test test/studies/arkouda/
+
   make_check:
     runs-on: ubuntu-latest
     container:
@@ -506,6 +531,7 @@ jobs:
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     needs:
+      - arkouda-smoke-test
       - make_check
       - make_chplvis
       - make_doc


### PR DESCRIPTION
Add a required GA job which does basic Arkouda smoke testing against current Chapel.

[trivial, not reviewed]