### PR TITLE
Fix a postinit case for unions; customize union errors for management types

### DIFF
--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10167,7 +10167,7 @@ static void resolveNewSetupManaged(CallExpr* newExpr, Type*& manager) {
         if (isRecord(type) && !isManagedPtrType(type))
           USR_FATAL_CONT(newExpr, "Cannot use new %s with record %s",
                                   toString(manager), toString(type));
-        if (isUnion(type) && !isManagedPtrType(type))
+        else if (isUnion(type) && !isManagedPtrType(type))
           USR_FATAL_CONT(newExpr, "Cannot use 'new %s' with union '%s'",
                                   toString(manager), toString(type));
         else if (!isClassLikeOrManaged(type))

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -10167,6 +10167,9 @@ static void resolveNewSetupManaged(CallExpr* newExpr, Type*& manager) {
         if (isRecord(type) && !isManagedPtrType(type))
           USR_FATAL_CONT(newExpr, "Cannot use new %s with record %s",
                                   toString(manager), toString(type));
+        if (isUnion(type) && !isManagedPtrType(type))
+          USR_FATAL_CONT(newExpr, "Cannot use 'new %s' with union '%s'",
+                                  toString(manager), toString(type));
         else if (!isClassLikeOrManaged(type))
           USR_FATAL_CONT(newExpr, "cannot use management %s on non-class %s",
                                    toString(manager), toString(type));
@@ -13273,7 +13276,7 @@ initializeClass(Expr* stmt, Symbol* sym) {
           deflt = new SymExpr(defaultTmp);
         }
         stmt->insertBefore(new CallExpr(PRIM_SET_MEMBER, sym, field, deflt));
-      } else if (isRecord(field->type)) {
+      } else if (isRecord(field->type) || isUnion(field->type)) {
         VarSymbol* tmp = newTemp("_init_class_tmp_", field->type);
         stmt->insertBefore(new DefExpr(tmp));
         initializeClass(stmt, tmp);
@@ -14400,7 +14403,7 @@ static void lowerPrimInitNonGenericRecordVar(CallExpr* call,
 
   resolveCallAndCallee(callInit);
 
-  if (isRecord(at) && at->hasPostInitializer()) {
+  if ((isRecord(at) || isUnion(at)) && at->hasPostInitializer()) {
     CallExpr* postinit = new CallExpr("postinit", gMethodToken, val);
     call->insertBefore(postinit);
     resolveCallAndCallee(postinit);
@@ -14651,7 +14654,7 @@ static void lowerPrimInitGenericRecordVar(CallExpr* call,
     USR_PRINT(call, "init resulted in type '%s'", toString(val->type));
   }
 
-  if (at && at->isRecord() && at->hasPostInitializer()) {
+  if (at && (at->isRecord() || at->isUnion()) && at->hasPostInitializer()) {
     CallExpr* postinit = new CallExpr("postinit", gMethodToken, val);
     call->insertBefore(postinit);
     resolveCallAndCallee(postinit);

--- a/test/types/unions/union-new-managed.chpl
+++ b/test/types/unions/union-new-managed.chpl
@@ -1,0 +1,11 @@
+union u {
+  var x: int;
+  var y: int;
+  var z: real;
+}
+
+var u1 = new owned u();
+var u2 = new shared u();
+var u3 = new unmanaged u();
+//var u4 = new borrowed u();
+

--- a/test/types/unions/union-new-managed.good
+++ b/test/types/unions/union-new-managed.good
@@ -1,0 +1,3 @@
+union-new-managed.chpl:7: error: Cannot use 'new owned' with union 'u'
+union-new-managed.chpl:8: error: Cannot use 'new shared' with union 'u'
+union-new-managed.chpl:9: error: Cannot use 'new unmanaged' with union 'u'

--- a/test/types/unions/union-postinit.good
+++ b/test/types/unions/union-postinit.good
@@ -1,4 +1,5 @@
 after initialization, active field is #-1
+after initialization, active field is #-1
 after initialization, active field is #0
 after initialization, active field is #1
 after initialization, active field is #2


### PR DESCRIPTION
While prepping my demo for this morning's Chapel meeting, I ran across a case where we weren't calling postinit() as we should've been.  In fact, one of the tests I added in #29253 had this bug, but it slipped past both me and my reviewer.  It seems that when declaring a union field like `var myU: u;` we did not call postinit().  The fix for this was simple, and reflected another `isRecord()` test that should've been expanded to include `isUnion()`.

This PR fixes that issue and also extends a few other 'isRecord()' tests in functionResolution.cpp to include unions as well.  The most visible of these is that we now generate a customized error for (illegal) 'new owned u()' and friends, and I've added a test to lock that in.  Here, the case was not as bad for non-unions, as we had a catch-all for "other non-record, non-class types."

Of the changes here, the one to line 13276/9 is pretty speculative.  I spent a few minutes trying to write a test showing that it improved things, but wasn't able to do so quickly.  My sense is that if this case should include unions (as I'm hypothesizing), it's easier to fix it now than to hunt it down later; and that if it shouldn't, it'll either bite us in an obvious way or be innocuous.

[reviewed by @benharsh ]