### PR TITLE
Serialize full check runs per event type

### DIFF
--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -10,6 +10,8 @@ on:
   workflow_dispatch:
 
 # Run serially per type of triggering event.
+# Primarily intended to limit (avoid) concurrent runs for multiple PR merges in
+# a row.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}
   queue: max

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -9,6 +9,11 @@ on:
       timezone: "America/Vancouver"
   workflow_dispatch:
 
+# Run serially per type of triggering event.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}
+  queue: max
+
 permissions:
   contents: read
   packages: read


### PR DESCRIPTION
Add a `concurrency` setting to `trigger-full-checks` causing it to run serially per triggering event type.

This means that a manual-, schedule-, and push-triggered run could all run concurrently, but additional invocations from the same trigger would have to wait. The intention is to avoid tying up a lot of resources from back-to-back PR merges (push events), which may come in bursts but do not require timely feedback on post-merge testing.

[reviewed by @jabraham17 , thanks!]