### PR TITLE
Remove Amazon Linux 2 prereqs entry and note

### DIFF
--- a/doc/rst/usingchapel/prereqs-commands.rst
+++ b/doc/rst/usingchapel/prereqs-commands.rst
@@ -13,25 +13,6 @@
       sudo apk add llvm-dev clang-dev clang-static llvm-static
 
 
-  * Amazon Linux 2 (but note `Amazon Linux 2 CHPL_LLVM==system incompatibility`_)::
-
-      sudo yum install git gcc gcc-c++ m4 perl python tcsh bash perl python python-devel python-setuptools bash make gawk python3 which libunwind-devel
-      sudo yum install wget tar openssl-devel
-      wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1.tar.gz
-      tar xvzf cmake-3.25.1.tar.gz
-      cd cmake-3.25.1
-      ./bootstrap
-      make
-      sudo make install
-      sudo update-alternatives --install /usr/bin/cmake cmake /usr/local/bin/cmake 1
-      sudo yum install gcc10 gcc10-c++
-      export CC=gcc10-gcc
-      export CXX=gcc10-g++
-      export CHPL_HOST_CC=gcc10-gcc
-      export CHPL_HOST_CXX=gcc10-g++
-      export CHPL_LLVM=bundled
-
-
   * Amazon Linux 2023::
 
       sudo dnf upgrade

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -86,24 +86,6 @@ We have used the following commands to install the above prerequisites:
 Compatibility Notes
 -------------------
 
-Amazon Linux 2 CHPL_LLVM==system incompatibility
-++++++++++++++++++++++++++++++++++++++++++++++++
-
-Amazon Linux 2 uses GCC 7.3.1 and only provides LLVM 11, but Chapel requires a
-newer GCC and newer LLVM. To use Chapel on this platform, installing a newer
-GCC is required. The repositories provide a GCC 10 package, which can be used
-to configure Chapel.
-
-.. code-block:: bash
-
-    export CC=gcc10-gcc
-    export CXX=gcc10-g++
-    export CHPL_HOST_CC=gcc10-gcc
-    export CHPL_HOST_CXX=gcc10-g++
-
-Chapel can then be built with ``CHPL_LLVM=none`` (still requires the newer GCC)
-or ``CHPL_LLVM=bundled``.
-
 Newer CMake required to build LLVM
 ++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
Remove Amazon Linux 2 information from `prereqs.rst`, now that the Amazon Linux 2 config is discontinued for EOL.

Follow up to https://github.com/chapel-lang/chapel/pull/29200 which removed the config.

[trivial, not reviewed]