### PR TITLE
Handle including prereqs.rst notes in extract-docs.py, add CI

### DIFF
--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -459,3 +459,18 @@ jobs:
     - name: run test-networking-packages.bash
       run: |
         ./util/cron/test-networking-packages.bash
+
+  prereqs-docs-compare:
+    runs-on: ubuntu-slim
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    env:
+      PREREQS_COMMANDS_FILENAME: "prereqs-commands.rst"
+    - name: generate a ${{ env.PREREQS_COMMANDS_FILENAME }}
+      run: |
+        util/devel/test/portability/apptainer/extract-docs.py > $PREREQS_COMMANDS_FILENAME
+    - name: compare against checked-in file
+      run: |
+        diff $PREREQS_COMMANDS_FILENAME doc/rst/usingchapel/prereqs-commands.rst

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -463,14 +463,14 @@ jobs:
   prereqs-docs-compare:
     runs-on: ubuntu-slim
     env:
-      PREREQS_COMMANDS_FILENAME: "prereqs-commands.rst"
+      PREREQS_COMMANDS_FILE: "doc/rst/usingchapel/prereqs-commands.rst"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: generate a ${{ env.PREREQS_COMMANDS_FILENAME }}
+      - name: generate ${{ env.PREREQS_COMMANDS_FILE }}
         run: |
-          util/devel/test/portability/apptainer/extract-docs.py > "$PREREQS_COMMANDS_FILENAME"
+          util/devel/test/portability/apptainer/extract-docs.py > "$PREREQS_COMMANDS_FILE"
       - name: compare against checked-in file
         run: |
-          diff "$PREREQS_COMMANDS_FILENAME" doc/rst/usingchapel/prereqs-commands.rst
+          git diff --exit-code "$PREREQS_COMMANDS_FILE"

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -470,7 +470,7 @@ jobs:
           persist-credentials: false
       - name: generate a ${{ env.PREREQS_COMMANDS_FILENAME }}
         run: |
-          util/devel/test/portability/apptainer/extract-docs.py > $PREREQS_COMMANDS_FILENAME
+          util/devel/test/portability/apptainer/extract-docs.py > "$PREREQS_COMMANDS_FILENAME"
       - name: compare against checked-in file
         run: |
-          diff $PREREQS_COMMANDS_FILENAME doc/rst/usingchapel/prereqs-commands.rst
+          diff "$PREREQS_COMMANDS_FILENAME" doc/rst/usingchapel/prereqs-commands.rst

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -462,15 +462,15 @@ jobs:
 
   prereqs-docs-compare:
     runs-on: ubuntu-slim
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
     env:
       PREREQS_COMMANDS_FILENAME: "prereqs-commands.rst"
-    - name: generate a ${{ env.PREREQS_COMMANDS_FILENAME }}
-      run: |
-        util/devel/test/portability/apptainer/extract-docs.py > $PREREQS_COMMANDS_FILENAME
-    - name: compare against checked-in file
-      run: |
-        diff $PREREQS_COMMANDS_FILENAME doc/rst/usingchapel/prereqs-commands.rst
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: generate a ${{ env.PREREQS_COMMANDS_FILENAME }}
+        run: |
+          util/devel/test/portability/apptainer/extract-docs.py > $PREREQS_COMMANDS_FILENAME
+      - name: compare against checked-in file
+        run: |
+          diff $PREREQS_COMMANDS_FILENAME doc/rst/usingchapel/prereqs-commands.rst

--- a/doc/rst/usingchapel/prereqs-commands.rst
+++ b/doc/rst/usingchapel/prereqs-commands.rst
@@ -1,4 +1,4 @@
-  * Alma Linux 10, 8, 9::
+  * Alma Linux 8, 9, 10::
 
       sudo dnf upgrade
       sudo dnf install epel-release
@@ -80,7 +80,7 @@
       sudo zypper install llvm-devel clang-devel clang
 
 
-  * Rocky Linux 10, 8, 9::
+  * Rocky Linux 8, 9, 10::
 
       sudo dnf upgrade
       sudo dnf install epel-release

--- a/doc/rst/usingchapel/prereqs-commands.rst
+++ b/doc/rst/usingchapel/prereqs-commands.rst
@@ -106,6 +106,17 @@
 Compatibility Notes
 -------------------
 
