### PR TITLE
Ensure start_test can be cleanly killed by Ctrl-C

### DIFF
--- a/util/test/start_test.py
+++ b/util/test/start_test.py
@@ -588,38 +588,41 @@ def invoke_sub_test(output, test_dir_path, test, for_files, path_for_log):
 
 
 def invoke_sub_tests(work, num_workers, for_files):
+    def invoke_sub_test_work(work):
+        item, output, other_args = work[0], work[1], work[2:]
+        status, output = invoke_sub_test(output, *other_args)
+        return (item, status, output)
+
+    invocations = []
+    for item, test_dir_path, test in work:
+        output = BufferedLogger() if num_workers > 1 else logger
+        path_for_log = item[1] if not for_files else os.path.relpath(item)
+        if num_workers > 1:
+            output.write()
+            if for_files:
+                output.write("[Working on file {0}]".format(path_for_log))
+            else:
+                output.write("[Working on directory {0}]".format(path_for_log))
+            path_for_log = None  # don't log again in invoke_sub_test
+        invocations.append(
+            (
+                item,
+                output,
+                test_dir_path,
+                test,
+                for_files,
+                path_for_log,
+            )
+        )
+
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=num_workers
     ) as executor:
-        futures = []
-        for item, test_dir_path, test in work:
-            output = BufferedLogger() if num_workers > 1 else logger
-            path_for_log = item[1] if not for_files else os.path.relpath(item)
-            if num_workers > 1:
-                output.write()
-                if for_files:
-                    output.write("[Working on file {0}]".format(path_for_log))
-                else:
-                    output.write(
-                        "[Working on directory {0}]".format(path_for_log)
-                    )
-                path_for_log = None  # don't log again in invoke_sub_test
-            futures.append(
-                (
-                    item,
-                    executor.submit(
-                        invoke_sub_test,
-                        output,
-                        test_dir_path,
-                        test,
-                        for_files,
-                        path_for_log,
-                    ),
-                )
-            )
-        for item, future in futures:
-            status, output = future.result()
-            yield (item, status, output)
+        try:
+            yield from executor.map(invoke_sub_test_work, invocations)
+        except BaseException:
+            executor.shutdown(wait=False, cancel_futures=True)
+            raise
 
 
 def run_sub_tests(items, num_workers):

--- a/util/test/sub_test.py
+++ b/util/test/sub_test.py
@@ -1573,23 +1573,27 @@ def run_tests(testsrc, common_test_args):
     if not testsrc:
         return
 
+    def _run_test_capture(testname):
+        buffer = io.StringIO()
+        run_test(common_test_args, testname, out=buffer)
+        return buffer.getvalue()
+
+    def _run_test_nocapture(testname):
+        run_test(common_test_args, testname, out=sys.stdout)
+        return ""
+
+    func = _run_test_capture if num_workers > 1 else _run_test_nocapture
+
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=num_workers
     ) as executor:
-
-        def _run_test_capture(testname):
-            buffer = io.StringIO()
-            run_test(common_test_args, testname, out=buffer)
-            return buffer.getvalue()
-
-        def _run_test_nocapture(testname):
-            run_test(common_test_args, testname, out=sys.stdout)
-            return ""
-
-        func = _run_test_capture if num_workers > 1 else _run_test_nocapture
-        for output in executor.map(func, testsrc):
-            sys.stdout.write(output)
-            sys.stdout.flush()
+        try:
+            for output in executor.map(func, testsrc):
+                sys.stdout.write(output)
+                sys.stdout.flush()
+        except BaseException:
+            executor.shutdown(wait=False, cancel_futures=True)
+            raise
 
 
 def run_test(test_args, testname, out=sys.stdout):


### PR DESCRIPTION
Ensures that start_test can be cleanly killed by Ctrl-C.

Previous work implemented parallel workers for start_test. Even with one parallel worker, the way it was implemented could result in runaway processes that require either spamming Ctrl-C to cancel or in the worse case require `kill`.

The workaround is two-fold. First, always use `map` and not submit for more consistent process execution thats handled by the Python executor library. Second, any exception (including KeyboardInterrupt) causes all executors to be forced to shutdown, handling any shutdown not already handled by `map`

[Reviewed by @arifthpe]