### PR TITLE
Move LLDB python support commands into commands file

### DIFF
--- a/compiler/etc/lldb.commands
+++ b/compiler/etc/lldb.commands
@@ -7,6 +7,4 @@ command regex dview 's/(.*)/expr -- (%1).dump()/'
 command regex flags  's/(.*)/expr -- viewFlags(%1)/'
 command regex loc    's/(.*)/expr -- ::stringLoc(%1)/'
 
-breakpoint set -n debuggerBreakHere -N debuggerBreakHere
-breakpoint command add -o up debuggerBreakHere
 command script import -c chpl_lldb_debuggerBreakHere.py

--- a/compiler/etc/lldb.commands
+++ b/compiler/etc/lldb.commands
@@ -7,4 +7,6 @@ command regex dview 's/(.*)/expr -- (%1).dump()/'
 command regex flags  's/(.*)/expr -- viewFlags(%1)/'
 command regex loc    's/(.*)/expr -- ::stringLoc(%1)/'
 
+breakpoint set -n debuggerBreakHere -N debuggerBreakHere
+target stop-hook add --name debuggerBreakHere -o "up"
 command script import -c chpl_lldb_debuggerBreakHere.py

--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -58,7 +58,7 @@ class DebuggerBreakHereStopHook:
 
 
 def __lldb_init_module(debugger, internal_dict):
-    debugger.HandleCommand("target stop-hook delete 1")
     debugger.HandleCommand(
         "target stop-hook add --script-class chpl_lldb_debuggerBreakHere.DebuggerBreakHereStopHook"
     )
+    debugger.HandleCommand("breakpoint set -n debuggerBreakHere -N debuggerBreakHere")

--- a/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
+++ b/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py
@@ -61,4 +61,6 @@ def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
         "target stop-hook add --script-class chpl_lldb_debuggerBreakHere.DebuggerBreakHereStopHook"
     )
-    debugger.HandleCommand("breakpoint set -n debuggerBreakHere -N debuggerBreakHere")
+    debugger.HandleCommand(
+        "breakpoint set -n debuggerBreakHere -N debuggerBreakHere"
+    )

--- a/runtime/etc/debug/chpl_parallel_dbg_commands.py
+++ b/runtime/etc/debug/chpl_parallel_dbg_commands.py
@@ -147,14 +147,8 @@ def connect(debugger: lldb.SBDebugger, command, result, internal_dict):
 def __lldb_init_module(debugger, internal_dict):
     print("Chapel parallel debugger commands loaded")
     directory = os.path.dirname(os.path.abspath(__file__))
-    pretty_printer_file = os.path.join(directory, "chpl_lldb_pretty_print.py")
-    lldb_commands_file = os.path.join(directory, "lldb.commands")
-    debuggerBreakHere_file = os.path.join(
-        directory, "chpl_lldb_debuggerBreakHere.py"
-    )
+    lldb_commands_file = os.path.join(directory, "lldb_with_python.commands")
     debugger.HandleCommand(f'command source "{lldb_commands_file}"')
-    debugger.HandleCommand(f'command script import "{debuggerBreakHere_file}"')
-    debugger.HandleCommand(f'command script import "{pretty_printer_file}"')
     debugger.HandleCommand(
         "command script add -f chpl_parallel_dbg_commands.on on"
     )

--- a/runtime/etc/debug/lldb_with_python.commands
+++ b/runtime/etc/debug/lldb_with_python.commands
@@ -1,4 +1,2 @@
-breakpoint set -n debuggerBreakHere -N debuggerBreakHere
-target stop-hook add --name debuggerBreakHere -o "up"
-command script import -c ./chpl_lldb_debuggerBreakHere.py
-command script import -c ./chpl_lldb_pretty_print.py
+command script import -c chpl_lldb_debuggerBreakHere.py
+command script import -c chpl_lldb_pretty_print.py

--- a/runtime/etc/debug/lldb_with_python.commands
+++ b/runtime/etc/debug/lldb_with_python.commands
@@ -1,0 +1,4 @@
+breakpoint set -n debuggerBreakHere -N debuggerBreakHere
+target stop-hook add --name debuggerBreakHere -o "up"
+command script import -c ./chpl_lldb_debuggerBreakHere.py
+command script import -c ./chpl_lldb_pretty_print.py