+Newer CMake required to build LLVM
+++++++++++++++++++++++++++++++++++
+
+On some systems, the cmake package is not new enough to build the bundled
+LLVM. That can be addressed either by installing CMake from source or by
+installing a system LLVM package using the commands shown above.
+
+Note that the LLVM support library is used even with ``CHPL_LLVM=none``,
+and so installing a system LLVM on these platforms is still important in
+that case.
+
 Outdated FreeBSD testing
 ++++++++++++++++++++++++
 
@@ -117,14 +128,3 @@ own box or otherwise continuing to update this test coverage. It is still our
 intention to support FreeBSD as a best effort, so feel free to open bug reports
 for Chapel on FreeBSD versions newer than we test, and/or let us know if this
 lack of testing coverage causes you concern.
-
-Newer CMake required to build LLVM
-++++++++++++++++++++++++++++++++++
-
-On some systems, the cmake package is not new enough to build the bundled
-LLVM. That can be addressed either by installing CMake from source or by
-installing a system LLVM package using the commands shown above.
-
-Note that the LLVM support library is used even with ``CHPL_LLVM=none``,
-and so installing a system LLVM on these platforms is still important in
-that case.

--- a/doc/rst/usingchapel/prereqs-commands.rst
+++ b/doc/rst/usingchapel/prereqs-commands.rst
@@ -29,7 +29,7 @@
       sudo pacman -S llvm clang
 
 
-  * CentOS Stream 9, 10::
+  * CentOS Stream 10, 9::
 
       sudo dnf upgrade
       sudo dnf install epel-release
@@ -38,7 +38,7 @@
       sudo dnf install llvm-devel clang clang-devel
 
 
-  * Debian 11 "Bullseye" (but note `Newer CMake required to build LLVM`_)::
+  * Debian 11 "Bullseye" (but see note `Newer CMake required to build LLVM`_)::
 
       sudo apt-get update
       sudo apt-get install gcc g++ m4 perl python3 python3-dev bash make mawk git pkg-config cmake libunwind-dev
@@ -103,3 +103,28 @@
       sudo apt-get install llvm-dev llvm clang libclang-dev libclang-cpp-dev libedit-dev
 
 
+Compatibility Notes
+-------------------
+
+Outdated FreeBSD testing
+++++++++++++++++++++++++
+
+Our portability testing for FreeBSD relies on public Vagrant boxes. At time of
+writing (May 2026), we have been unable to find a box for FreeBSD releases
+newer than 14.3. Due to limited resources, and lacking information on how
+widely used Chapel is on FreeBSD, we have not taken on the work of making our
+own box or otherwise continuing to update this test coverage. It is still our
+intention to support FreeBSD as a best effort, so feel free to open bug reports
+for Chapel on FreeBSD versions newer than we test, and/or let us know if this
+lack of testing coverage causes you concern.
+
+Newer CMake required to build LLVM
+++++++++++++++++++++++++++++++++++
+
+On some systems, the cmake package is not new enough to build the bundled
+LLVM. That can be addressed either by installing CMake from source or by
+installing a system LLVM package using the commands shown above.
+
+Note that the LLVM support library is used even with ``CHPL_LLVM=none``,
+and so installing a system LLVM on these platforms is still important in
+that case.

--- a/doc/rst/usingchapel/prereqs-commands.rst
+++ b/doc/rst/usingchapel/prereqs-commands.rst
@@ -29,7 +29,7 @@
       sudo pacman -S llvm clang
 
 
-  * CentOS Stream 10, 9::
+  * CentOS Stream 9, 10::
 
       sudo dnf upgrade
       sudo dnf install epel-release

--- a/doc/rst/usingchapel/prereqs.rst
+++ b/doc/rst/usingchapel/prereqs.rst
@@ -82,29 +82,3 @@ Installation
 We have used the following commands to install the above prerequisites:
 
 .. include:: prereqs-commands.rst
-
-Compatibility Notes
--------------------
-
-Newer CMake required to build LLVM
-++++++++++++++++++++++++++++++++++
-
-On some systems, the cmake package is not new enough to build the bundled
-LLVM. That can be addressed either by installing CMake from source or by
-installing a system LLVM package using the commands shown above.
-
-Note that the LLVM support library is used even with ``CHPL_LLVM=none``,
-and so installing a system LLVM on these platforms is still important in
-that case.
-
-Outdated FreeBSD testing
-++++++++++++++++++++++++
-
-Our portability testing for FreeBSD relies on public Vagrant boxes. At time of
-writing (May 2026), we have been unable to find a box for FreeBSD releases
-newer than 14.3. Due to limited resources, and lacking information on how
-widely used Chapel is on FreeBSD, we have not taken on the work of making our
-own box or otherwise continuing to update this test coverage. It is still our
-intention to support FreeBSD as a best effort, so feel free to open bug reports
-for Chapel on FreeBSD versions newer than we test, and/or let us know if this
-lack of testing coverage causes you concern.

