### PR TITLE
Use parallel `start_test` in GCC, Python, and LLVM version jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -451,7 +451,7 @@ jobs:
 
           num_procs=$(./util/buildRelease/chpl-make-cpu_count)
           make -j"$num_procs"
-          make test-venv
+          make -j"$num_procs" test-venv
 
           start_test test/release/examples
 
@@ -490,7 +490,7 @@ jobs:
 
           num_procs=$(./util/buildRelease/chpl-make-cpu_count)
           make -j"$num_procs"
-          make test-venv
+          make -j"$num_procs" test-venv
 
           start_test test/release/examples test/library/packages/Python test/interop/python
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -449,7 +449,8 @@ jobs:
 
           export CHPL_LAUNCHER=none
 
-          make -j"$(./util/buildRelease/chpl-make-cpu_count)"
+          num_procs=$(./util/buildRelease/chpl-make-cpu_count)
+          make -j"$num_procs"
           make test-venv
 
           start_test test/release/examples

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -454,7 +454,7 @@ jobs:
           make -j"$num_procs" test-venv
           make -j"$num_procs" spectests
 
-          start_test test/release/examples
+          start_test -j"$num_procs" test/release/examples
 
   python-version-tests:
     if: github.event_name == 'merge_group' || github.event_name == 'push'
@@ -494,7 +494,7 @@ jobs:
           make -j"$num_procs" test-venv
           make -j"$num_procs" spectests
 
-          start_test test/release/examples test/library/packages/Python test/interop/python
+          start_test -j"$num_procs" test/release/examples test/library/packages/Python test/interop/python
 
   llvm-version-tests:
     if: github.event_name == 'merge_group' || github.event_name == 'push'
@@ -541,7 +541,7 @@ jobs:
           make -j"$num_procs" test-venv
           make -j"$num_procs" spectests
 
-          start_test test/release/examples test/llvm
+          start_test -j"$num_procs" test/release/examples test/llvm
 
   release-tarball-smoke-test:
     if: github.event_name == 'merge_group' || github.event_name == 'push'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -452,6 +452,7 @@ jobs:
           num_procs=$(./util/buildRelease/chpl-make-cpu_count)
           make -j"$num_procs"
           make -j"$num_procs" test-venv
+          make -j"$num_procs" spectests
 
           start_test test/release/examples
 
@@ -491,6 +492,7 @@ jobs:
           num_procs=$(./util/buildRelease/chpl-make-cpu_count)
           make -j"$num_procs"
           make -j"$num_procs" test-venv
+          make -j"$num_procs" spectests
 
           start_test test/release/examples test/library/packages/Python test/interop/python
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -454,7 +454,7 @@ jobs:
           make -j"$num_procs" test-venv
           make -j"$num_procs" spectests
 
-          start_test -j"$num_procs" test/release/examples
+          start_test --parallel "$num_procs" test/release/examples
 
   python-version-tests:
     if: github.event_name == 'merge_group' || github.event_name == 'push'
@@ -494,7 +494,7 @@ jobs:
           make -j"$num_procs" test-venv
           make -j"$num_procs" spectests
 
-          start_test -j"$num_procs" test/release/examples test/library/packages/Python test/interop/python
+          start_test --parallel "$num_procs" test/release/examples test/library/packages/Python test/interop/python
 
   llvm-version-tests:
     if: github.event_name == 'merge_group' || github.event_name == 'push'
@@ -541,7 +541,7 @@ jobs:
           make -j"$num_procs" test-venv
           make -j"$num_procs" spectests
 
-          start_test -j"$num_procs" test/release/examples test/llvm
+          start_test --parallel "$num_procs" test/release/examples test/llvm
 
   release-tarball-smoke-test:
     if: github.event_name == 'merge_group' || github.event_name == 'push'


### PR DESCRIPTION
Use the new parallel `start_test` functionality from https://github.com/chapel-lang/chapel/pull/29017 in the `{gcc,python,llvm}-version-tests` jobs.

While here, also `make` (and test) `spectests` across these configs, as well as passing a `-j` to `make test-venv` in case that may do something in the future.

[trivial, not reviewed]