### PR TITLE
Make longer-running CI checks only run in merge queue

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ defaults:
 
 jobs:
   arkouda-smoke-test:
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'push'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
@@ -404,7 +404,7 @@ jobs:
         make test-chpl-language-server -j"$(util/buildRelease/chpl-make-cpu_count)"
 
   gcc-version-tests:
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -455,7 +455,7 @@ jobs:
           start_test test/release/examples
 
   python-version-tests:
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -494,7 +494,7 @@ jobs:
           start_test test/release/examples test/library/packages/Python test/interop/python
 
   release-tarball-smoke-test:
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'push'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
@@ -570,7 +570,7 @@ jobs:
           ./util/buildRelease/smokeTest
 
   test-homebrew:
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -590,7 +590,7 @@ jobs:
           fi
 
   test-c2chapel:
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'push'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ defaults:
 
 jobs:
   arkouda-smoke-test:
+    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
@@ -403,6 +404,7 @@ jobs:
         make test-chpl-language-server -j"$(util/buildRelease/chpl-make-cpu_count)"
 
   gcc-version-tests:
+    if: github.event_name == 'merge_group'
     strategy:
       fail-fast: false
       matrix:
@@ -453,6 +455,7 @@ jobs:
           start_test test/release/examples
 
   python-version-tests:
+    if: github.event_name == 'merge_group'
     strategy:
       fail-fast: false
       matrix:
@@ -491,6 +494,7 @@ jobs:
           start_test test/release/examples test/library/packages/Python test/interop/python
 
   release-tarball-smoke-test:
+    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
@@ -566,6 +570,7 @@ jobs:
           ./util/buildRelease/smokeTest
 
   test-homebrew:
+    if: github.event_name == 'merge_group'
     strategy:
       fail-fast: false
       matrix:
@@ -585,6 +590,7 @@ jobs:
           fi
 
   test-c2chapel:
+    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
@@ -624,7 +630,6 @@ jobs:
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     needs:
-      - arkouda-smoke-test
       - make_check
       - make_chplvis
       - make_doc
@@ -639,12 +644,7 @@ jobs:
       - run-shellcheck
       - check-format
       - test_chpl_language_server
-      - gcc-version-tests
-      - python-version-tests
-      - release-tarball-smoke-test
       - chapel-code-smoke-test
-      - test-homebrew
-      - test-c2chapel
       - test-networking-packages
     steps:
       - name: Fail


### PR DESCRIPTION
Set GA CI jobs that take longer than ~15 minutes to run only in the merge queue or on push to `main` (not on PR pushes).

I selected all jobs that took longer than 15 minutes in a recent run (https://github.com/chapel-lang/chapel/actions/runs/30296505708?pr=29163), except `chapel-code-smoke-test` on macOS (16m 47s) as I think it's valuable coverage.

[reviewed by @jabraham17 , thanks!]