### PR TITLE
Put in stopgap to avoid a failure in nightly testing tonight

### DIFF
--- a/test/types/unions/union-init-throws.good
+++ b/test/types/unions/union-init-throws.good
@@ -6,4 +6,4 @@ u8 got DupFieldError:
 u9 got DupFieldError: 
 uncaught DupFieldError: 
   union-init-throws.chpl:31: thrown here
-  union-init-throws.chpl:92: uncaught here
+  union-init-throws.chpl:22: uncaught here


### PR DESCRIPTION
Due to a long merge cycle, Jade's #28856 conflicted with my #29253 from last week and broke the output of this test, arguably making it worse.  Jade agrees that this is a backslide in behavior and has a fix underway, but it's not going in today, so I'm committing the incorrect behavior for now to avoid a slew of failure mails tonight and others potentially seeing this in their paratests.

[trivial, not reviewed]