### PR TITLE
Add dummy DCO check for merge queue

### DIFF
--- a/.github/workflows/dco_merge_group.yml
+++ b/.github/workflows/dco_merge_group.yml
@@ -1,0 +1,18 @@
+# Dummy DCO workflow which gives a passing status in the merge queue, to work
+# around https://github.com/dcoapp/app/issues/199 and
+# https://github.com/dcoapp/app/issues/302 .
+
+name: DCO
+
+on:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  DCO:
+    runs-on: ubuntu-slim
+    steps:
+      - name: pass (dummy workflow to satisfy merge queue requirement)
+        run: exit 0


### PR DESCRIPTION
Currently, the DCO check app we're using doesn't run properly in merge queues, so work around it by publishing a passing `DCO` check via a dummy GA job.

Workaround suggested at https://github.com/dcoapp/app/issues/199#issuecomment-1626060564.

The correct solution will be to give the app more permissions (if we decide that's okay) per https://github.com/dcoapp/app/issues/302, but we'd need an org owner to do that and Brad is currently on vacation.

[trivial workaround, not reviewed]