--- a/util/devel/test/portability/apptainer/extract-docs.py
+++ b/util/devel/test/portability/apptainer/extract-docs.py
@@ -11,9 +11,33 @@
 
 import os
 import re
+import sys
 from contextlib import contextmanager
 
 directories = ["current", "../vagrant/current"]
+compatibility_notes = {
+    "FreeBSD": (
+        "Outdated FreeBSD testing",
+        """Our portability testing for FreeBSD relies on public Vagrant boxes. At time of
+writing (May 2026), we have been unable to find a box for FreeBSD releases
+newer than 14.3. Due to limited resources, and lacking information on how
+widely used Chapel is on FreeBSD, we have not taken on the work of making our
+own box or otherwise continuing to update this test coverage. It is still our
+intention to support FreeBSD as a best effort, so feel free to open bug reports
+for Chapel on FreeBSD versions newer than we test, and/or let us know if this
+lack of testing coverage causes you concern.""",
+    ),
+    'Debian 11 "Bullseye"': (
+        "Newer CMake required to build LLVM",
+        """On some systems, the cmake package is not new enough to build the bundled
+LLVM. That can be addressed either by installing CMake from source or by
+installing a system LLVM package using the commands shown above.
+
+Note that the LLVM support library is used even with ``CHPL_LLVM=none``,
+and so installing a system LLVM on these platforms is still important in
+that case.""",
+    ),
+}
 
 
 def gather_provision_script_cmds(path):
@@ -207,9 +231,19 @@ def main():
 
     subdirs.sort(key=fixname)
 
+    tonotes = {}
+    unused_notes = set(compatibility_notes.keys())
     tocmds = {}
 
     for subpath in subdirs:
+        for note_key, note_info in compatibility_notes.items():
+            if note_key in fixname(subpath):
+                tonotes[subpath] = note_info
+                unused_notes.discard(note_key)
+                break
+        else:
+            tonotes[subpath] = None
+
         cmds = []
         if os.path.isdir(subpath):
             sdef = os.path.join(subpath, "image.def")
@@ -261,6 +295,12 @@ def main():
 
         tocmds[subpath] = result
 
+    if unused_notes:
+        print(
+            f"Error: could not find matching config for the following compatibility notes: {unused_notes}"
+        )
+        sys.exit(1)
+
     tab = {}
 
     i = 0
@@ -268,9 +308,14 @@ def main():
         subpath = subdirs[i]
         names = []
 
-        # find how many configs have the same commands
+        # find how many configs have the same commands and notes
         cmds = tocmds[subpath]
-        while i < len(subdirs) and tocmds[subdirs[i]] == cmds:
+        notes = tonotes[subpath]
+        while (
+            i < len(subdirs)
+            and tocmds[subdirs[i]] == cmds
+            and tonotes[subdirs[i]] == notes
+        ):
             names.append(fixname(subdirs[i]))
             i += 1
 
@@ -303,16 +348,28 @@ def main():
                     j += 1
                 shortnames.append(shortname)
 
-        tab[",".join(shortnames)] = cmds
+        tab[",".join(shortnames)] = (cmds, notes)
 
     # finally, output the table
-    for names, cmds in sorted(tab.items(), key=lambda x: x[0]):
-        print("  * " + names + "::")
+    for names, (cmds, notes) in sorted(tab.items(), key=lambda x: x[0]):
+        notes_str = f" (but see note `{notes[0]}`_)" if notes else ""
+        print("  * " + names + f"{notes_str}::")
         print()
         for cmd in cmds:
             print("      " + cmd)
         print()
         print()
+
+    # print compatibility notes section, if there are any notes
+    if compatibility_notes:
+        print("Compatibility Notes")
+        print("-------------------")
+        for note_name, note_text in compatibility_notes.values():
+            print()
+            print(note_name)
+            print("+" * len(note_name))
+            print()
+            print(note_text)
 
 
 if __name__ == "__main__":

