### PR TITLE
Add 10 minute timeout to each step that apt installs

### DIFF
--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -43,6 +43,7 @@ jobs:
       with:
         persist-credentials: false
     - name: install fluid and libfltk-dev
+      timeout-minutes: 10
       run: |
         apt update && apt install -y \
           fluid \
@@ -428,6 +429,7 @@ jobs:
         with:
           persist-credentials: false
       - name: install deps
+        timeout-minutes: 10
         run: |
           if [[ "$OS" == "macos"* ]] ; then
             brew install llvm

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           echo "GCC_VERSION=${{ matrix.gcc_version }}" >> "$GITHUB_ENV"
       - name: Install GCC
+        timeout-minutes: 10
         uses: egor-tensin/setup-gcc@a2861a8b8538f49cf2850980acccf6b05a1b2ae4 # v2
         with:
           version: ${{ matrix.gcc_version }}
@@ -106,6 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python
+        timeout-minutes: 10
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python_version }}
@@ -117,6 +119,7 @@ jobs:
           source util/cron/common-python.bash
           check_python_version "${{ matrix.python_version }}"
       - name: Install LLVM dependency
+        timeout-minutes: 10
         run: |
           sudo apt install \
             clang \
@@ -146,6 +149,7 @@ jobs:
     runs-on: ${{ matrix.llvm_version >= 17 && 'ubuntu-latest' || 'ubuntu-22.04' }}
     steps:
       - name: Install LLVM ${{ matrix.llvm_version }} from official convenience script
+        timeout-minutes: 10
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh

--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -66,6 +66,7 @@ jobs:
       apptainer_config: ${{ matrix.apptainer_config }}
     steps:
       - name: install Apptainer
+        timeout-minutes: 10
         run: |
           sudo add-apt-repository -y ppa:apptainer/ppa
           sudo apt update
@@ -118,6 +119,7 @@ jobs:
         path: arkouda
         persist-credentials: false
     - name: apt install some Arkouda deps
+      timeout-minutes: 10
       run: |
         apt update && apt install -y \
           libzmq3-dev \


### PR DESCRIPTION
Add a 10 minute timeout to all of our GA steps that do an `apt install` (directly or indirectly).

This should prevent us from wasting a ton of time and waiting around when the Ubuntu repo mirrors we're trying to use are down ([like right now](https://github.com/actions/runner-images/issues/14594)).

[reviewed by @jabraham17 , thanks!]