### PR TITLE
Move start_test parallelism setup to function, add logging

### DIFF
--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -103,7 +103,7 @@ def run_tests(tests):
     # set up
     set_up_environment()
     set_up_general()
-    set_up_parallelism(files)
+    set_up_parallelism(files, dirs)
     set_up_performance_testing_A()  # A and B are separate in order to keep
     # output the same from old start_test
     set_up_executables()
@@ -1168,7 +1168,7 @@ def set_up_general():
         compiler = args.compiler
 
 
-def set_up_parallelism(files):
+def set_up_parallelism(files, dirs):
     global file_workers
     # Individual test files are normally run serially. They may be run in
     # parallel only when BOTH --parallel and --allow-unsafe-parallel are given.

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -1174,7 +1174,7 @@ def set_up_parallelism():
     # This is "unsafe" because individually-specified files may share a
     # directory and thus shared state (e.g. writing to the same local file,
     # custom CLEANFILES, or prediff/skipif/precomp/etc side effects), which can
-    # cause suprious failures.
+    # cause spurious failures.
     #
     # out of caution, we only run in parallel in the "normal" run state, e.g.,
     # no parallel performance testing or graph generation

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -96,21 +96,23 @@ def run_tests(tests):
                 "[Error: {0} is not a valid file or directory]".format(i)
             )
             had_invalid_file = True
+    num_files = num_files
+    num_dirs = num_dirs
 
-    if had_invalid_file and len(files) == 0 and len(dirs) == 0:
+    if had_invalid_file and num_files == 0 and num_dirs == 0:
         sys.exit(2)
 
     # set up
     set_up_environment()
     set_up_general()
-    set_up_parallelism()
+    set_up_parallelism(num_files)
     set_up_performance_testing_A()  # A and B are separate in order to keep
     # output the same from old start_test
     set_up_executables()
     set_up_performance_testing_B()
 
     # autogenerate tests from spec if no tests were given
-    if len(files) == 0 and len(dirs) == 0:  # no tests specified
+    if num_files == 0 and num_dirs == 0:  # no tests specified
         auto_generate_tests()
         if os.getcwd() == home:
             dirs = [test_dir]
@@ -1168,7 +1170,7 @@ def set_up_general():
         compiler = args.compiler
 
 
-def set_up_parallelism():
+def set_up_parallelism(num_files):
     global file_workers
     # Individual test files are normally run serially. They may be run in
     # parallel only when BOTH --parallel and --allow-unsafe-parallel are given.
@@ -1185,7 +1187,7 @@ def set_up_parallelism():
         and not args.gen_graphs
         and args.parallel > 1
         and args.allow_unsafe_parallel
