### PR TITLE
Enable `merge_group` trigger for CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -597,14 +597,14 @@ jobs:
 
   # This job exists to have a single check for which failure means merging
   # should be blocked, for GH required status checks purposes.
-  # It runs (and fails) if any of the jobs listed in its `needs` ran and
-  # failed; otherwise, it will be skipped, which GH considers acceptable for a
-  # 'required' check.
-  # This is separate from merge queue requirements; this jobs will block even
-  # adding to the merge merge queue.
-  # When adding a new job which we would like to block PR merging, add it to
-  # the `needs` list below. Note that if a dependent job is _skipped_, it will
-  # not trigger failure of this job.
+  # - It runs (and fails) if any of the jobs listed in its `needs` ran and
+  #   failed; otherwise, it will be skipped, which GH considers acceptable for a
+  #   'required' check.
+  # - This is separate from merge queue requirements; this jobs will block even
+  #   adding to the merge merge queue.
+  # - When adding a new job which we would like to block PR merging, add it to
+  #   the `needs` list below. Note that if a dependent job is _skipped_, it will
+  #   not trigger failure of this job.
   checks-alert-failure:
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -599,6 +600,8 @@ jobs:
   # It runs (and fails) if any of the jobs listed in its `needs` ran and
   # failed; otherwise, it will be skipped, which GH considers acceptable for a
   # 'required' check.
+  # This is separate from merge queue requirements; this jobs will block even
+  # adding to the merge merge queue.
   # When adding a new job which we would like to block PR merging, add it to
   # the `needs` list below. Note that if a dependent job is _skipped_, it will
   # not trigger failure of this job.


### PR DESCRIPTION
Enable the CI workflow to run on the `merge_group` trigger, in preparation for enabling the merge queue on this repo.

For now, use the same set of checks for `push`, `pull_request`, and `merge_group` triggers to keep things simple. Once we get this working, we'll want to skip longer-running checks for the `pull_request` (and maybe `push`) triggers, so they only run a single time in the merge queue.

[trivial, not reviewed]