### PR TITLE
Disable the flaky `arkouda-smoke-test` job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ defaults:
 
 jobs:
   arkouda-smoke-test:
+    if: false
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,51 +26,51 @@ defaults:
 #   [3] https://github.com/actions/starter-workflows/issues/162
 
 jobs:
-  arkouda-smoke-test:
-    if: false
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
-    env:
-      ZLIB_TARBALL: zlib-1.3.1.tar.gz
-    steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-    - name: install some Arkouda deps
-      run: |
-        apt update && apt install -y \
-          libzmq3-dev \
-          libcurl4-openssl-dev
-    - name: cache zlib for arrow
-      id: cache-zlib
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
-      with:
-        path: ${{ env.ZLIB_TARBALL }}
-        key: ${{ env.ZLIB_TARBALL }}
-    - name: fetch zlib tarball
-      if: steps.cache-zlib.outputs.cache-hit != 'true'
-      run: |
-        wget https://zlib.net/fossils/${{ env.ZLIB_TARBALL }}
-    - name: set downloaded zlib tarball path
-      run: |
-        echo "ARROW_ZLIB_URL=$(pwd)/${{ env.ZLIB_TARBALL }}" >> "$GITHUB_ENV"
-    - name: run Arkouda smoke testing
-      run: |
-        source ./util/cron/common.bash
-        source ./util/setchplenv.bash
-        export CHPL_TEST_ARKOUDA_PERF=false
-        source ./util/cron/common-arkouda.bash
+  # arkouda-smoke-test:
+  #   if: false
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: ghcr.io/${{ github.repository_owner }}/chapel-github-ci:latest
+  #     credentials:
+  #       username: ${{ github.actor }}
+  #       password: ${{ secrets.github_token }}
+  #   env:
+  #     ZLIB_TARBALL: zlib-1.3.1.tar.gz
+  #   steps:
+  #   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+  #   - name: install some Arkouda deps
+  #     run: |
+  #       apt update && apt install -y \
+  #         libzmq3-dev \
+  #         libcurl4-openssl-dev
+  #   - name: cache zlib for arrow
+  #     id: cache-zlib
+  #     uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+  #     with:
+  #       path: ${{ env.ZLIB_TARBALL }}
+  #       key: ${{ env.ZLIB_TARBALL }}
+  #   - name: fetch zlib tarball
+  #     if: steps.cache-zlib.outputs.cache-hit != 'true'
+  #     run: |
+  #       wget https://zlib.net/fossils/${{ env.ZLIB_TARBALL }}
+  #   - name: set downloaded zlib tarball path
+  #     run: |
+  #       echo "ARROW_ZLIB_URL=$(pwd)/${{ env.ZLIB_TARBALL }}" >> "$GITHUB_ENV"
+  #   - name: run Arkouda smoke testing
+  #     run: |
+  #       source ./util/cron/common.bash
+  #       source ./util/setchplenv.bash
+  #       export CHPL_TEST_ARKOUDA_PERF=false
+  #       source ./util/cron/common-arkouda.bash
 
-        export NIGHTLY_TEST_SETTINGS=true
-        export CHPL_SMOKE_SKIP_DOC=true
-        export CHPL_SMOKE_SKIP_MAKE_MASON=true
-        export ARKOUDA_SMOKE_TEST=true
-        ./util/buildRelease/smokeTest
-        make test-venv
+  #       export NIGHTLY_TEST_SETTINGS=true
+  #       export CHPL_SMOKE_SKIP_DOC=true
+  #       export CHPL_SMOKE_SKIP_MAKE_MASON=true
+  #       export ARKOUDA_SMOKE_TEST=true
+  #       ./util/buildRelease/smokeTest
+  #       make test-venv
 
-        start_test test/studies/arkouda/
+  #       start_test test/studies/arkouda/
 
   make_check:
     runs-on: ubuntu-latest
@@ -625,7 +625,7 @@ jobs:
     if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     needs:
-      - arkouda-smoke-test
+      # - arkouda-smoke-test
       - make_check
       - make_chplvis
       - make_doc


### PR DESCRIPTION
Temporarily disable the `arkouda-smoke-test` job, as it is flaky in downloading Arrow's zlib dependence.

https://github.com/chapel-lang/chapel/pull/29172 attempted to work around this, but turns out this was not working, as evidenced by recent runs trying (and failing) to download the zlib tarball from the internet even after a cache hit: https://github.com/chapel-lang/chapel/actions/runs/30303528505/job/90102055402?pr=29176

[trivial, not reviewed]