### PR TITLE
Add content to nightly failure mail message

### DIFF
--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -21,3 +21,8 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - run: exit 1
+  also-trigger-failure:
+    runs-on: ubuntu-slim
+    steps:
+      - name: break it
+        run: exit 1

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -39,9 +39,11 @@ jobs:
       - name: gather info for email
         id: info
         run: |
+          gh api /repos/chapel-lang/chapel/commits/${{ github.sha }} > commit.json
+
           {
             echo "date=$(date +'%Y-%m-%d')"
-            echo "message=$(gh api /repos/chapel-lang/chapel/commits/${{ github.sha }} | jq -r '.commit.message' | head -n 1)"
+            echo "message=$(jq -r '.commit.message' commit.json | head -n 1)"
           } >> "$GITHUB_OUTPUT"
       - name: Send mail
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -40,10 +40,13 @@ jobs:
         id: info
         run: |
           gh api /repos/chapel-lang/chapel/commits/${{ github.sha }} | tee commit.json
+          gh api /repos/chapel-lang/chapel/actions/runs/${{ github.run_id }}/jobs | tee jobs.json
 
           {
             echo "date=$(date +'%Y-%m-%d')"
             echo "message=$(jq -r '.commit.message' commit.json | head -n 1)"
+            echo "num_jobs=$(jq '.jobs | length' jobs.json)"
+            echo "failed_jobs=$(jq '.jobs[] | select(.status != "completed" or .conclusion != "success" ) | .name' jobs.json)"
           } >> "$GITHUB_OUTPUT"
       - name: Send mail
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
@@ -58,9 +61,13 @@ jobs:
            to: "anna.rift@hpe.com"
            from:  "Chapel Automaton <chapel_commits@cray.com>"
            body: |
-             One or more GitHub Actions jobs have failed.
+             One or more GitHub Actions jobs have failed:
 
-             Ran at commit ${{ github.sha }}.
+             ---
+             ${{ steps.info.outputs.failed_jobs }}
+             ---
+
+             Ran ${{ steps.info.outpus.num_jobs }} jobs at commit ${{ github.sha }}.
              > ${{ steps.info.outputs.message }}
 
              GitHub Actions run info:

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -39,6 +39,9 @@ jobs:
       - name: determine date
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+      - name: get commit message
+        id: message
+        run: echo "message=$(curl 'https://api.github.com/repos/chapel-lang/chapel/commits/${{ github.sha }}' | jq -r '.commit.message' | head -n 1)" >> "$GITHUB_OUTPUT"
       - name: Send mail
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
         with:
@@ -52,4 +55,14 @@ jobs:
            to: "anna.rift@hpe.com"
            from:  "Chapel Automaton <chapel_commits@cray.com>"
            body: |
-             Test nightly mail from GA -- a required status check has failed
+             One or more GitHub Actions jobs have failed.
+
+             Ran at commit ${{ github.sha }}.
+             > ${{ steps.message.outputs.message }}
+
+             GitHub Actions run info:
+             - SHA: ${{ github.sha }}
+             - Run ID: ${{ github.run_id }}
+             - Run attempt #: ${{ github.run_attempt }}
+             - Run number: ${{ github.run_number }}
+             - Triggering event name: ${{ github.event_name }}

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       EMAIL_BODY_FILENAME: email.html
     steps:
-      - name: get date
+      - name: determine date
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
       - name: generate email body

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -52,8 +52,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: generate email body
         run: |
-          cat << 'EOF' > ${{ env.EMAIL_BODY_FILENAME }}
-          The following GitHub Actions jobs have failed:
+          [[ $num_jobs -eq 1 ]] && plural="" || plural="s"
+
+          cat << EOF > ${{ env.EMAIL_BODY_FILENAME }}
+          The following GitHub Actions job$plural failed:
 
           --------
           ${{ steps.info.outputs.failed_jobs }}

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -48,14 +48,22 @@ jobs:
 
           message=$(jq -r '.commit.message' commit.json | head -n 1)
           num_jobs=$(jq '.jobs | length' jobs.json)
