### PR TITLE
Set cancel-in-progress for old PR checks against same SHA

### DIFF
--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -13,10 +13,11 @@ on:
 
 # In the merge queue case, cancel previous merge groups headed by the same PR,
 # since only the latest may be relevant to merging.
-# In any other case (PRs), just serialize runs against the same SHA.
+# In any other case (PRs), cancel previous runs against the same SHA, which
+# should only occur if a PR is closed/reopened or has a label change.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.merge_group.head_ref || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'merge_group' }}
+  cancel-in-progress: true
 
 
 permissions:


### PR DESCRIPTION
Cancel previous PR check runs against the same SHA.

This fixes an unintended consequence of https://github.com/chapel-lang/chapel/pull/29274, in which when labeling or unlabeling a PR, a new check run is queued up and has to wait for the previous one to complete. This would also happen for closing and reopening a PR. In all of these cases, I think we don't want to have to wait around for the latest run to start, and also don't care to see the previous run's results.

Follow up to https://github.com/chapel-lang/chapel/pull/29274.

[reviewed by @jabraham17 , thanks!]