### PR TITLE
Install wget in CI container image

### DIFF
--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3-venv \
     time \
     tzdata \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
Add `wget` to packages installed in CI container image, for use in https://github.com/chapel-lang/chapel/pull/29166 and future jobs.

[trivial, not reviewed]