-          failed_jobs=$(jq '.jobs[] | select(.status != "completed" or .conclusion != "success" ) | .name' jobs.json | sort)
+          failed_job_ids=$(jq '[.jobs[] | select(.status != "completed" or .conclusion != "success")] | sort_by(.name) | .[].id' jobs.json)
+
+          failed_jobs_html=""
+          for id in "${failed_job_ids[@]}"; do
+            gh api "/repos/chapel-lang/chapel/actions/jobs/$id" > "job_$id.json"
+            failed_jobs_html+=$(jq -r '{html_url, name, first_bad_step: ([.steps[] | select(.conclusion != "success")] | first).name} | "<a href=\"\(.html_url)\">\(.name)</a>, step \(.first_bad_step)"' "job_$id.json")
+          done
 
           [[ $num_jobs -eq 1 ]] && plural="" || plural="s"
 
           cat << EOF > ${{ env.EMAIL_BODY_FILENAME }}
           <h3>The following GitHub Actions job$plural failed:</h3>
 
-          $failed_jobs
+          <ul>
+          $failed_jobs_html
+          </ul>
           <hr>
 
           <p>Ran $num_jobs total jobs at commit ${{ github.sha }} "$message".</p>

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -53,21 +53,21 @@ jobs:
           [[ $num_jobs -eq 1 ]] && plural="" || plural="s"
 
           cat << EOF > ${{ env.EMAIL_BODY_FILENAME }}
-          The following GitHub Actions job$plural failed:
+          <h3>The following GitHub Actions job$plural failed:</h3>
 
-          --------
           $failed_jobs
-          --------
+          <hr>
 
-          Ran $num_jobs total jobs at commit ${{ github.sha }}.
-          > $message
+          <p>Ran $num_jobs total jobs at commit ${{ github.sha }} "$message".</p>
 
-          GitHub Actions run info:
-          - SHA: ${{ github.sha }}
-          - Run ID: ${{ github.run_id }}
-          - Run attempt #: ${{ github.run_attempt }}
-          - Run number: ${{ github.run_number }}
-          - Triggering event name: ${{ github.event_name }}
+          <p>GitHub Actions run info:</p>
+          <ul>
+            <li>SHA: ${{ github.sha }}</li>
+            <li>Run ID: ${{ github.run_id }}</li>
+            <li>Run attempt #: ${{ github.run_attempt }}</li>
+            <li>Run number: ${{ github.run_number }}</li>
+            <li>Triggering event name: ${{ github.event_name }}</li>
+          </ul>
           EOF
 
           cat email.html

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -38,31 +38,29 @@ jobs:
     env:
       EMAIL_BODY_FILENAME: email.html
     steps:
-      - name: gather info for email
-        id: info
+      - name: get date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+      - name: generate email body
         run: |
           gh api /repos/chapel-lang/chapel/commits/${{ github.sha }} | tee commit.json
           gh api /repos/chapel-lang/chapel/actions/runs/${{ github.run_id }}/jobs | tee jobs.json
 
-          {
-            echo "date=$(date +'%Y-%m-%d')"
-            echo "message=$(jq -r '.commit.message' commit.json | head -n 1)"
-            echo "num_jobs=$(jq '.jobs | length' jobs.json)"
-            echo "failed_jobs=$(jq '.jobs[] | select(.status != "completed" or .conclusion != "success" ) | .name' jobs.json | sort)"
-          } >> "$GITHUB_OUTPUT"
-      - name: generate email body
-        run: |
+          message=$(jq -r '.commit.message' commit.json | head -n 1)
+          num_jobs=$(jq '.jobs | length' jobs.json)
+          failed_jobs=$(jq '.jobs[] | select(.status != "completed" or .conclusion != "success" ) | .name' jobs.json | sort)
+
           [[ $num_jobs -eq 1 ]] && plural="" || plural="s"
 
           cat << EOF > ${{ env.EMAIL_BODY_FILENAME }}
           The following GitHub Actions job$plural failed:
 
           --------
-          ${{ steps.info.outputs.failed_jobs }}
+          $failed_jobs
           --------
 
-          Ran ${{ steps.info.outputs.num_jobs }} total jobs at commit ${{ github.sha }}.
-          > ${{ steps.info.outputs.message }}
+          Ran $num_jobs total jobs at commit ${{ github.sha }}.
+          > $message
 
           GitHub Actions run info:
           - SHA: ${{ github.sha }}
@@ -82,7 +80,7 @@ jobs:
            secure: true
            username:  ${{ secrets.MAIL_USERNAME }}
            password: ${{ secrets.MAIL_PASSWORD }}
