### PR TITLE
Revert "Use a cached copy of zlib for Arkouda's Arrow dep"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,8 +33,6 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-    env:
-      ZLIB_TARBALL: zlib-1.3.1.tar.gz
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: install some Arkouda deps
@@ -42,19 +40,6 @@ jobs:
         apt update && apt install -y \
           libzmq3-dev \
           libcurl4-openssl-dev
-    - name: cache zlib for arrow
-      id: cache-zlib
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
-      with:
-        path: ${{ env.ZLIB_TARBALL }}
-        key: ${{ env.ZLIB_TARBALL }}
-    - name: fetch zlib tarball
-      if: steps.cache-zlib.outputs.cache-hit != 'true'
-      run: |
-        wget https://zlib.net/fossils/${{ env.ZLIB_TARBALL }}
-    - name: set downloaded zlib tarball path
-      run: |
-        echo "ARROW_ZLIB_URL=$(pwd)/${{ env.ZLIB_TARBALL }}" >> "$GITHUB_ENV"
     - name: run Arkouda smoke testing
       run: |
         source ./util/cron/common.bash


### PR DESCRIPTION
Reverts chapel-lang/chapel#29172

Turns out this was not working, as evidenced by recent runs trying (and failing) to download the zlib tarball from the internet even after a cache hit: https://github.com/chapel-lang/chapel/actions/runs/30303528505/job/90102055402?pr=29176

[reverting bad fix, not reviewed]