### PR TITLE
Fix LLDB test prediffs

### DIFF
--- a/test/compflags/bradc/gdbddash/declint-lldb.prediff
+++ b/test/compflags/bradc/gdbddash/declint-lldb.prediff
@@ -8,7 +8,7 @@ tmpfile=$outfile.raw.tmp
 # some gdbs print out extra stuff.  This filters it out
 #
 mv $outfile $tmpfile
-grep -v "Current executable set to" $tmpfile | grep -v "Executing commands in" | grep -v "settings set" | grep -v "command regex" | grep -v "breakpoint set" | grep -v "breakpoint command" | grep -v 'command script import' | grep -v "Breakpoint 1" | grep -v "target create" | grep -v "command source" | grep -iv 'stop hook' > $outfile
+grep -v "Current executable set to" $tmpfile | grep -v "Executing commands in" | grep -v "settings set" | grep -v "command regex" | grep -v "breakpoint set" | grep -v "breakpoint command" | grep -v 'command script import' | grep -v "Breakpoint 1" | grep -v "target create" | grep -v "command source" | grep -iv 'stop hook' | grep -iv 'stop-hook' > $outfile
 rm $tmpfile
 
 #

--- a/test/compflags/driver/monolithic/debugger/declint-lldb.prediff
+++ b/test/compflags/driver/monolithic/debugger/declint-lldb.prediff
@@ -8,7 +8,7 @@ tmpfile=$outfile.raw.tmp
 # some gdbs print out extra stuff.  This filters it out
 #
 mv $outfile $tmpfile
-grep -v "Current executable set to" $tmpfile | grep -v "Executing commands in" | grep -v "settings set" | grep -v "command regex" | grep -v "breakpoint set" | grep -v "breakpoint command" | grep -v 'command script import' | grep -v "Breakpoint 1" | grep -v "target create" | grep -v "command source" | grep -iv "stop hook" > $outfile
+grep -v "Current executable set to" $tmpfile | grep -v "Executing commands in" | grep -v "settings set" | grep -v "command regex" | grep -v "breakpoint set" | grep -v "breakpoint command" | grep -v 'command script import' | grep -v "Breakpoint 1" | grep -v "target create" | grep -v "command source" | grep -iv "stop hook" | grep -v "stop-hook" > $outfile
 rm $tmpfile
 
 #
@@ -16,6 +16,6 @@ rm $tmpfile
 # this ensures that a linefeed is added
 #
 numlines=`wc -l $outfile`
-if [["$numlines" == "0 $outfile"]]; then
+if [[ "$numlines" == "0 $outfile" ]]; then
   echo >> $outfile
 fi

--- a/test/execflags/lldbddash/declint.prediff
+++ b/test/execflags/lldbddash/declint.prediff
@@ -17,7 +17,8 @@ grep -v "Breakpoint 1: where" $tmpfile | \
   grep -v 'command script import' | \
   grep -v 'target stop-hook add' | \
   grep -v 'Stop hook #' | \
-  grep -v 'runtime/etc/debug/lldb.commands' \
+  grep -v 'runtime/etc/debug/lldb.commands' | \
+  grep -v 'runtime/etc/debug/lldb_with_python.commands' \
   > $outfile
 # Also filter out line about memleaks arguments to executable
 mv $outfile $tmpfile


### PR DESCRIPTION
This is a follow-up to #29240 , which changed some of the output that we'd normally prediff away. In this PR I add some additional strings to eliminate, following the pre-established pattern. This PR also fixes a minor bash bug with an if-statement.

Trivial, not reviewed.