-           subject: "[Chapel GA Tests] ${{ steps.info.outputs.date }}"
+           subject: "[Chapel GA Tests] ${{ steps.date.outputs.date }}"
            to: "anna.rift@hpe.com"
            from:  "Chapel Automaton <chapel_commits@cray.com>"
            html_body: file://${{ env.EMAIL_BODY_FILENAME }}

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -39,7 +39,7 @@ jobs:
       - name: gather info for email
         id: info
         run: |
-          gh api /repos/chapel-lang/chapel/commits/${{ github.sha }} > commit.json
+          gh api /repos/chapel-lang/chapel/commits/${{ github.sha }} | tee commit.json
 
           {
             echo "date=$(date +'%Y-%m-%d')"

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -46,7 +46,7 @@ jobs:
             echo "date=$(date +'%Y-%m-%d')"
             echo "message=$(jq -r '.commit.message' commit.json | head -n 1)"
             echo "num_jobs=$(jq '.jobs | length' jobs.json)"
-            echo "failed_jobs=$(jq '.jobs[] | select(.status != "completed" or .conclusion != "success" ) | .name' jobs.json)"
+            echo "failed_jobs=$(jq '.jobs[] | select(.status != "completed" or .conclusion != "success" ) | .name' jobs.json | sort)"
           } >> "$GITHUB_OUTPUT"
       - name: Send mail
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -67,7 +67,7 @@ jobs:
              ${{ steps.info.outputs.failed_jobs }}
              ---
 
-             Ran ${{ steps.info.outpus.num_jobs }} jobs at commit ${{ github.sha }}.
+             Ran ${{ steps.info.outputs.num_jobs }} jobs at commit ${{ github.sha }}.
              > ${{ steps.info.outputs.message }}
 
              GitHub Actions run info:

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -36,12 +36,13 @@ jobs:
       - extended-checks
       - full-checks
     steps:
-      - name: determine date
-        id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
-      - name: get commit message
-        id: message
-        run: echo "message=$(curl 'https://api.github.com/repos/chapel-lang/chapel/commits/${{ github.sha }}' | jq -r '.commit.message' | head -n 1)" >> "$GITHUB_OUTPUT"
+      - name: gather info for email
+        id: info
+        run: |
+          {
+            echo "date=$(date +'%Y-%m-%d')"
+            echo "message=$(curl 'https://api.github.com/repos/chapel-lang/chapel/commits/${{ github.sha }}' | jq -r '.commit.message' | head -n 1)"
+          } >> "$GITHUB_OUTPUT"
       - name: Send mail
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
         with:
@@ -51,14 +52,14 @@ jobs:
            secure: true
            username:  ${{ secrets.MAIL_USERNAME }}
            password: ${{ secrets.MAIL_PASSWORD }}
-           subject: "[Chapel GA Tests] ${{ steps.date.outputs.date }}"
+           subject: "[Chapel GA Tests] ${{ steps.info.outputs.date }}"
            to: "anna.rift@hpe.com"
            from:  "Chapel Automaton <chapel_commits@cray.com>"
            body: |
              One or more GitHub Actions jobs have failed.
 
              Ran at commit ${{ github.sha }}.
-             > ${{ steps.message.outputs.message }}
+             > ${{ steps.info.outputs.message }}
 
              GitHub Actions run info:
              - SHA: ${{ github.sha }}

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -48,6 +48,25 @@ jobs:
             echo "num_jobs=$(jq '.jobs | length' jobs.json)"
             echo "failed_jobs=$(jq '.jobs[] | select(.status != "completed" or .conclusion != "success" ) | .name' jobs.json | sort)"
           } >> "$GITHUB_OUTPUT"
+      - name: generate email body
+        run: |
+          cat << 'EOF' > email.html
+          The following GitHub Actions jobs have failed:
+
+          --------
+          ${{ steps.info.outputs.failed_jobs }}
+          --------
+
+          Ran ${{ steps.info.outputs.num_jobs }} jobs at commit ${{ github.sha }}.
+          > ${{ steps.info.outputs.message }}
+
+          GitHub Actions run info:
+          - SHA: ${{ github.sha }}
+          - Run ID: ${{ github.run_id }}
+          - Run attempt #: ${{ github.run_attempt }}
+          - Run number: ${{ github.run_number }}
+          - Triggering event name: ${{ github.event_name }}
+          EOF
       - name: Send mail
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
         with:
@@ -60,19 +79,4 @@ jobs:
            subject: "[Chapel GA Tests] ${{ steps.info.outputs.date }}"
            to: "anna.rift@hpe.com"
            from:  "Chapel Automaton <chapel_commits@cray.com>"
-           body: |
-             The following GitHub Actions jobs have failed:
-
-             --------
-             ${{ steps.info.outputs.failed_jobs }}
-             --------
-
-             Ran ${{ steps.info.outputs.num_jobs }} jobs at commit ${{ github.sha }}.
-             > ${{ steps.info.outputs.message }}
-
-             GitHub Actions run info:
-             - SHA: ${{ github.sha }}
-             - Run ID: ${{ github.run_id }}
-             - Run attempt #: ${{ github.run_attempt }}
-             - Run number: ${{ github.run_number }}
-             - Triggering event name: ${{ github.event_name }}
+           html_body: file://email.html

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -53,6 +53,7 @@ jobs:
           failed_jobs_html=""
           for id in "${failed_job_ids[@]}"; do
             gh api "/repos/chapel-lang/chapel/actions/jobs/$id" > "job_$id.json"
+            sleep 0.25
             failed_jobs_html+=$(jq -r '{html_url, name, first_bad_step: ([.steps[] | select(.conclusion != "success")] | first).name} | "<a href=\"\(.html_url)\">\(.name)</a>, step \(.first_bad_step)"' "job_$id.json")
           done
 

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -64,6 +64,7 @@ jobs:
           <ul>
           $failed_jobs_html
           </ul>
+
           <hr>
 
           <p>Ran $num_jobs total jobs at commit ${{ github.sha }} "$message".</p>

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -61,11 +61,11 @@ jobs:
            to: "anna.rift@hpe.com"
            from:  "Chapel Automaton <chapel_commits@cray.com>"
            body: |
-             One or more GitHub Actions jobs have failed:
+             The following GitHub Actions jobs have failed:
 
-             ---
+             --------
              ${{ steps.info.outputs.failed_jobs }}
-             ---
+             --------
 
              Ran ${{ steps.info.outputs.num_jobs }} jobs at commit ${{ github.sha }}.
              > ${{ steps.info.outputs.message }}

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -57,7 +57,7 @@ jobs:
           ${{ steps.info.outputs.failed_jobs }}
           --------
 
-          Ran ${{ steps.info.outputs.num_jobs }} jobs at commit ${{ github.sha }}.
+          Ran ${{ steps.info.outputs.num_jobs }} total jobs at commit ${{ github.sha }}.
           > ${{ steps.info.outputs.message }}
 
           GitHub Actions run info:

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -35,6 +35,8 @@ jobs:
       - core-checks
       - extended-checks
       - full-checks
+    env:
+      EMAIL_BODY_FILENAME: email.html
     steps:
       - name: gather info for email
         id: info
@@ -50,7 +52,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: generate email body
         run: |
-          cat << 'EOF' > email.html
+          cat << 'EOF' > ${{ env.EMAIL_BODY_FILENAME }}
           The following GitHub Actions jobs have failed:
 
           --------
@@ -81,4 +83,4 @@ jobs:
            subject: "[Chapel GA Tests] ${{ steps.info.outputs.date }}"
            to: "anna.rift@hpe.com"
            from:  "Chapel Automaton <chapel_commits@cray.com>"
-           html_body: file://email.html
+           html_body: file://${{ env.EMAIL_BODY_FILENAME }}

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           {
             echo "date=$(date +'%Y-%m-%d')"
-            echo "message=$(curl 'https://api.github.com/repos/chapel-lang/chapel/commits/${{ github.sha }}' | jq -r '.commit.message' | head -n 1)"
+            echo "message=$(gh api /repos/chapel-lang/chapel/commits/${{ github.sha }} | jq -r '.commit.message' | head -n 1)"
           } >> "$GITHUB_OUTPUT"
       - name: Send mail
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -67,6 +67,8 @@ jobs:
           - Run number: ${{ github.run_number }}
           - Triggering event name: ${{ github.event_name }}
           EOF
+
+          cat email.html
       - name: Send mail
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
         with:


### PR DESCRIPTION
Fill out the body of the nightly failure mail message to include a list of failed jobs with links as well as some info about the GA workflow run.

[iterating prototype, not reviewed]