--- a/util/devel/test/portability/apptainer/extract-docs.py
+++ b/util/devel/test/portability/apptainer/extract-docs.py
@@ -322,8 +322,12 @@ def main():
         # Sort by last "word" of fixed name as natural number if present, so
         # version 10 is after 9.
         # Based off of: https://stackoverflow.com/a/4836734
-        int_or_str = lambda convert_str: int(convert_str) if convert_str.isdigit() else convert_str
-        names.sort(key=lambda name: [int_or_str(c) for c in re.split('([0-9]+)', name)])
+        int_or_str = lambda convert_str: (
+            int(convert_str) if convert_str.isdigit() else convert_str
+        )
+        names.sort(
+            key=lambda name: [int_or_str(c) for c in re.split("([0-9]+)", name)]
+        )
 
         # summarize names string
         # remove words that occur repeatedly

--- a/util/devel/test/portability/apptainer/extract-docs.py
+++ b/util/devel/test/portability/apptainer/extract-docs.py
@@ -377,7 +377,7 @@ def main():
     if compatibility_notes:
         print("Compatibility Notes")
         print("-------------------")
-        for note_name, note_text in compatibility_notes.values():
+        for note_name, note_text in sorted(compatibility_notes.values()):
             print()
             print(note_name)
             print("+" * len(note_name))

--- a/util/devel/test/portability/apptainer/extract-docs.py
+++ b/util/devel/test/portability/apptainer/extract-docs.py
@@ -198,6 +198,13 @@ def extract_vfile_commands(vfile):
                             cmds.extend(subcmds)
     return cmds
 
+def to_int_or_zero(convert_string):
+    res = 0
+    try:
+        res = int(convert_string)
+    except ValueError:
+        pass
+    return res
 
 @contextmanager
 def cd(newdir):
@@ -318,6 +325,10 @@ def main():
         ):
             names.append(fixname(subdirs[i]))
             i += 1
+
+        # sort by last "word" of fixed name as natural number if present, so
+        # version 10 is after 9
+        names.sort(key=lambda name: to_int_or_zero(name.split()[-1]))
 
         # summarize names string
         # remove words that occur repeatedly

--- a/util/devel/test/portability/apptainer/extract-docs.py
+++ b/util/devel/test/portability/apptainer/extract-docs.py
@@ -198,6 +198,7 @@ def extract_vfile_commands(vfile):
                             cmds.extend(subcmds)
     return cmds
 
+
 def to_int_or_zero(convert_string):
     res = 0
     try:
@@ -205,6 +206,7 @@ def to_int_or_zero(convert_string):
     except ValueError:
         pass
     return res
+
 
 @contextmanager
 def cd(newdir):

--- a/util/devel/test/portability/apptainer/extract-docs.py
+++ b/util/devel/test/portability/apptainer/extract-docs.py
@@ -199,15 +199,6 @@ def extract_vfile_commands(vfile):
     return cmds
 
 
-def to_int_or_zero(convert_string):
-    res = 0
-    try:
-        res = int(convert_string)
-    except ValueError:
-        pass
-    return res
-
-
 @contextmanager
 def cd(newdir):
     prevdir = os.getcwd()
@@ -328,9 +319,11 @@ def main():
             names.append(fixname(subdirs[i]))
             i += 1
 
-        # sort by last "word" of fixed name as natural number if present, so
-        # version 10 is after 9
-        names.sort(key=lambda name: to_int_or_zero(name.split()[-1]))
+        # Sort by last "word" of fixed name as natural number if present, so
+        # version 10 is after 9.
+        # Based off of: https://stackoverflow.com/a/4836734
+        int_or_str = lambda convert_str: int(convert_str) if convert_str.isdigit() else convert_str
+        names.sort(key=lambda name: [int_or_str(c) for c in re.split('([0-9]+)', name)])
 
         # summarize names string
         # remove words that occur repeatedly


### PR DESCRIPTION
Make `util/devel/test/portability/apptainer/extract-docs.py` handle outputting compatibility notes as well so no manual adjustments to its output are needed, then add a CI check that the live `doc/rst/usingchapel/prereqs-commands.rst` matches its output.

While here, also make the script output OS groups (list of versions) in natural number ordering, so `10` comes after `9`, and update `prereqs-commands.rst` to match.

This CI check runs no matter whether or not relevant files were changed, because 1) it is so cheap that checking paths would probably be as expensive as just running it, and 2) I expect it to have zero false-positives.

[reviewed by @jabraham17 , thanks!]

Testing:
- [x] local built docs look right, including notes section