### PR TITLE
Make linting workflows sparse-checkout .github

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   NIGHTLY_TEST_SETTINGS: true
 
-defaults:
+dfaults:
   run:
     shell: bash -exuo pipefail {0}
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   NIGHTLY_TEST_SETTINGS: true
 
-dfaults:
+defaults:
   run:
     shell: bash -exuo pipefail {0}
 

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        sparse-checkout: .github
         persist-credentials: false
     - name: Download actionlint
       id: get_actionlint
@@ -41,6 +42,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        sparse-checkout: .github
         persist-credentials: false
     - name: Run zizmor
       uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0


### PR DESCRIPTION
Make the checkouts in `lint-workflows.yml` sparse-checkout just the `.github` path (which contains all workflows and related configs), to shave a few seconds off their runtime.

[trivial, not reviewed]