--- a/runtime/src/comm/none/comm-none.c
+++ b/runtime/src/comm/none/comm-none.c
@@ -183,7 +183,19 @@ int chpl_comm_run_in_lldb(int argc, char* argv[], int lldbArgnum, int* status) {
   CHPL_RT_PRGINFO_DECLARE(CHPL_RT_ROOT_PROGRAM_PLACEHOLDER, CHPL_HOME);
   char* command = (char*)"lldb";
 
-  const char* lldb_commands = chpl_glom_strings(2, CHPL_HOME, "/runtime/etc/debug/lldb.commands");
+  const char* lldb_commands = NULL;
+
+  if (chpl_lldb_supports_python()) {
+    lldb_commands = chpl_glom_strings(2, CHPL_HOME, "/runtime/etc/debug/lldb_with_python.commands");
+  } else {
+    lldb_commands = chpl_glom_strings(2, CHPL_HOME, "/runtime/etc/debug/lldb.commands");
+    chpl_warning(
+      "LLDB does not support scripting with Python"
+      ", pretty-printer will not be used",
+      0, CHPL_FILE_IDX_COMMAND_LINE
+    );
+  }
+
   if (access(lldb_commands, R_OK) == 0) {
     command = chpl_glom_strings(4, command, " --source \"", lldb_commands, "\"");
   } else {
@@ -191,34 +203,6 @@ int chpl_comm_run_in_lldb(int argc, char* argv[], int lldbArgnum, int* status) {
       "Could not find 'lldb.commands' file, falling back to basic settings",
       0, CHPL_FILE_IDX_COMMAND_LINE);
     command = chpl_glom_strings(2, command, " -o 'b debuggerBreakHere'");
-  }
-
-
-  if (chpl_lldb_supports_python()) {
-
-    const char* debuggerBreakHereCommands = chpl_glom_strings(2, CHPL_HOME, "/runtime/etc/debug/chpl_lldb_debuggerBreakHere.py");
-    if (access(debuggerBreakHereCommands, R_OK) == 0) {
-      command = chpl_glom_strings(4, command,
-        " -o 'command script import \"", debuggerBreakHereCommands, "\"'");
-    } else {
-      chpl_warning("Could not find lldb debuggerBreakHere script, it will be ignored",
-                    0, CHPL_FILE_IDX_COMMAND_LINE);
-    }
-
-    const char* pretty_printer = chpl_glom_strings(2, CHPL_HOME, "/runtime/etc/debug/chpl_lldb_pretty_print.py");
-    if (access(pretty_printer, R_OK) == 0) {
-      command = chpl_glom_strings(4, command,
-        " -o 'command script import \"", pretty_printer, "\"'");
-    } else {
-      chpl_warning("Could not find lldb pretty-printer, it will be ignored",
-                    0, CHPL_FILE_IDX_COMMAND_LINE);
-    }
-  } else {
-    chpl_warning(
-      "LLDB does not support scripting with Python"
-      ", pretty-printer will not be used",
-      0, CHPL_FILE_IDX_COMMAND_LINE
-    );
   }
 
   const char* debuggerCmdFile = chpl_get_debugger_cmd_file();

--- a/test/llvm/debugInfo/lldb/functionCalls.chpl
+++ b/test/llvm/debugInfo/lldb/functionCalls.chpl
@@ -46,7 +46,7 @@ proc main() {
   breakpoint;
 }
 
-// CHECK: breakpoint set -n debuggerBreakHere -N debuggerBreakHere
+// CHECK: Stop hook #1
 // CHECK-NEXT: Breakpoint [[#BREAKPOINT_START:]]
 
 // CHECK: b myFunc

--- a/test/llvm/debugInfo/lldb/methodCallsClass.chpl
+++ b/test/llvm/debugInfo/lldb/methodCallsClass.chpl
@@ -28,7 +28,7 @@ proc main() {
   breakpoint;
 }
 
-// CHECK: breakpoint set -n debuggerBreakHere -N debuggerBreakHere
+// CHECK: Stop hook #1
 // CHECK-NEXT: Breakpoint [[#BREAKPOINT_START:]]
 
 // CHECK: b methodCallsClass.chpl:8

--- a/test/llvm/debugInfo/lldb/methodCallsRec.chpl
+++ b/test/llvm/debugInfo/lldb/methodCallsRec.chpl
@@ -24,7 +24,7 @@ proc main() {
   breakpoint;
 }
 
-// CHECK: breakpoint set -n debuggerBreakHere -N debuggerBreakHere
+// CHECK: Stop hook #1
 // CHECK-NEXT: Breakpoint [[#BREAKPOINT_START:]]
 
 // CHECK: b methodCallsRec.chpl:8

--- a/test/llvm/debugInfo/lldb/targetVar.chpl
+++ b/test/llvm/debugInfo/lldb/targetVar.chpl
@@ -1,4 +1,4 @@
-// CHECK: breakpoint set -n debuggerBreakHere -N debuggerBreakHere
+// CHECK: Stop hook #1
 // CHECK-NEXT: Breakpoint [[#BREAKPOINT_START:]]
 
 const myGlobal = 42;


### PR DESCRIPTION
We have observed some strange behavior on a macos system where long file paths passed to LLDB can be truncated. This resulted in some tests hanging and timing out. The most expedient fix here is to move these lengthy commands into a .commands file, and select that commands file when detecting python support.

[reviewed-by @dlongnecke-cray , @jabraham17]