### PR TITLE
Fix edge-case UB in Random.chpl

### DIFF
--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -2164,7 +2164,7 @@ module Random {
             // because this version will calculate the same modulus, but the LHS
             // value is less than 2^32.
 
-        const negbound:uint(32) = ( -(bound:int(32)) ):uint(32);
+        const negbound:uint(32) = __primitive("u-", bound);
         const threshold:uint(32) = negbound % bound;
         var r:uint(32);
 

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -2086,7 +2086,7 @@ module Random {
             // because this version will calculate the same modulus, but the LHS
             // value is less than 2^32.
 
-        const negbound:uint(32) = ( -(bound:int(32)) ):uint(32);
+        const negbound:uint(32) = __primitive("u-", bound);
         const threshold:uint(32) = negbound % bound;
         var tmprng:pcg_setseq_64_xsh_rr_32_rng;
         var tmpinc:uint(64);

--- a/modules/standard/Random.chpl
+++ b/modules/standard/Random.chpl
@@ -1981,21 +1981,21 @@ module Random {
     private inline
     proc pcg_output_rxs_m_xs_8_8(state:uint(8)):uint(8)
     {
-      const word:uint(8) = ((state >> ((state >> 6) + 2)) ^ state) * 217;
+      const word:uint(8) = (((state >> ((state >> 6) + 2)) ^ state):uint(32) * 217:uint(32)):uint(8);
       return (word >> 6) ^ word;
     }
 
     private inline
     proc pcg_output_rxs_m_xs_16_16(state:uint(16)):uint(16)
     {
-      const word:uint(16) = ((state >> ((state >> 13) + 3)) ^ state) * 62169;
+      const word:uint(16) = (((state >> ((state >> 13) + 3)) ^ state):uint(32) * 62169:uint(32)):uint(16);
       return (word >> 11) ^ word;
     }
 
     private inline
     proc pcg_output_rxs_m_xs_32_32(state:uint(32)):uint(32)
     {
-      const word:uint(32) = ((state >> ((state >> 28) + 4)) ^ state) * 277803737;
+      const word:uint(32) = ((state >> ((state >> 28) + 4)) ^ state):uint(32) * 277803737:uint(32);
       return (word >> 22) ^ word;
     }
 


### PR DESCRIPTION
Fixes two issues in Random that can result in UB

* Since Chapel has no unary `-` on uint, a workaround was used to negate uint's by first casting them to signed numbers. However, this can result in overflow when a value is too big to fit in a signed int. It is possible to negate the uint directly (in C and LLVM IR), so by using the low level Chapel primitive we avoid this problem
* A few procedures where incorrectly translated from C to Chapel code, namely `pcg_output_rxs_m_xs_16_16` (and friends). In the old Chapel code, `pcg_output_rxs_m_xs_16_16(38490)` "overflowed". This was because the Chapel expression `... * 62169` was codegened as `uint(16) * uint(16)`. In C promotion rules, this math would be promoted to `int` and then the result would be truncated back to `uint16`. This would result in "overflow" at `int` width, but didn't really matter since we truncate the result anyway. However, the [original code in C](https://github.com/imneme/pcg-c/blob/83252d9c23df9c82ecb42210afed61a7b42402d7/include/pcg_variants.h#L176) was written as `... * 62169u`, which was essentially `uint(16) * uint(32)`. Therefore, the math was done at `uint32` width and then truncated to `uint16`. The end result was the same, but not technically guaranteed by the C standard. This fix is to force computation at uint32 width and explicitly downcast the result to int16. I made similar changes to the similar functions for other bit-widths with similar logic.

- [x] paratest