### PR TITLE
Move `test-make-install-check` to Full checks

### DIFF
--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -433,13 +433,3 @@ jobs:
     - name: run test-c2chapel.bash
       run: |
         ./util/cron/test-c2chapel.bash
-
-  test-make-install-check:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-    - name: run test-make-install-check.bash
-      run: |
-        ./util/cron/test-make-install-check.bash

--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -26,3 +26,13 @@ jobs:
     steps:
       - name: break it
         run: exit 1
+
+  test-make-install-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - name: run test-make-install-check.bash
+      run: |
+        ./util/cron/test-make-install-check.bash


### PR DESCRIPTION
Move GA job `test-make-install-check` from the "Extended" to "Full" check suite so it does not run in the merge queue, as it consistently takes longer than the merge queue timeout.

Follow up to https://github.com/chapel-lang/chapel/pull/29220 which added this job.

[trivial, not reviewed]