### PR TITLE
Cancel superseded or destroyed merge group workflow runs

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -31,8 +31,10 @@ jobs:
       shell: bash
     - name: Check workflow files
       run: |
-        # ignore is to work around https://github.com/rhysd/actionlint/issues/657
-        ${STEPS_GET_ACTIONLINT_OUTPUTS_EXECUTABLE} -color -ignore 'unexpected key \"queue\" for \"concurrency\" section'
+        # ignores are to work around:
+        # - https://github.com/rhysd/actionlint/issues/657
+        # - https://github.com/rhysd/actionlint/issues/726
+        ${STEPS_GET_ACTIONLINT_OUTPUTS_EXECUTABLE} -color -ignore 'unexpected key \"queue\" for \"concurrency\" section' -ignore 'invalid activity type "destroyed" for "merge_group" Webhook event'
       shell: bash
       env:
         STEPS_GET_ACTIONLINT_OUTPUTS_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}

--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -29,11 +29,11 @@ defaults:
 
 jobs:
   core-checks:
-    if: github.event.merge_group.action != 'destroyed'
+    if: github.event.action != 'destroyed'
     uses: ./.github/workflows/core-ci-checks.yml
 
   should-run-extended-checks:
-    if: github.event.merge_group.action != 'destroyed'
+    if: github.event.action != 'destroyed'
     runs-on: ubuntu-slim
     env:
       EXTENDED_CHECKS_LABEL: "run extended CI checks"

--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -29,11 +29,11 @@ defaults:
 
 jobs:
   core-checks:
-    if: github.event.action != 'destroyed'
+    if: ${{ ! (github.event_name == 'merge_group' && github.event.action == 'destroyed') }}
     uses: ./.github/workflows/core-ci-checks.yml
 
   should-run-extended-checks:
-    if: github.event.action != 'destroyed'
+    if: ${{ ! (github.event_name == 'merge_group' && github.event.action == 'destroyed') }}
     runs-on: ubuntu-slim
     env:
       EXTENDED_CHECKS_LABEL: "run extended CI checks"

--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -8,6 +8,16 @@ on:
     # specified, so make sure to keep them.
     types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
+    # Also trigger on destroyed groups, just to cancel old runs in progress.
+    types: [checks_requested, destroyed]
+
+# In the merge queue case, cancel previous merge groups headed by the same PR,
+# since only the latest may be relevant to merging.
+# In the PR case, just serialize runs against the same SHA.
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.merge_group.head_commit.message || github.event.pull_request.head.sha }}"
+  cancel-in-progress: ${{ case(github.event_name == 'merge_group', 'true', 'false') }}
+
 
 permissions:
   contents: read
@@ -19,9 +29,11 @@ defaults:
 
 jobs:
   core-checks:
+    if: github.event.merge_group.action != 'destroyed'
     uses: ./.github/workflows/core-ci-checks.yml
 
   should-run-extended-checks:
+    if: github.event.merge_group.action != 'destroyed'
     runs-on: ubuntu-slim
     env:
       EXTENDED_CHECKS_LABEL: "run extended CI checks"

--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -13,9 +13,9 @@ on:
 
 # In the merge queue case, cancel previous merge groups headed by the same PR,
 # since only the latest may be relevant to merging.
-# In the PR case, just serialize runs against the same SHA.
+# In any other case (PRs), just serialize runs against the same SHA.
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.merge_group.head_commit.message || github.event.pull_request.head.sha }}"
+  group: ${{ github.workflow }}-${{ github.event.merge_group.head_ref || github.sha }}
   cancel-in-progress: ${{ case(github.event_name == 'merge_group', true, false) }}
 
 

--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -16,7 +16,7 @@ on:
 # In any other case (PRs), just serialize runs against the same SHA.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.merge_group.head_ref || github.sha }}
-  cancel-in-progress: ${{ case(github.event_name == 'merge_group', true, false) }}
+  cancel-in-progress: ${{ github.event_name == 'merge_group' }}
 
 
 permissions:

--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -16,7 +16,7 @@ on:
 # In the PR case, just serialize runs against the same SHA.
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.merge_group.head_commit.message || github.event.pull_request.head.sha }}"
-  cancel-in-progress: ${{ case(github.event_name == 'merge_group', 'true', 'false') }}
+  cancel-in-progress: ${{ case(github.event_name == 'merge_group', true, false) }}
 
 
 permissions:


### PR DESCRIPTION
Adjust the merge queue checks to cancel previous runs from any aborted or invalidated merge attempts.

This is relevant when a merge group is invalidated due to someone bypassing or jumping the queue, or when items ahead are removed (manually or due to failures). For some reason, GitHub does not cancel the running workflows in that case, even though their results are now irrelevant; see https://github.com/orgs/community/discussions/137976.

Inspired by [this snippet](https://github.com/orgs/community/discussions/137976#discussioncomment-14004793) for cancelling old runs via `concurrency` on the merge group `destroyed` action, and [this pattern](https://runs-on.com/github-actions/concurrency/#the-classic-cancel-superseded-pr-runs-pattern) for making the `concurrency` `group` unique per-run (and irrelevant) in a case you don't want to include in the limits.

Adds more silencing to our `actionlint` check to work around https://github.com/rhysd/actionlint/issues/726.

[reviewed by @jabraham17 , thanks!]