-        and len(files) > 1
+        and num_files > 1
     )
     if args.parallel > 1 and not args.allow_unsafe_parallel and files:
         print(

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -1167,6 +1167,7 @@ def set_up_general():
     else:
         compiler = args.compiler
 
+
 def set_up_parallelism():
     global file_workers
     # Individual test files are normally run serially. They may be run in
@@ -1202,6 +1203,7 @@ def set_up_parallelism():
     logger.write(f"[parallel dirs: {args.parallel}]")
     logger.write(f"[parallel files: {file_workers}]")
     logger.write(f"[parallel sub_test: {args.parallel_sub_test}]")
+
 
 def set_up_performance_testing_A():
     # performance

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -103,7 +103,7 @@ def run_tests(tests):
     # set up
     set_up_environment()
     set_up_general()
-    set_up_parallelism()
+    set_up_parallelism(files)
     set_up_performance_testing_A()  # A and B are separate in order to keep
     # output the same from old start_test
     set_up_executables()
@@ -1168,7 +1168,7 @@ def set_up_general():
         compiler = args.compiler
 
 
-def set_up_parallelism():
+def set_up_parallelism(files):
     global file_workers
     # Individual test files are normally run serially. They may be run in
     # parallel only when BOTH --parallel and --allow-unsafe-parallel are given.

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -103,6 +103,7 @@ def run_tests(tests):
     # set up
     set_up_environment()
     set_up_general()
+    set_up_parallelism()
     set_up_performance_testing_A()  # A and B are separate in order to keep
     # output the same from old start_test
     set_up_executables()
@@ -153,31 +154,6 @@ def run_tests(tests):
     else:
         os.environ["CHPL_TEST_NOTESTS"] = "1"
 
-    # Individual test files are normally run serially. They may be run in
-    # parallel only when BOTH --parallel and --allow-unsafe-parallel are given.
-    # This is "unsafe" because individually-specified files may share a
-    # directory and thus shared state (e.g. writing to the same local file,
-    # custom CLEANFILES, or prediff/skipif/precomp/etc side effects), which can
-    # cause suprious failures.
-    #
-    # out of caution, we only run in parallel in the "normal" run state, e.g.,
-    # no parallel performance testing or graph generation
-    files_parallel = (
-        not args.clean_only
-        and not args.performance
-        and not args.gen_graphs
-        and args.parallel > 1
-        and args.allow_unsafe_parallel
-        and len(files) > 1
-    )
-
-    if args.parallel > 1 and not args.allow_unsafe_parallel and files:
-        print(
-            "[Error: --parallel only applies to directories - to test files in parallel also pass --allow-unsafe-parallel]"
-        )
-        sys.exit(1)
-
-    file_workers = args.parallel if files_parallel else 1
     test_files(files, file_workers)
 
     os.environ["CHPL_TEST_FUTURES"] = str(args.futures_mode)
@@ -192,12 +168,6 @@ def run_tests(tests):
             testruns = ["graph"]
         else:
             testruns = ["run"]
-
-    if args.parallel_sub_test > 1 and not args.allow_unsafe_parallel and dirs:
-        print(
-            "[Error: --parallel-sub_test runs multiple tests within a directory concurrently and requires --allow-unsafe-parallel]"
-        )
-        sys.exit(1)
 
     for tests in dirs:
         for t in testruns:
@@ -1197,6 +1167,41 @@ def set_up_general():
     else:
         compiler = args.compiler
 
+def set_up_parallelism():
+    global file_workers
+    # Individual test files are normally run serially. They may be run in
+    # parallel only when BOTH --parallel and --allow-unsafe-parallel are given.
+    # This is "unsafe" because individually-specified files may share a
+    # directory and thus shared state (e.g. writing to the same local file,
+    # custom CLEANFILES, or prediff/skipif/precomp/etc side effects), which can
+    # cause suprious failures.
+    #
+    # out of caution, we only run in parallel in the "normal" run state, e.g.,
+    # no parallel performance testing or graph generation
+    files_parallel = (
+        not args.clean_only
+        and not args.performance
+        and not args.gen_graphs
+        and args.parallel > 1
+        and args.allow_unsafe_parallel
+        and len(files) > 1
+    )
+    if args.parallel > 1 and not args.allow_unsafe_parallel and files:
+        print(
+            "[Error: --parallel only applies to directories - to test files in parallel also pass --allow-unsafe-parallel]"
+        )
+        sys.exit(1)
+    file_workers = args.parallel if files_parallel else 1
+
+    if args.parallel_sub_test > 1 and not args.allow_unsafe_parallel and dirs:
+        print(
+            "[Error: --parallel-sub_test runs multiple tests within a directory concurrently and requires --allow-unsafe-parallel]"
+        )
+        sys.exit(1)
+
+    logger.write(f"[parallel dirs: {args.parallel}]")
+    logger.write(f"[parallel files: {file_workers}]")
+    logger.write(f"[parallel sub_test: {args.parallel_sub_test}]")
 
 def set_up_performance_testing_A():
     # performance

--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -96,23 +96,21 @@ def run_tests(tests):
                 "[Error: {0} is not a valid file or directory]".format(i)
             )
             had_invalid_file = True
-    num_files = num_files
-    num_dirs = num_dirs
 
-    if had_invalid_file and num_files == 0 and num_dirs == 0:
+    if had_invalid_file and len(files) == 0 and len(dirs) == 0:
         sys.exit(2)
 
     # set up
     set_up_environment()
     set_up_general()
-    set_up_parallelism(num_files)
+    set_up_parallelism()
     set_up_performance_testing_A()  # A and B are separate in order to keep
     # output the same from old start_test
     set_up_executables()
     set_up_performance_testing_B()
 
     # autogenerate tests from spec if no tests were given
-    if num_files == 0 and num_dirs == 0:  # no tests specified
+    if len(files) == 0 and len(dirs) == 0:  # no tests specified
         auto_generate_tests()
         if os.getcwd() == home:
             dirs = [test_dir]
@@ -1170,7 +1168,7 @@ def set_up_general():
         compiler = args.compiler
 
 
-def set_up_parallelism(num_files):
+def set_up_parallelism():
     global file_workers
     # Individual test files are normally run serially. They may be run in
     # parallel only when BOTH --parallel and --allow-unsafe-parallel are given.
@@ -1187,7 +1185,7 @@ def set_up_parallelism(num_files):
         and not args.gen_graphs
         and args.parallel > 1
         and args.allow_unsafe_parallel
-        and num_files > 1
+        and len(files) > 1
     )
     if args.parallel > 1 and not args.allow_unsafe_parallel and files:
         print(


### PR DESCRIPTION
Add logging to the top of a `start_test` run about the parallelism knob settings, and while at it refactor validating and printing these values into its own setup function.

[reviewed by @jabraham17 , thanks!]