### PR TITLE
Fix missing double quotes in Python GA job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -420,7 +420,7 @@ jobs:
           export CHPL_LAUNCHER=none
 
           num_procs=$(./util/buildRelease/chpl-make-cpu_count)
-          make -j$num_procs
+          make -j"$num_procs"
           make test-venv
 
           start_test test/release/examples test/library/packages/Python test/interop/python


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/29154.

[trivial, not reviewed]