### PR TITLE
Skip non-files in check_large_files check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -286,6 +286,10 @@ jobs:
               if [ "$file" = "" ]; then
                   continue
               fi
+              if [ ! -f "$file" ]; then
+                  echo "Skipping $file (not a regular file)"
+                  continue
+              fi
               echo "Checking file: $file"
 
               file_size=$(wc -c "$file" | awk '{print $1}')


### PR DESCRIPTION
Skips non-files in check_large_files, since `wc -c` does not work on them

non-files can occur when a symlink to a directory is changed

[Not reviewed - trivial]