### PR TITLE
Fix setting make -j arg in test_install.bash

### DIFF
--- a/util/buildRelease/test_install.bash
+++ b/util/buildRelease/test_install.bash
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -exuo pipefail
+
 if [ ! -f configure ]
 then
   echo "Should be run from a CHPL_HOME directory" 1>&2

--- a/util/buildRelease/test_install.bash
+++ b/util/buildRelease/test_install.bash
@@ -8,12 +8,12 @@ then
   exit 1
 fi
 
+num_procs=`$CHPL_HOME/util/buildRelease/chpl-make-cpu_count`
+echo "Using $num_procs threads for parallel make"
+
 unset CHPL_HOME
 export CHPL_CHECK_HOME=`pwd`
 wd=`pwd`
-
-num_procs=`$CHPL_HOME/util/buildRelease/chpl-make-cpu_count`
-echo "Using $num_procs threads for parallel make"
 
 export CHPL_LLVM=bundled
 


### PR DESCRIPTION
Fix a bug in `util/buildRelease/test_install.bash` where `$CHPL_HOME/util/buildRelease/chpl-make-cpu_count` is invoked after unsetting `$CHPL_HOME`, so the script is not found.

The resulting empty output is used as the argument to `make`'s `-j`, leading to running with an unlimited number of jobs. Since this script builds bundled LLVM, that makes it easy to run OOM.

The underlying issue of invoking the script relative to `CHPL_HOME` while the latter is unset has been present since e0900d91d7d55989a924f03ce7b9b89a461675a2. More recently, a2a128fb164dc31df3385fc83068a1191b942603 removed the in-theory-unnecessary default value of `1` offered in place of the script output, changing from being stuck at `-j1` to being at uncapped `-j`.

While here, also add `set -exuo pipefail` to this script as a good Bash practice. In particular, `e` would have caught this bug.

[reviewed by @jabraham17 , thanks!]