### PR TITLE
Fix test when run with gcc

### DIFF
--- a/test/library/standard/Math/abs-errors.lastcompopts
+++ b/test/library/standard/Math/abs-errors.lastcompopts
@@ -1,1 +1,1 @@
---checks --no-cc-warnings --ccflags -Wno-constant-conversion --ccflags -Wno-integer-overflow
+--checks --no-cc-warnings --ccflags -Wno-constant-conversion --ccflags -Wno-integer-overflow --ccflags -Wno-overflow


### PR DESCRIPTION
Fixes a test which would fail when run with the gcc backend, since the warning from gcc is different than from clang

[Not reviewed - trivial]