### PR TITLE
Use even smaller numbers with scanOps test

### DIFF
--- a/test/scan/testScanOps.execopts
+++ b/test/scan/testScanOps.execopts
@@ -2,5 +2,5 @@
 
 # use a smaller size for UB testing, since otherwise + and * will likely overflow
 if [ "$CHPL_SANITIZE_EXE" == "undefined" ]; then
-  echo "--maxInt=$((2**5)) --n=15"
+  echo "--maxInt=$((2**4)) --n=15"
 fi


### PR DESCRIPTION
Uses even smaller numbers with scanOps test to avoid overflow

[Not reviewed]