### PR TITLE
Add timeouts to reused GA workflow calls

### DIFF
--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -20,12 +20,15 @@ defaults:
 jobs:
   core-checks:
     uses: ./.github/workflows/core-ci-checks.yml
+    timeout-minutes: 30
 
   extended-checks:
     uses: ./.github/workflows/extended-ci-checks.yml
+    timeout-minutes: 90
 
   full-checks:
     uses: ./.github/workflows/full-ci-checks.yml
+    timeout-minutes: 240
 
   send-failure-mail:
     if: cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')

--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -20,6 +20,7 @@ defaults:
 jobs:
   core-checks:
     uses: ./.github/workflows/core-ci-checks.yml
+    timeout-minutes: 30
 
   should-run-extended-checks:
     runs-on: ubuntu-slim
@@ -40,6 +41,7 @@ jobs:
     needs: should-run-extended-checks
     if: needs.should-run-extended-checks.outputs.run-all == 'true'
     uses: ./.github/workflows/extended-ci-checks.yml
+    timeout-minutes: 90
 
   # This job exists to have a single check for which failure means merging
   # should be blocked, for GH required status checks purposes.


### PR DESCRIPTION
Add timeouts to the invocations of our reusable CI workflows (core, extended, and full checks) from their triggering workflows.

Recently we've encountered a lot of our allotted runners being tied up with jobs that have clearly gone wrong, taking hours on a step that should take minutes. If they never fail on their own, these keep running until they hit the global GA timeout of 6 hours.

To reclaim the wasted resources earlier we have to set our own timeouts. GA does not support workflow-level timeouts, only job- and step-level. However, since almost all our long-running workflows are triggered via a reusable workflow call, we should be able to set the timeout on the jobs which do the workflow calls. I've set a timeout of 30 minutes for Core checks, 90 minutes for Extended, and 240 minutes for Full, none of which should get hit under normal circumstances.

Unfortunately, the timeout numbers are repeated between `trigger-pr-checks.yml` and `trigger-full-checks.yml` -- without another reusable workflow "shell" around each actual check workflow, I don't know how to get around this.

[reviewer info placeholder]