### PR TITLE
Pass GH_TOKEN to send-failure-mail workflow

### DIFF
--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -36,6 +36,7 @@ jobs:
       - extended-checks
       - full-checks
     env:
+      GH_TOKEN: ${{ github.token }}
       EMAIL_BODY_FILENAME: email.html
     steps:
       - name: determine date


### PR DESCRIPTION
Pass `GH_TOKEN` env var into the `send-failure-mail` job to be able to use `gh` in it.

Follow up to https://github.com/chapel-lang/chapel/pull/29263.

[trivial, not reviewed]