### PR TITLE
Use a cached copy of zlib for Arkouda's Arrow dep

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,8 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
+    env:
+      ZLIB_TARBALL: zlib-1.3.1.tar.gz
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: install some Arkouda deps
@@ -39,6 +41,19 @@ jobs:
         apt update && apt install -y \
           libzmq3-dev \
           libcurl4-openssl-dev
+    - name: cache zlib for arrow
+      id: cache-zlib
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+      with:
+        path: ${{ env.ZLIB_TARBALL }}
+        key: zlib-tarball-${{ hashFiles(env.ZLIB_TARBALL) }}
+    - name: fetch zlib tarball
+      if: steps.cache-zlib.outputs.cache-hit != 'true'
+      run: |
+        wget https://zlib.net/fossils/${{ env.ZLIB_TARBALL }}
+    - name: set downloaded zlib tarball path
+      run: |
+        echo "ARROW_ZLIB_URL=$(pwd)/${{ env.ZLIB_TARBALL }}" >> "$GITHUB_ENV"
     - name: run Arkouda smoke testing
       run: |
         source ./util/cron/common.bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
       with:
         path: ${{ env.ZLIB_TARBALL }}
-        key: zlib-tarball-${{ hashFiles(env.ZLIB_TARBALL) }}
+        key: ${{ env.ZLIB_TARBALL }}
     - name: fetch zlib tarball
       if: steps.cache-zlib.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
We are occasionally seeing the fetch of https://zlib.net/fossils/zlib-1.3.1.tar.gz (a dependency of Arrow, which is a dependency of Arkouda) fail in the `arkouda-smoke-test` job. Try to fix this by keeping a cached copy of it and directing Arrow to use that.

This naive caching approach should be fine, since it's unlikely this dep will be updated with any frequency, and Arrow checks the hash of the tarball against an expected value so if an update does occur we won't be silently missing it.

[trivial, not reviewed]

- [x] zlib tarball restored from cache on subsequent runs