### PR TITLE
Use ubuntu-slim in select jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -232,7 +232,7 @@ jobs:
 
   check_large_files:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       IGNORE_LABEL: "large files ok"
     steps:
@@ -311,7 +311,7 @@ jobs:
 
   publish-docs:
     if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: make_doc
     steps:
       - name: download docs
@@ -344,7 +344,7 @@ jobs:
             rm ~/.ssh/known_hosts
 
   run-shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -355,7 +355,7 @@ jobs:
           ignore_paths: ./test/* ./third-party/*
 
   check-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       EXTENSIONLESS_PYTHON_FILES: ""
       BLACK_OPTIONS: "--check --verbose --line-length 80"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -623,7 +623,7 @@ jobs:
   #   not trigger failure of this job.
   checks-alert-failure:
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs:
       # - arkouda-smoke-test
       - make_check

--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -10,7 +10,7 @@ jobs:
   send_email:
    # run this workflow step only when the PR is merged, only on the chapel-lang/chapel repo.
     if:  github.event.pull_request.merged == true && github.repository == 'chapel-lang/chapel'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: print git events
         run:  cat "$GITHUB_EVENT_PATH"

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Download actionlint

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -30,7 +30,7 @@ jobs:
   # Canary for any linter failures
   linters-alert-failure:
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs:
       - actionlint
     steps:

--- a/.github/workflows/meetings.yml
+++ b/.github/workflows/meetings.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       discussions: write
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   check-and-update:
     if: github.repository == 'chapel-lang/chapel'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
     - name: Checkout this repository


### PR DESCRIPTION
Switches select jobs to use `ubuntu-slim`, since this should load faster and be a faster/lighter-weight CI

[Reviewed by @arifthpe]