### PR TITLE
Fix permissions for running monitor-homebrew workflow

### DIFF
--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout this repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        persist-credentials: false
+        persist-credentials: true
 
     - name: Fetch released version of Chapel formula
       run: |

--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -8,7 +8,7 @@ on:
     - cron: '30 23 * * *' # Runs at 4:30 PM PDT (3:30 PM PST) (11:30 PM UTC)
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   file_changed: false

--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   file_changed: false

--- a/.github/workflows/monitor-homebrew.yml
+++ b/.github/workflows/monitor-homebrew.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout this repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        persist-credentials: true
+        persist-credentials: true # Needed to push new branch
 
     - name: Fetch released version of Chapel formula
       run: |


### PR DESCRIPTION
Grant the `monitor-homebrew` workflow adequate permissions to do its job (`write` access to `contents` and `pull-requests`).

Follow up to https://github.com/chapel-lang/chapel/pull/29160 which excessively restricted permissions.

[trivial, not reviewed]