### PR TITLE
Use sparse-checkout in prereqs-docs-compare job

### DIFF
--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -476,14 +476,15 @@ jobs:
     runs-on: ubuntu-slim
     env:
       PREREQS_COMMANDS_FILE: "doc/rst/usingchapel/prereqs-commands.rst"
+      PORTABILITY_TEST_DIR: "util/devel/test/portability"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          sparse-checkout: util/devel/test/portability
+          sparse-checkout: ${{ env.PORTABILITY_TEST_DIR }}
           persist-credentials: false
       - name: generate ${{ env.PREREQS_COMMANDS_FILE }}
         run: |
-          util/devel/test/portability/apptainer/extract-docs.py > "$PREREQS_COMMANDS_FILE"
+          ${{ env.PORTABILITY_TEST_DIR }}/apptainer/extract-docs.py > "$PREREQS_COMMANDS_FILE"
       - name: compare against checked-in file
         run: |
           git diff --exit-code "$PREREQS_COMMANDS_FILE"

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -481,8 +481,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
-            "${{ env.PORTABILITY_TEST_DIR }}"
-            "doc"
+            ${{ env.PORTABILITY_TEST_DIR }}
+            doc
           persist-credentials: false
       - name: generate ${{ env.PREREQS_COMMANDS_FILE }}
         run: |

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -480,7 +480,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          sparse-checkout: ${{ env.PORTABILITY_TEST_DIR }} "doc"
+          sparse-checkout: |
+            "${{ env.PORTABILITY_TEST_DIR }}"
+            "doc"
           persist-credentials: false
       - name: generate ${{ env.PREREQS_COMMANDS_FILE }}
         run: |

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -480,7 +480,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          sparse-checkout: ${{ env.PORTABILITY_TEST_DIR }}
+          sparse-checkout: ${{ env.PORTABILITY_TEST_DIR }} "doc"
           persist-credentials: false
       - name: generate ${{ env.PREREQS_COMMANDS_FILE }}
         run: |

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -479,6 +479,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          sparse-checkout: util/devel/test/portability
           persist-credentials: false
       - name: generate ${{ env.PREREQS_COMMANDS_FILE }}
         run: |


### PR DESCRIPTION
Sparse-checkout `util/devel/test/portability` in the `prereqs-docs-compare` job, since it does not need the full Chapel tree.

This job does a diff against a regenerated `doc/rst/usingchapel/prereqs-commands.rst`. This is not included in the sparse-checkout, however as long as the diff works correctly that's fine.

[trivial, not reviewed]