### PR TITLE
Add a timeout for the arkouda smoketest

### DIFF
--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -26,6 +26,7 @@ jobs:
         password: ${{ secrets.github_token }}
     env:
       ARROW_VERSION: "19.0.1"
+    timeout-minutes: 90 # usually takes ~45 minutes, double for safety
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:


### PR DESCRIPTION
Adds a timeout for the arkouda smoketest, to prevent a server crash from hanging until the default job limit of 6 hours

[Reviewed by @arifthpe]


