### PR TITLE
Make tests which rely on optimized assembly more robust

### DIFF
--- a/test/llvm/assertVectorize/math-calls.prediff
+++ b/test/llvm/assertVectorize/math-calls.prediff
@@ -4,13 +4,6 @@ TESTNAME=$1
 OUTFILE=$2
 TMPFILE=$OUTFILE.prediff.tmp
 
-# filter out warnings from the backend that cannot be silenced
-grep -v 'library call cannot be vectorized' $OUTFILE > $TMPFILE
-mv $TMPFILE $OUTFILE
-grep -v 'the optimizer was unable to perform the requested transformation' $OUTFILE > $TMPFILE
-mv $TMPFILE $OUTFILE
-
-
 # filter out -Winvalid-feature-combination
 if grep -q 'invalid-feature-combination' $OUTFILE; then
   grep -v 'invalid-feature-combination' $OUTFILE > $TMPFILE

--- a/test/llvm/fma/FmaHardwareSpecialization.prediff
+++ b/test/llvm/fma/FmaHardwareSpecialization.prediff
@@ -66,3 +66,11 @@ with open(outfile, 'a') as fp:
     fp.write('Did not find {}'.format(ins))
     fp.write(out)
     fp.write('\n')
+
+# filter out -Winvalid-feature-combination
+lines = open(outfile).readlines()
+if any('invalid-feature-combination' in line for line in lines):
+  lines = [line for line in lines if 'invalid-feature-combination' not in line]
+  lines = [line for line in lines if 'warning generated' not in line]
+  with open(outfile, 'w') as fp:
+    fp.writelines(lines)


### PR DESCRIPTION
Makes a few tests which rely on optimized assembly output more robust by prediffing away a warning which can occur on some platforms

[Reviewed by @arifthpe]