### PR TITLE
Make all upload-artifact steps error if file not found

### DIFF
--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -75,6 +75,7 @@ jobs:
       with:
         name: documentation
         path: docs.tar.gz
+        if-no-files-found: error
 
   make_mason:
     runs-on: ubuntu-latest

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -347,6 +347,7 @@ jobs:
       with:
         path: ./tar/chapel-test.tar.gz
         archive: false
+        if-no-files-found: error
 
   test-homebrew:
     strategy:


### PR DESCRIPTION
Set `if-no-files-found: error` (default is `warn`) on all our uses of https://github.com/actions/upload-artifact, since we should consider it a failure if an expected artifact is missing.

[trivial, not reviewed]