### PR TITLE
Enable `merge_group` trigger for workflow linters

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -555,6 +555,8 @@ jobs:
             exit 2
           fi
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Compile Chapel and run example tests
         run: |
           source util/setchplenv.bash

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
This makes passing the workflow linters a requirement to pass the merge queue, which it should definitely be to avoid broken or incorrectly-passing workflow checks getting through.

Follow up to https://github.com/chapel-lang/chapel/pull/29174 which enabled the CI workflow for `merge_group`.

Also includes a follow up fix to a Zizmor complaint about https://github.com/chapel-lang/chapel/pull/29156 (which got through the merge queue and brought this to my attention).

[trivial fix, not reviewed]