### PR TITLE
Zizmor ignore unpinned chapel-github-ci image in full checks workflow

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,6 +3,7 @@ rules:
     ignore:
       - core-ci-checks.yml
       - extended-ci-checks.yml
+      - full-ci-checks.yml
   dangerous-triggers:
     ignore:
       - email.yml:2


### PR DESCRIPTION
Extend silencing the zizmor error for unpinned version of `chapel-github-ci` to `full-ci-checks.yml`, which contains an instance of it since https://github.com/chapel-lang/chapel/pull/29282.

Follow up to https://github.com/chapel-lang/chapel/pull/29282.

[trivial fix, not reviewed]