### PR TITLE
Use homebrew linux image :latest rather than :main

### DIFF
--- a/util/packaging/docker/test/Dockerfile
+++ b/util/packaging/docker/test/Dockerfile
@@ -1,7 +1,7 @@
 # This is a container used to run homebrew-ci
 
 # Get the homebrew ubuntu container
-FROM ghcr.io/homebrew/brew:main
+FROM ghcr.io/homebrew/brew:latest
 
 # Redundant to brew_install.bash but imporant for anyone working in this container
 # which can be ran without brew_install.bash

--- a/util/packaging/homebrew/readme.md
+++ b/util/packaging/homebrew/readme.md
@@ -37,7 +37,7 @@ https://github.com/Homebrew/homebrew-core/blob/main/CONTRIBUTING.md
 
 The container is executed using the following instructions:
 ```
-docker run --interactive --tty --rm --pull always ghcr.io/homebrew/brew:main /bin/bash
+docker run --interactive --tty --rm --pull always ghcr.io/homebrew/brew:latest /bin/bash
 ```
 
 Formulas can be copied to the container using the following command:


### PR DESCRIPTION
Base our Linux Homebrew testing image off of `ghcr.io/homebrew/brew:latest` rather than `ghcr.io/homebrew/brew:main`.

Based off of ghcr.io/homebrew/brew, it looks like `main` is the volatile tip of the `main` branch of https://github.com/Homebrew/brew, whereas `latest` is the latest release, which is probably more stable and what we want to test anyways.

[trivial, not reviewed]