### PR TITLE
Use bash as default shell for GA runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,10 @@ permissions:
 env:
   NIGHTLY_TEST_SETTINGS: true
 
+defaults:
+  run:
+    shell: bash
+
 # NOTE: each job has to specify the container section in its entirety, which is
 # certainly repetetive, but the `defaults` section can't be applied and the `env`
 # context isn't available in the `jobs` section


### PR DESCRIPTION
Set `bash` as the default shell to use for `run` steps in our CI workflow.

This will save some time (or repeatedly setting this per-`run`) in porting over Jenkins scripts, many of which expect to run on `bash`.

[trivial, not reviewed]