### PR TITLE
Restore performance for DistributedSortPerf test

### DIFF
--- a/runtime/include/chpl-cache.h
+++ b/runtime/include/chpl-cache.h
@@ -53,8 +53,8 @@ extern "C" {
 static inline
 void chpl_cache_warn_if_disabled(void)
 {
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                          CHPL_CACHE_REMOTE);
+  // TODO: Stop reading this in runtime code.
+  extern const int CHPL_CACHE_REMOTE;
 
   if (CHPL_CACHE_REMOTE && !chpl_env_rt_get_bool("CACHE_QUIET", false)) {
     if (CHPL_RT_USING_ASAN) {
@@ -70,8 +70,15 @@ void chpl_cache_warn_if_disabled(void)
 static inline
 int chpl_cache_enabled(void)
 {
-  CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER,
-                          CHPL_CACHE_REMOTE);
+  // TODO: This used to be a 'prginfo' read, but it can't be because that
+  //       prevents LTO (link-time optimization), resulting in a 10%~ drop
+  //       in performance.
+  //
+  // Ultimately, the runtime cache code should not read 'CHPL_CACHE_REMOTE'
+  // at all, and checks about whether or not to use the cache should be
+  // moved into program code in some capacity. This makes LTO safe and also
+  // simplifies the runtime's responsibilities here.
+  extern const int CHPL_CACHE_REMOTE;
 
   // The remote cache is not compatible with ASan, and it uses thread local
   // storage, so if tasks can migrate between threads we lose our ability to

--- a/runtime/include/chpl-comm-compiler-macros.h
+++ b/runtime/include/chpl-comm-compiler-macros.h
@@ -28,9 +28,9 @@
 #include "chpl-error.h"
 #include "chpl-wide-ptr-fns.h"
 
-#include "chpl-prefetch.h" // for chpl_prefetch
-#include "chpl-cache.h" // chpl_rt_is_cache_enabled_fast, chpl_cache_comm_get etc
-#include "chpl-gpu.h" // for comm between device and host
+#include "chpl-prefetch.h"  // for chpl_prefetch
+#include "chpl-cache.h"     // chpl_cache_enabled, chpl_cache_comm_get etc
+#include "chpl-gpu.h"       // for comm between device and host
 
 // Don't warn about chpl_comm_get e.g. in this file.
 #include "chpl-comm-no-warning-macros.h"
@@ -47,16 +47,6 @@ extern "C" {
 
 #define CHPL_COMM_UNKNOWN_ID -1
 
-static ___always_inline int chpl_rt_is_cache_enabled_fast(void) {
-  extern const int CHPL_CACHE_REMOTE;
-
-  // The remote cache is not compatible with ASan, and it uses thread local
-  // storage, so if tasks can migrate between threads we lose our ability to
-  // correctly fence.
-  return CHPL_CACHE_REMOTE && !CHPL_RT_USING_ASAN &&
-         !chpl_task_canMigrateThreads();
-}
-
 static ___always_inline
 void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
                        size_t size, int32_t commID, int32_t ln, int32_t fn)
@@ -65,7 +55,7 @@ void chpl_gen_comm_get(void *addr, c_nodeid_t node, void* raddr,
   if (chpl_nodeID == node) {
     memmove(addr, raddr, size);
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_get(addr, node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -87,7 +77,7 @@ void chpl_gen_comm_get_from_subloc(void *addr, c_nodeid_t src_node,
     chpl_gpu_comm_get(dst_subloc, addr, src_node, src_subloc, raddr, size,
                       commID, ln, fn);
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_get(addr, src_node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -112,7 +102,7 @@ void chpl_gen_comm_prefetch(c_nodeid_t node, void* raddr,
       chpl_prefetch((unsigned char*)raddr + offset);
     }
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_prefetch(node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -130,7 +120,7 @@ void chpl_gen_comm_put(void* addr, c_nodeid_t node, void* raddr,
   if (chpl_nodeID == node) {
     memmove(raddr, addr, size);
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_put(addr, node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -153,7 +143,7 @@ void chpl_gen_comm_put_to_subloc(void* addr,
     chpl_gpu_comm_put(dst_node, dst_subloc, raddr, src_subloc, addr, size,
                       commID, ln, fn);
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
       chpl_cache_comm_put(addr, dst_node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -179,7 +169,7 @@ void chpl_gen_comm_get_strd(void *addr, void *dststr, c_nodeid_t node, c_subloci
   if( 0 ) {
 #endif // HAS_GPU_LOCALE
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_get_strd(addr, (size_t*)dststr, node, raddr, (size_t*)srcstr, (size_t*)count, strlevels, elemSize, commID, ln, fn);
 #endif
   } else {
@@ -204,7 +194,7 @@ void chpl_gen_comm_put_strd(void *addr, void *dststr, c_nodeid_t node, c_subloci
   if( 0 ) {
 #endif // HAS_GPU_LOCALE
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_put_strd(addr, (size_t*)dststr, node, raddr, (size_t*)srcstr, (size_t*)count, strlevels, elemSize, commID, ln, fn);
 #endif
   } else {
@@ -219,7 +209,7 @@ void chpl_gen_comm_get_unordered(void *addr, c_nodeid_t node, void* raddr,
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_get_unordered(addr, node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -233,7 +223,7 @@ void chpl_gen_comm_put_unordered(void* addr, c_nodeid_t node, void* raddr,
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_put_unordered(addr, node, raddr, size, commID, ln, fn);
 #endif
   } else {
@@ -249,7 +239,7 @@ void chpl_gen_comm_getput_unordered(c_nodeid_t dstnode, void* dstaddr,
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_getput_unordered(dstnode, dstaddr, srcnode, srcaddr, size, commID, ln, fn);
 #endif
   } else {
@@ -262,7 +252,7 @@ void chpl_gen_comm_getput_unordered_task_fence(void)
 {
   if (0) {
 #ifdef HAS_CHPL_CACHE_FNS
-  } else if( chpl_rt_is_cache_enabled_fast() ) {
+  } else if( chpl_cache_enabled() ) {
     chpl_cache_comm_getput_unordered_task_fence();
 #endif
   } else {


### PR DESCRIPTION
This PR attempts to restore performance for the DistributedSortPerf test when running on `gasnet-ibv.fast`. It replaces struct reads of `CHPL_CACHE_REMOTE` in the `chpl-cache.h` header with direct references. This enables LLVM link-time optimizations to fold away the memory read.

This should be viewed as a short-term workaround. In the long run, I think we should adjust the runtime's cache code so that it does not check for `CHPL_CACHE_REMOTE` at all. Instead, Chapel programs will be responsible for checking it in order to determine if they can use the cache or not. Doing so means programs can continue to safely benefit from LTO, while the runtime code is simplified because it no longer has to concern itself.

I am not entirely sure what form this will take, but it almost certainly involves adjusting the shims in `chpl-comm-compiler-macros.h` in some capacity.

Reviewed by @jabraham17. Thanks!