### PR TITLE
Fix test in quickstart config

### DIFF
--- a/test/types/range/internals/chpl__mod-correctness.compopts
+++ b/test/types/range/internals/chpl__mod-correctness.compopts
@@ -1,0 +1,1 @@
+-snoRegex


### PR DESCRIPTION
Fixes a test which fails in the quickstart config, as quickstart has no regex support

[Not reviewed - trivial]