### PR TITLE
Improve stacktraces for Errors from aggregates

### DIFF
--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -410,9 +410,12 @@ bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
       errorVar = info.errorVar;
 
       // (a) an enclosing try/try!
-      errorPolicy->insertAtTail(
-        new CallExpr(PRIM_MOVE, errorVar,
-          new CallExpr(gChplErrorPropagateStackInfo, new SymExpr(errorVar))));
+      if (!node->parentSymbol ||
+          !node->parentSymbol->hasFlag(FLAG_COMPILER_GENERATED)) {
+        errorPolicy->insertAtTail(
+          new CallExpr(PRIM_MOVE, errorVar,
+            new CallExpr(gChplErrorPropagateStackInfo, new SymExpr(errorVar))));
+      }
       errorPolicy->insertAtTail(gotoHandler());
     } else {
       // without try, need an error variable

--- a/compiler/passes/errorHandling.cpp
+++ b/compiler/passes/errorHandling.cpp
@@ -212,7 +212,7 @@ private:
   AList  errorCond(VarSymbol* errorVar,
                    BlockStmt* thenBlock,
                    BlockStmt* elseBlock = NULL);
-  CallExpr* haltExpr(VarSymbol* error, bool tryBang);
+  void haltExpr(VarSymbol* error, bool tryBang, BlockStmt* body, Symbol* parent);
   void setupForThrowingLoop(Stmt* node,
                             LabelSymbol* handlerLabel,
                             BlockStmt* body);
@@ -356,7 +356,7 @@ void ErrorHandlingVisitor::lowerCatches(const TryInfo& info) {
 
   if (!hasCatchAll) {
     if (tryStmt->tryBang()) {
-      currHandler->insertAtTail(haltExpr(errorVar, true));
+      haltExpr(errorVar, true, currHandler, tryStmt->parentSymbol);
     } else if (!tryStack.empty()) {
       currHandler->insertAtTail(setOuterErrorAndGotoHandler(errorVar, tryStmt->parentSymbol));
     } else if (outError != NULL) {
@@ -429,7 +429,7 @@ bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
         if (node->parentSymbol->hasFlag(FLAG_ITERATOR_FN))
           // (c) coforall or similar in a non-throwing iterator
           // ==> we will propagate the error when the iterator is inlined
-          errorPolicy->insertAtTail(haltExpr(errorVar, false));
+          haltExpr(errorVar, false, errorPolicy, node->parentSymbol);
         else if (node->parentSymbol->hasFlag(FLAG_TASK_FN_FROM_ITERATOR_FN))
           // (d) coforall/... in a task function in a non-throwing iterator
           // ==> propagate the error through the task function
@@ -437,11 +437,11 @@ bool ErrorHandlingVisitor::enterCallExpr(CallExpr* node) {
         else
           // (e) coforall or similar in a non-throwing procedure
           // ==> halt right away
-          errorPolicy->insertAtTail(haltExpr(errorVar, true));
+          haltExpr(errorVar, true, errorPolicy, node->parentSymbol);
       }
       else {
         // (f) a throwing call in a non-throwing function ==> halt right away
-        errorPolicy->insertAtTail(haltExpr(errorVar, true));
+        haltExpr(errorVar, true, errorPolicy, node->parentSymbol);
       }
     }
 
@@ -632,7 +632,7 @@ void ErrorHandlingVisitor::exitForallLoop(Stmt* node) {
   } else if (outError != NULL) {
     handler->insertAtTail(setOutGotoEpilogue(normErr, node->parentSymbol));
   } else {
-    handler->insertAtTail(haltExpr(normErr, false));
+    haltExpr(normErr, false, handler, node->parentSymbol);
   }
   info.handlerLabel->defPoint->insertAfter(errorCond(err, handler));
 }
@@ -846,11 +846,14 @@ static AList errorCondHelper(VarSymbol* errorVar,
 // (with try!). If not, the compiler is adding the halt-on-error for one
 // reason or another and later passes should be able to change the halt
 // into other error handling (as with, say, iterator inlining).
-CallExpr* ErrorHandlingVisitor::haltExpr(VarSymbol* errorVar, bool tryBang) {
-  if (tryBang)
-    return new CallExpr(gChplUncaughtError, errorVar);
-
-  return new CallExpr(gChplPropagateError, errorVar);
+void ErrorHandlingVisitor::haltExpr(VarSymbol* errorVar, bool tryBang, BlockStmt* block, Symbol* parent) {
+  auto retFunc = tryBang ? gChplUncaughtError : gChplPropagateError;
+  if (!parent || !parent->hasFlag(FLAG_COMPILER_GENERATED)) {
+    block->insertAtTail(
+      new CallExpr(PRIM_MOVE, errorVar,
+        new CallExpr(gChplErrorPropagateStackInfo, new SymExpr(errorVar))));
+  }
+  block->insertAtTail(new CallExpr(retFunc, errorVar));
 }
 
 

--- a/test/classes/initializers/errors/errHandling/calls/tryBangExpressionDefaultRecord.good
+++ b/test/classes/initializers/errors/errHandling/calls/tryBangExpressionDefaultRecord.good
@@ -1,3 +1,4 @@
 uncaught Error: value too large
   tryBangExpressionDefaultRecord.chpl:5: thrown here
-  tryBangExpressionDefaultRecord.chpl:22: uncaught here
+  tryBangExpressionDefaultRecord.chpl:22: called from here
+  tryBangExpressionDefaultRecord.chpl:28: uncaught here

--- a/test/classes/initializers/errors/errHandling/calls/tryBangExpressionRecord.good
+++ b/test/classes/initializers/errors/errHandling/calls/tryBangExpressionRecord.good
@@ -1,4 +1,5 @@
 (x = 8)
 uncaught Error: value too large
   tryBangExpressionRecord.chpl:5: thrown here
-  tryBangExpressionRecord.chpl:14: uncaught here
+  tryBangExpressionRecord.chpl:14: called from here
+  tryBangExpressionRecord.chpl:22: uncaught here

--- a/test/classes/initializers/errors/errHandling/initWithTryBang.good
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang.good
@@ -1,3 +1,4 @@
 uncaught Error: 
   initWithTryBang.chpl:16: thrown here
+  initWithTryBang.chpl:19: called from here
   initWithTryBang.chpl:19: uncaught here

--- a/test/classes/initializers/errors/errHandling/initWithTryBang2.bad
+++ b/test/classes/initializers/errors/errHandling/initWithTryBang2.bad
@@ -1,3 +1,4 @@
 uncaught Error: 
   initWithTryBang2.chpl:14: thrown here
+  initWithTryBang2.chpl:17: called from here
   initWithTryBang2.chpl:17: uncaught here

--- a/test/errhandling/ferguson/output-format.good
+++ b/test/errhandling/ferguson/output-format.good
@@ -1,4 +1,5 @@
 MyError: custom message
 uncaught MyError: custom message
   output-format.chpl:14: thrown here
+  output-format.chpl:18: called from here
   output-format.chpl:18: uncaught here

--- a/test/errhandling/ferguson/returns-in-try.1.good
+++ b/test/errhandling/ferguson/returns-in-try.1.good
@@ -1,3 +1,4 @@
 uncaught MyError: 
   returns-in-try.chpl:10: thrown here
-  returns-in-try.chpl:17: uncaught here
+  returns-in-try.chpl:17: called from here
+  returns-in-try.chpl:16: uncaught here

--- a/test/errhandling/ferguson/returns-in-try.2.good
+++ b/test/errhandling/ferguson/returns-in-try.2.good
@@ -1,4 +1,5 @@
 1
 uncaught MyError: 
   returns-in-try.chpl:10: thrown here
-  returns-in-try.chpl:22: uncaught here
+  returns-in-try.chpl:22: called from here
+  returns-in-try.chpl:21: uncaught here

--- a/test/errhandling/ferguson/returns-in-try.6.good
+++ b/test/errhandling/ferguson/returns-in-try.6.good
@@ -5,4 +5,5 @@
 5
 uncaught MyError: 
   returns-in-try.chpl:10: thrown here
-  returns-in-try.chpl:50: uncaught here
+  returns-in-try.chpl:50: called from here
+  returns-in-try.chpl:49: uncaught here

--- a/test/errhandling/ferguson/throws-destroys.1.good
+++ b/test/errhandling/ferguson/throws-destroys.1.good
@@ -2,4 +2,5 @@ in simpleThrow, r=(x = 1)
 destroying R(x=1)
 uncaught Error: 
   throws-destroys.chpl:36: thrown here
+  throws-destroys.chpl:9: called from here
   throws-destroys.chpl:9: uncaught here

--- a/test/errhandling/ferguson/throws-destroys.2.good
+++ b/test/errhandling/ferguson/throws-destroys.2.good
@@ -2,4 +2,5 @@ in conditionalThrow, r=(x = 2)
 destroying R(x=2)
 uncaught Error: 
   throws-destroys.chpl:42: thrown here
+  throws-destroys.chpl:11: called from here
   throws-destroys.chpl:11: uncaught here

--- a/test/errhandling/ferguson/throws-destroys.4.good
+++ b/test/errhandling/ferguson/throws-destroys.4.good
@@ -2,4 +2,5 @@ in loopThrow, r=(x = 3)
 destroying R(x=3)
 uncaught Error: 
   throws-destroys.chpl:49: thrown here
+  throws-destroys.chpl:15: called from here
   throws-destroys.chpl:15: uncaught here

--- a/test/errhandling/ferguson/throws-destroys.5.good
+++ b/test/errhandling/ferguson/throws-destroys.5.good
@@ -2,4 +2,5 @@ in loopThrow, r=(x = 3)
 destroying R(x=3)
 uncaught Error: 
   throws-destroys.chpl:49: thrown here
+  throws-destroys.chpl:17: called from here
   throws-destroys.chpl:17: uncaught here

--- a/test/errhandling/ferguson/throws-destroys.6.good
+++ b/test/errhandling/ferguson/throws-destroys.6.good
@@ -2,4 +2,5 @@ in inThrow, r=(x = 4)
 destroying R(x=4)
 uncaught Error: 
   throws-destroys.chpl:55: thrown here
+  throws-destroys.chpl:19: called from here
   throws-destroys.chpl:19: uncaught here

--- a/test/errhandling/ferguson/throws-destroys.7.good
+++ b/test/errhandling/ferguson/throws-destroys.7.good
@@ -2,4 +2,5 @@ in loopThrow, r=(x = 101)
 destroying R(x=101)
 uncaught Error: 
   throws-destroys.chpl:63: thrown here
+  throws-destroys.chpl:21: called from here
   throws-destroys.chpl:21: uncaught here

--- a/test/errhandling/ferguson/throws-destroys.8.good
+++ b/test/errhandling/ferguson/throws-destroys.8.good
@@ -4,4 +4,5 @@ in loopThrow, r=(x = 102)
 destroying R(x=102)
 uncaught Error: 
   throws-destroys.chpl:63: thrown here
+  throws-destroys.chpl:23: called from here
   throws-destroys.chpl:23: uncaught here

--- a/test/errhandling/ferguson/try-expr-nested.4.good
+++ b/test/errhandling/ferguson/try-expr-nested.4.good
@@ -1,4 +1,5 @@
 uncaught StringError: Test
   try-expr-nested.chpl:9: thrown here
   try-expr-nested.chpl:31: called from here
+  try-expr-nested.chpl:39: called from here
   try-expr-nested.chpl:39: uncaught here

--- a/test/errhandling/ferguson/try-expr-nested.5.good
+++ b/test/errhandling/ferguson/try-expr-nested.5.good
@@ -1,4 +1,5 @@
 uncaught StringError: Test
   try-expr-nested.chpl:9: thrown here
   try-expr-nested.chpl:33: called from here
+  try-expr-nested.chpl:39: called from here
   try-expr-nested.chpl:39: uncaught here

--- a/test/errhandling/ferguson/try-expr.8.good
+++ b/test/errhandling/ferguson/try-expr.8.good
@@ -1,3 +1,4 @@
 uncaught StringError: Test
   try-expr.chpl:9: thrown here
-  try-expr.chpl:18: uncaught here
+  try-expr.chpl:18: called from here
+  try-expr.chpl:39: uncaught here

--- a/test/errhandling/misc/issue-23905.comm-none.good
+++ b/test/errhandling/misc/issue-23905.comm-none.good
@@ -1,3 +1,4 @@
 uncaught TaskErrors: 2 errors: Error: in forall ... Error: in forall
   issue-23905.chpl:6: thrown here
-  issue-23905.chpl:6: uncaught here
+  issue-23905.chpl:6: called from here
+  issue-23905.chpl:2: uncaught here

--- a/test/errhandling/misc/issue-23905.good
+++ b/test/errhandling/misc/issue-23905.good
@@ -1,3 +1,4 @@
 uncaught TaskErrors: 8 errors: Error: in forall ... Error: in forall
   issue-23905.chpl:6: thrown here
-  issue-23905.chpl:6: uncaught here
+  issue-23905.chpl:6: called from here
+  issue-23905.chpl:2: uncaught here

--- a/test/errhandling/psahabu/coforall-try-bang-2.good
+++ b/test/errhandling/psahabu/coforall-try-bang-2.good
@@ -1,3 +1,4 @@
 uncaught Error: 
   coforall-try-bang-2.chpl:3: thrown here
-  coforall-try-bang-2.chpl:9: uncaught here
+  coforall-try-bang-2.chpl:9: called from here
+  coforall-try-bang-2.chpl:8: uncaught here

--- a/test/errhandling/psahabu/coforall-try-bang-nested.good
+++ b/test/errhandling/psahabu/coforall-try-bang-nested.good
@@ -1,4 +1,5 @@
 uncaught Error: 
   coforall-try-bang-nested.chpl:3: thrown here
   coforall-try-bang-nested.chpl:10: called from here
-  coforall-try-bang-nested.chpl:9: uncaught here
+  coforall-try-bang-nested.chpl:9: called from here
+  coforall-try-bang-nested.chpl:8: uncaught here

--- a/test/errhandling/psahabu/defer-throw-fatal.1.good
+++ b/test/errhandling/psahabu/defer-throw-fatal.1.good
@@ -1,3 +1,4 @@
 uncaught Error: 
   defer-throw-fatal.chpl:14: thrown here
-  defer-throw-fatal.chpl:13: uncaught here
+  defer-throw-fatal.chpl:13: called from here
+  defer-throw-fatal.chpl:42: uncaught here

--- a/test/errhandling/psahabu/no-prop.good
+++ b/test/errhandling/psahabu/no-prop.good
@@ -2,4 +2,5 @@ calling noPropError
 should not propagate
 uncaught Error: 
   ../ExampleErrors.chpl:2: thrown here
+  no-prop.chpl:5: called from here
   no-prop.chpl:5: uncaught here

--- a/test/errhandling/psahabu/propagate-implicit.good
+++ b/test/errhandling/psahabu/propagate-implicit.good
@@ -1,4 +1,5 @@
 calling propError
 uncaught Error: 
   ../ExampleErrors.chpl:2: thrown here
-  propagate-implicit.chpl:4: uncaught here
+  propagate-implicit.chpl:4: called from here
+  propagate-implicit.chpl:9: uncaught here

--- a/test/errhandling/psahabu/propagate.good
+++ b/test/errhandling/psahabu/propagate.good
@@ -2,4 +2,5 @@ calling propError
 uncaught Error: 
   ../ExampleErrors.chpl:2: thrown here
   propagate.chpl:4: called from here
-  propagate.chpl:4: uncaught here
+  propagate.chpl:4: called from here
+  propagate.chpl:9: uncaught here

--- a/test/errhandling/psahabu/throw-nil.good
+++ b/test/errhandling/psahabu/throw-nil.good
@@ -1,4 +1,5 @@
 throwing nil
 uncaught NilThrownError: thrown error was nil
   throw-nil.chpl:3: thrown here
+  throw-nil.chpl:7: called from here
   throw-nil.chpl:7: uncaught here

--- a/test/errhandling/psahabu/top-try-bang.good
+++ b/test/errhandling/psahabu/top-try-bang.good
@@ -1,4 +1,5 @@
 should not continue
 uncaught Error: 
   ../ExampleErrors.chpl:2: thrown here
+  top-try-bang.chpl:5: called from here
   top-try-bang.chpl:5: uncaught here

--- a/test/errhandling/stacktrace/basic.1-0.good
+++ b/test/errhandling/stacktrace/basic.1-0.good
@@ -2,4 +2,5 @@ uncaught Error: oops
   basic.chpl:2: thrown here
   basic.chpl:5: called from here
   basic.chpl:8: called from here
+  basic.chpl:24: called from here
   basic.chpl:24: uncaught here

--- a/test/errhandling/stacktrace/basic.2-0.good
+++ b/test/errhandling/stacktrace/basic.2-0.good
@@ -8,4 +8,5 @@ uncaught Error: oops
   basic.chpl:2: thrown here
   basic.chpl:5: called from here
   basic.chpl:8: called from here
+  basic.chpl:24: called from here
   basic.chpl:24: uncaught here

--- a/test/errhandling/stacktrace/basicExpr.good
+++ b/test/errhandling/stacktrace/basicExpr.good
@@ -1,4 +1,5 @@
 uncaught Error: oops
   basicExpr.chpl:2: thrown here
   basicExpr.chpl:6: called from here
-  basicExpr.chpl:9: uncaught here
+  basicExpr.chpl:9: called from here
+  basicExpr.chpl:13: uncaught here

--- a/test/errhandling/stacktrace/basicInline.1-0.good
+++ b/test/errhandling/stacktrace/basicInline.1-0.good
@@ -2,4 +2,5 @@ uncaught Error: oops
   basicInline.chpl:2: thrown here
   basicInline.chpl:5: called from here
   basicInline.chpl:8: called from here
+  basicInline.chpl:24: called from here
   basicInline.chpl:24: uncaught here

--- a/test/errhandling/stacktrace/basicInline.2-0.good
+++ b/test/errhandling/stacktrace/basicInline.2-0.good
@@ -8,4 +8,5 @@ uncaught Error: oops
   basicInline.chpl:2: thrown here
   basicInline.chpl:5: called from here
   basicInline.chpl:8: called from here
+  basicInline.chpl:24: called from here
   basicInline.chpl:24: uncaught here

--- a/test/errhandling/stacktrace/propagateThroughCoforall.1-0.good
+++ b/test/errhandling/stacktrace/propagateThroughCoforall.1-0.good
@@ -2,4 +2,5 @@ uncaught TaskErrors: 1 errors: Error: oops
   propagateThroughCoforall.chpl:5: thrown here
   propagateThroughCoforall.chpl:5: called from here
   propagateThroughCoforall.chpl:11: called from here
+  propagateThroughCoforall.chpl:34: called from here
   propagateThroughCoforall.chpl:34: uncaught here

--- a/test/errhandling/stacktrace/propagateThroughCoforall.2-0.good
+++ b/test/errhandling/stacktrace/propagateThroughCoforall.2-0.good
@@ -12,4 +12,5 @@ uncaught TaskErrors: 1 errors: Error: oops
   propagateThroughCoforall.chpl:5: thrown here
   propagateThroughCoforall.chpl:5: called from here
   propagateThroughCoforall.chpl:11: called from here
+  propagateThroughCoforall.chpl:34: called from here
   propagateThroughCoforall.chpl:34: uncaught here

--- a/test/errhandling/stacktrace/propagateThroughForall.1-0.good
+++ b/test/errhandling/stacktrace/propagateThroughForall.1-0.good
@@ -1,5 +1,7 @@
 uncaught TaskErrors: 1 errors: Error: oops
   propagateThroughForall.chpl:5: thrown here
   propagateThroughForall.chpl:5: called from here
+  propagateThroughForall.chpl:5: called from here
   propagateThroughForall.chpl:11: called from here
+  propagateThroughForall.chpl:34: called from here
   propagateThroughForall.chpl:34: uncaught here

--- a/test/errhandling/stacktrace/propagateThroughForall.2-0.good
+++ b/test/errhandling/stacktrace/propagateThroughForall.2-0.good
@@ -2,8 +2,9 @@ caught error: 1 errors: Error: oops
 stack trace:
   (frame 1) propagateThroughForall.chpl:5
   (frame 2) propagateThroughForall.chpl:5
-  (frame 3) propagateThroughForall.chpl:11
-  (frame 4) propagateThroughForall.chpl:17
+  (frame 3) propagateThroughForall.chpl:5
+  (frame 4) propagateThroughForall.chpl:11
+  (frame 5) propagateThroughForall.chpl:17
 caught error: oops
 stack trace:
   (frame 1) propagateThroughForall.chpl:2
@@ -11,5 +12,7 @@ stack trace:
 uncaught TaskErrors: 1 errors: Error: oops
   propagateThroughForall.chpl:5: thrown here
   propagateThroughForall.chpl:5: called from here
+  propagateThroughForall.chpl:5: called from here
   propagateThroughForall.chpl:11: called from here
+  propagateThroughForall.chpl:34: called from here
   propagateThroughForall.chpl:34: uncaught here

--- a/test/errhandling/stacktrace/propagateThroughIterator2.1-0.good
+++ b/test/errhandling/stacktrace/propagateThroughIterator2.1-0.good
@@ -2,4 +2,5 @@ uncaught Error: oops
   propagateThroughIterator2.chpl:2: thrown here
   propagateThroughIterator2.chpl:14: called from here
   propagateThroughIterator2.chpl:14: called from here
+  propagateThroughIterator2.chpl:30: called from here
   propagateThroughIterator2.chpl:30: uncaught here

--- a/test/errhandling/stacktrace/propagateThroughIterator2.2-0.good
+++ b/test/errhandling/stacktrace/propagateThroughIterator2.2-0.good
@@ -8,4 +8,5 @@ uncaught Error: oops
   propagateThroughIterator2.chpl:2: thrown here
   propagateThroughIterator2.chpl:14: called from here
   propagateThroughIterator2.chpl:14: called from here
+  propagateThroughIterator2.chpl:30: called from here
   propagateThroughIterator2.chpl:30: uncaught here

--- a/test/errhandling/stacktrace/propagateThroughParIterator.1-0.good
+++ b/test/errhandling/stacktrace/propagateThroughParIterator.1-0.good
@@ -2,4 +2,5 @@ uncaught Error: oops
   propagateThroughParIterator.chpl:2: thrown here
   propagateThroughParIterator.chpl:21: called from here
   propagateThroughParIterator.chpl:21: called from here
+  propagateThroughParIterator.chpl:37: called from here
   propagateThroughParIterator.chpl:37: uncaught here

--- a/test/errhandling/stacktrace/propagateThroughParIterator.2-0.good
+++ b/test/errhandling/stacktrace/propagateThroughParIterator.2-0.good
@@ -8,4 +8,5 @@ uncaught Error: oops
   propagateThroughParIterator.chpl:2: thrown here
   propagateThroughParIterator.chpl:21: called from here
   propagateThroughParIterator.chpl:21: called from here
+  propagateThroughParIterator.chpl:37: called from here
   propagateThroughParIterator.chpl:37: uncaught here

--- a/test/errhandling/stacktrace/stressTest.16.good
+++ b/test/errhandling/stacktrace/stressTest.16.good
@@ -17,4 +17,5 @@ uncaught MyError: oops
   stressTest.chpl:9: called from here
   stressTest.chpl:9: called from here
   stressTest.chpl:9: called from here
+  stressTest.chpl:17: called from here
   stressTest.chpl:17: uncaught here

--- a/test/errhandling/stacktrace/stressTest.256.good
+++ b/test/errhandling/stacktrace/stressTest.256.good
@@ -257,4 +257,5 @@ uncaught MyError: oops
   stressTest.chpl:9: called from here
   stressTest.chpl:9: called from here
   stressTest.chpl:9: called from here
+  stressTest.chpl:17: called from here
   stressTest.chpl:17: uncaught here

--- a/test/errhandling/stacktrace/throwFromCoforall.1-0.good
+++ b/test/errhandling/stacktrace/throwFromCoforall.1-0.good
@@ -3,4 +3,5 @@ uncaught TaskErrors: 1 errors: Error: oops
   throwFromCoforall.chpl:2: called from here
   throwFromCoforall.chpl:8: called from here
   throwFromCoforall.chpl:11: called from here
+  throwFromCoforall.chpl:34: called from here
   throwFromCoforall.chpl:34: uncaught here

--- a/test/errhandling/stacktrace/throwFromCoforall.2-0.good
+++ b/test/errhandling/stacktrace/throwFromCoforall.2-0.good
@@ -13,4 +13,5 @@ uncaught TaskErrors: 1 errors: Error: oops
   throwFromCoforall.chpl:2: called from here
   throwFromCoforall.chpl:8: called from here
   throwFromCoforall.chpl:11: called from here
+  throwFromCoforall.chpl:34: called from here
   throwFromCoforall.chpl:34: uncaught here

--- a/test/errhandling/stacktrace/throwFromForall.1-0.good
+++ b/test/errhandling/stacktrace/throwFromForall.1-0.good
@@ -1,6 +1,8 @@
 uncaught TaskErrors: 1 errors: Error: oops
   throwFromForall.chpl:2: thrown here
   throwFromForall.chpl:2: called from here
+  throwFromForall.chpl:2: called from here
   throwFromForall.chpl:8: called from here
   throwFromForall.chpl:11: called from here
+  throwFromForall.chpl:34: called from here
   throwFromForall.chpl:34: uncaught here

--- a/test/errhandling/stacktrace/throwFromForall.2-0.good
+++ b/test/errhandling/stacktrace/throwFromForall.2-0.good
@@ -2,15 +2,18 @@ caught error: 1 errors: Error: oops
 stack trace:
   (frame 1) throwFromForall.chpl:2
   (frame 2) throwFromForall.chpl:2
-  (frame 3) throwFromForall.chpl:8
-  (frame 4) throwFromForall.chpl:11
-  (frame 5) throwFromForall.chpl:17
+  (frame 3) throwFromForall.chpl:2
+  (frame 4) throwFromForall.chpl:8
+  (frame 5) throwFromForall.chpl:11
+  (frame 6) throwFromForall.chpl:17
 caught error: oops
 stack trace:
   (frame 1) throwFromForall.chpl:4
 uncaught TaskErrors: 1 errors: Error: oops
   throwFromForall.chpl:2: thrown here
   throwFromForall.chpl:2: called from here
+  throwFromForall.chpl:2: called from here
   throwFromForall.chpl:8: called from here
   throwFromForall.chpl:11: called from here
+  throwFromForall.chpl:34: called from here
   throwFromForall.chpl:34: uncaught here

--- a/test/errhandling/stacktrace/throwFromParIterator.1-0.good
+++ b/test/errhandling/stacktrace/throwFromParIterator.1-0.good
@@ -1,4 +1,5 @@
 uncaught Error: oops
   throwFromParIterator.chpl:17: thrown here
   throwFromParIterator.chpl:17: called from here
+  throwFromParIterator.chpl:33: called from here
   throwFromParIterator.chpl:33: uncaught here

--- a/test/errhandling/stacktrace/throwFromParIterator.2-0.good
+++ b/test/errhandling/stacktrace/throwFromParIterator.2-0.good
@@ -6,4 +6,5 @@ stack trace:
 uncaught Error: oops
   throwFromParIterator.chpl:17: thrown here
   throwFromParIterator.chpl:17: called from here
+  throwFromParIterator.chpl:33: called from here
   throwFromParIterator.chpl:33: uncaught here

--- a/test/errhandling/stacktrace/throwingAggregate.chpl
+++ b/test/errhandling/stacktrace/throwingAggregate.chpl
@@ -1,0 +1,71 @@
+config param doCatch = false;
+
+proc throwIfEq(val, eq) throws {
+  if val == eq then
+    throw new Error("value is equal to " + eq:string);
+}
+record R {
+  var x: int;
+  proc init(val: int) throws {
+    x = val;
+    init this;
+    throwIfEq(val, 0);
+  }
+  proc postinit() throws {
+    throwIfEq(x, 1);
+  }
+  proc method() throws {
+    throwIfEq(x, 2);
+  }
+}
+class C {
+  var x: int;
+  proc init(val: int) throws {
+    x = val;
+    init this;
+    throwIfEq(val, 0);
+  }
+  proc postinit() throws {
+    throwIfEq(x, 1);
+  }
+  proc method() throws {
+    throwIfEq(x, 2);
+  }
+}
+union U {
+  var x: int;
+  proc init(val: int) throws {
+    x = val;
+    init this;
+    throwIfEq(val, 0);
+  }
+  proc postinit() throws {
+    throwIfEq(x, 1);
+  }
+  proc method() throws {
+    throwIfEq(x, 2);
+  }
+}
+
+
+proc test(type t) {
+  for val in 0..2 {
+    try {
+      writeln("creating ", t:string, " with value ", val);
+      var r = new t(val);
+      writeln("created ", r);
+      r.method();
+    } catch e {
+      writeln("caught error: ", e.message());
+      writeln("stack trace:");
+      for ((f, l), idx) in zip(e.stacktrace(), 1..) {
+        writeln("  (frame ", idx, ") ", f, ":", l);
+      }
+    }
+  }
+}
+
+test(R);
+test(owned C);
+test(shared C);
+test(U);

--- a/test/errhandling/stacktrace/throwingAggregate.good
+++ b/test/errhandling/stacktrace/throwingAggregate.good
@@ -24,7 +24,6 @@ stack trace:
   (frame 2) throwingAggregate.chpl:55
   (frame 3) throwingAggregate.chpl:55
   (frame 4) throwingAggregate.chpl:55
-  (frame 5) throwingAggregate.chpl:55
 creating owned C with value 1
 caught error: value is equal to 1
 stack trace:
@@ -32,7 +31,6 @@ stack trace:
   (frame 2) throwingAggregate.chpl:29
   (frame 3) throwingAggregate.chpl:55
   (frame 4) throwingAggregate.chpl:55
-  (frame 5) throwingAggregate.chpl:55
 creating owned C with value 2
 created {x = 2}
 caught error: value is equal to 2
@@ -47,7 +45,6 @@ stack trace:
   (frame 2) throwingAggregate.chpl:55
   (frame 3) throwingAggregate.chpl:55
   (frame 4) throwingAggregate.chpl:55
-  (frame 5) throwingAggregate.chpl:55
 creating shared C with value 1
 caught error: value is equal to 1
 stack trace:
@@ -55,7 +52,6 @@ stack trace:
   (frame 2) throwingAggregate.chpl:29
   (frame 3) throwingAggregate.chpl:55
   (frame 4) throwingAggregate.chpl:55
-  (frame 5) throwingAggregate.chpl:55
 creating shared C with value 2
 created {x = 2}
 caught error: value is equal to 2

--- a/test/errhandling/stacktrace/throwingAggregate.good
+++ b/test/errhandling/stacktrace/throwingAggregate.good
@@ -1,0 +1,84 @@
+creating R with value 0
+caught error: value is equal to 0
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:12
+  (frame 3) throwingAggregate.chpl:55
+creating R with value 1
+caught error: value is equal to 1
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:15
+  (frame 3) throwingAggregate.chpl:55
+creating R with value 2
+created (x = 2)
+caught error: value is equal to 2
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:18
+  (frame 3) throwingAggregate.chpl:57
+creating owned C with value 0
+caught error: value is equal to 0
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:55
+  (frame 3) throwingAggregate.chpl:55
+  (frame 4) throwingAggregate.chpl:55
+  (frame 5) throwingAggregate.chpl:55
+creating owned C with value 1
+caught error: value is equal to 1
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:29
+  (frame 3) throwingAggregate.chpl:55
+  (frame 4) throwingAggregate.chpl:55
+  (frame 5) throwingAggregate.chpl:55
+creating owned C with value 2
+created {x = 2}
+caught error: value is equal to 2
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:32
+  (frame 3) throwingAggregate.chpl:57
+creating shared C with value 0
+caught error: value is equal to 0
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:55
+  (frame 3) throwingAggregate.chpl:55
+  (frame 4) throwingAggregate.chpl:55
+  (frame 5) throwingAggregate.chpl:55
+creating shared C with value 1
+caught error: value is equal to 1
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:29
+  (frame 3) throwingAggregate.chpl:55
+  (frame 4) throwingAggregate.chpl:55
+  (frame 5) throwingAggregate.chpl:55
+creating shared C with value 2
+created {x = 2}
+caught error: value is equal to 2
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:32
+  (frame 3) throwingAggregate.chpl:57
+creating U with value 0
+caught error: value is equal to 0
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:40
+  (frame 3) throwingAggregate.chpl:55
+creating U with value 1
+caught error: value is equal to 1
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:43
+  (frame 3) throwingAggregate.chpl:55
+creating U with value 2
+created (x = 2)
+caught error: value is equal to 2
+stack trace:
+  (frame 1) throwingAggregate.chpl:5
+  (frame 2) throwingAggregate.chpl:46
+  (frame 3) throwingAggregate.chpl:57

--- a/test/errhandling/tryBangNonBlockStmt.good
+++ b/test/errhandling/tryBangNonBlockStmt.good
@@ -1,4 +1,5 @@
 uncaught TaskErrors: 1 errors: Error: Intended to fail
   tryBangNonBlockStmt.chpl:1: thrown here
   tryBangNonBlockStmt.chpl:1: called from here
+  tryBangNonBlockStmt.chpl:1: called from here
   tryBangNonBlockStmt.chpl:1: uncaught here

--- a/test/execflags/diten/configComplex.good
+++ b/test/execflags/diten/configComplex.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: bad cast from string '3.1i + 1.1' to complex(128)
   <command line setting of 'z'>:0: thrown here
+  <command line setting of 'z'>:0: called from here
   <command line setting of 'z'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidBoolean.good
+++ b/test/execflags/shannon/configs/configVarInvalidBoolean.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: bad cast from string 'maybe' to bool
   <command line setting of 'x'>:0: thrown here
+  <command line setting of 'x'>:0: called from here
   <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidComplex.good
+++ b/test/execflags/shannon/configs/configVarInvalidComplex.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: bad cast from string '5.6+7.8j' to complex(128)
   <command line setting of 'x'>:0: thrown here
+  <command line setting of 'x'>:0: called from here
   <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidFloat.good
+++ b/test/execflags/shannon/configs/configVarInvalidFloat.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: bad cast from string 'true' to real(64)
   <command line setting of 'x'>:0: thrown here
+  <command line setting of 'x'>:0: called from here
   <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/shannon/configs/configVarInvalidInteger.good
+++ b/test/execflags/shannon/configs/configVarInvalidInteger.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: bad cast from string '56.78' to int(64)
   <command line setting of 'x'>:0: thrown here
+  <command line setting of 'x'>:0: called from here
   <command line setting of 'x'>:0: uncaught here

--- a/test/execflags/tmacd/config_num.bad
+++ b/test/execflags/tmacd/config_num.bad
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: bad cast from string '2i+3' to complex(128)
   <command line setting of 'z'>:0: thrown here
+  <command line setting of 'z'>:0: called from here
   <command line setting of 'z'>:0: uncaught here

--- a/test/functions/fcf/ThrowingAnonProcHalts.good
+++ b/test/functions/fcf/ThrowingAnonProcHalts.good
@@ -1,3 +1,4 @@
 uncaught Error: Halt!
   ThrowingAnonProcHalts.chpl:2: thrown here
+  ThrowingAnonProcHalts.chpl:3: called from here
   ThrowingAnonProcHalts.chpl:3: uncaught here

--- a/test/io/bharshbarg/readTypeEOF.prediff
+++ b/test/io/bharshbarg/readTypeEOF.prediff
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+chpl_sanitize=$($CHPL_HOME/util/chplenv/chpl_sanitizers.py)
+
+if [[ $chpl_sanitize == "undefined" ]]; then
+  # UBsan may warn about this. its harmless, in this case the following occurs
+  # * an error is thrown
+  # * after the error is thrown BUT before its handled,
+  #    we assign some temporaries from a tuple that contains a bool
+  # * the bool was never initialized because of the thrown error,
+  #   and will never be used because an error is thrown
+  # This is harmless and it comes about because of how we lower tuples and errors.
+  # its not worth rewriting how we lower errors to be before any values are
+  # assigned (even if never used), so just squash
+  sed "0,\|is not a valid value for type '_Bool'|{//d;}" "$2" > "$2.tmp"
+  sed "0,\|is not a valid value for type 'chpl_bool'|{//d;}" "$2" > "$2.tmp"
+  mv "$2.tmp" "$2"
+fi

--- a/test/io/errors/serializeUserError.comm-none.good
+++ b/test/io/errors/serializeUserError.comm-none.good
@@ -5,4 +5,5 @@ uncaught IllegalArgumentError: User error thrown from serialize!
   serializeUserError.chpl:20: called from here
   serializeUserError.chpl:20: called from here
   serializeUserError.chpl:20: called from here
+  serializeUserError.chpl:20: called from here
   serializeUserError.chpl:20: uncaught here

--- a/test/io/errors/serializeUserError.good
+++ b/test/io/errors/serializeUserError.good
@@ -6,4 +6,5 @@ uncaught IllegalArgumentError: User error thrown from serialize!
   serializeUserError.chpl:20: called from here
   serializeUserError.chpl:20: called from here
   serializeUserError.chpl:20: called from here
+  serializeUserError.chpl:20: called from here
   serializeUserError.chpl:20: uncaught here

--- a/test/io/errors/serializeUserError.no-local.good
+++ b/test/io/errors/serializeUserError.no-local.good
@@ -1,0 +1,1 @@
+serializeUserError.good

--- a/test/io/ferguson/error-invalid-channel.write.comm-none.good
+++ b/test/io/ferguson/error-invalid-channel.write.comm-none.good
@@ -2,4 +2,5 @@ uncaught SystemError: Invalid argument (Operation attempted on an invalid fileWr
   error-invalid-channel.chpl:7: thrown here
   error-invalid-channel.chpl:7: called from here
   error-invalid-channel.chpl:7: called from here
+  error-invalid-channel.chpl:7: called from here
   error-invalid-channel.chpl:7: uncaught here

--- a/test/io/ferguson/error-invalid-channel.write.good
+++ b/test/io/ferguson/error-invalid-channel.write.good
@@ -3,4 +3,5 @@ uncaught SystemError: Invalid argument (Operation attempted on an invalid fileWr
   error-invalid-channel.chpl:7: called from here
   error-invalid-channel.chpl:7: called from here
   error-invalid-channel.chpl:7: called from here
+  error-invalid-channel.chpl:7: called from here
   error-invalid-channel.chpl:7: uncaught here

--- a/test/io/ferguson/error-invalid-channel.write.no-local.good
+++ b/test/io/ferguson/error-invalid-channel.write.no-local.good
@@ -1,0 +1,1 @@
+error-invalid-channel.write.good

--- a/test/io/ferguson/issue-16945-error-read-nil-non-nilable.comm-none.good
+++ b/test/io/ferguson/issue-16945-error-read-nil-non-nilable.comm-none.good
@@ -19,4 +19,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading str
   issue-16945-error-read-nil-non-nilable.chpl:12: called from here
   issue-16945-error-read-nil-non-nilable.chpl:12: called from here
   issue-16945-error-read-nil-non-nilable.chpl:12: called from here
+  issue-16945-error-read-nil-non-nilable.chpl:12: called from here
   issue-16945-error-read-nil-non-nilable.chpl:12: uncaught here

--- a/test/io/ferguson/issue-16945-error-read-nil-non-nilable.good
+++ b/test/io/ferguson/issue-16945-error-read-nil-non-nilable.good
@@ -22,4 +22,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading str
   issue-16945-error-read-nil-non-nilable.chpl:12: called from here
   issue-16945-error-read-nil-non-nilable.chpl:12: called from here
   issue-16945-error-read-nil-non-nilable.chpl:12: called from here
+  issue-16945-error-read-nil-non-nilable.chpl:12: called from here
   issue-16945-error-read-nil-non-nilable.chpl:12: uncaught here

--- a/test/io/ferguson/issue-16945-error-read-nil-non-nilable.no-local.good
+++ b/test/io/ferguson/issue-16945-error-read-nil-non-nilable.no-local.good
@@ -1,0 +1,1 @@
+issue-16945-error-read-nil-non-nilable.good

--- a/test/io/ferguson/memfile-format-error-offset.comm-none.good
+++ b/test/io/ferguson/memfile-format-error-offset.comm-none.good
@@ -6,4 +6,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading str
   memfile-format-error-offset.chpl:12: called from here
   memfile-format-error-offset.chpl:12: called from here
   memfile-format-error-offset.chpl:12: called from here
+  memfile-format-error-offset.chpl:12: called from here
   memfile-format-error-offset.chpl:12: uncaught here

--- a/test/io/ferguson/memfile-format-error-offset.good
+++ b/test/io/ferguson/memfile-format-error-offset.good
@@ -7,4 +7,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading str
   memfile-format-error-offset.chpl:12: called from here
   memfile-format-error-offset.chpl:12: called from here
   memfile-format-error-offset.chpl:12: called from here
+  memfile-format-error-offset.chpl:12: called from here
   memfile-format-error-offset.chpl:12: uncaught here

--- a/test/io/ferguson/memfile-format-error-offset.no-local.good
+++ b/test/io/ferguson/memfile-format-error-offset.no-local.good
@@ -1,0 +1,1 @@
+memfile-format-error-offset.good

--- a/test/io/ferguson/read-class-reorder.bad
+++ b/test/io/ferguson/read-class-reorder.bad
@@ -15,4 +15,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading str
   read-class-reorder.chpl:31: called from here
   read-class-reorder.chpl:31: called from here
   read-class-reorder.chpl:31: called from here
+  read-class-reorder.chpl:31: called from here
   read-class-reorder.chpl:31: uncaught here

--- a/test/io/ferguson/read-class-reorder.skipif
+++ b/test/io/ferguson/read-class-reorder.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM != none
+COMPOPTS <= --no-local

--- a/test/io/ferguson/read-class-reorder2.bad
+++ b/test/io/ferguson/read-class-reorder2.bad
@@ -16,4 +16,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading str
   read-class-reorder2.chpl:29: called from here
   read-class-reorder2.chpl:29: called from here
   read-class-reorder2.chpl:29: called from here
+  read-class-reorder2.chpl:29: called from here
   read-class-reorder2.chpl:29: uncaught here

--- a/test/io/ferguson/read-class-reorder2.skipif
+++ b/test/io/ferguson/read-class-reorder2.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM != none
+COMPOPTS <= --no-local

--- a/test/io/ferguson/read-class-reorder3.bad
+++ b/test/io/ferguson/read-class-reorder3.bad
@@ -16,4 +16,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading str
   read-class-reorder3.chpl:28: called from here
   read-class-reorder3.chpl:28: called from here
   read-class-reorder3.chpl:28: called from here
+  read-class-reorder3.chpl:28: called from here
   read-class-reorder3.chpl:28: uncaught here

--- a/test/io/ferguson/read-class-reorder3.skipif
+++ b/test/io/ferguson/read-class-reorder3.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM != none
+COMPOPTS <= --no-local

--- a/test/io/ferguson/stdin-is-directory/stdin-is-directory.good
+++ b/test/io/ferguson/stdin-is-directory/stdin-is-directory.good
@@ -2,4 +2,5 @@ uncaught SystemError: Invalid argument: fd 0 (stdin) is a directory (in file.ini
   <internal>:0: thrown here
   <internal>:0: called from here
   <internal>:0: called from here
+  <internal>:0: called from here
   <internal>:0: uncaught here

--- a/test/io/marybeth/testformat-error.bytes.good
+++ b/test/io/marybeth/testformat-error.bytes.good
@@ -1,4 +1,5 @@
 uncaught SystemError: Invalid argument: Too many arguments for format string (in bytes.format)
   testformat-error.chpl:4: thrown here
   testformat-error.chpl:4: called from here
+  testformat-error.chpl:4: called from here
   testformat-error.chpl:4: uncaught here

--- a/test/io/marybeth/testformat-error.string.good
+++ b/test/io/marybeth/testformat-error.string.good
@@ -1,4 +1,5 @@
 uncaught SystemError: Invalid argument: Too many arguments for format string (in string.format)
   testformat-error.chpl:4: thrown here
   testformat-error.chpl:4: called from here
+  testformat-error.chpl:4: called from here
   testformat-error.chpl:4: uncaught here

--- a/test/io/marybeth/testreadln5.comm-none.good
+++ b/test/io/marybeth/testreadln5.comm-none.good
@@ -2,4 +2,5 @@ uncaught SystemError: Bad file descriptor (Operation attempted on an invalid fil
   testreadln5.chpl:5: thrown here
   testreadln5.chpl:5: called from here
   testreadln5.chpl:5: called from here
+  testreadln5.chpl:5: called from here
   testreadln5.chpl:5: uncaught here

--- a/test/io/marybeth/testreadln5.good
+++ b/test/io/marybeth/testreadln5.good
@@ -3,4 +3,5 @@ uncaught SystemError: Bad file descriptor (Operation attempted on an invalid fil
   testreadln5.chpl:5: called from here
   testreadln5.chpl:5: called from here
   testreadln5.chpl:5: called from here
+  testreadln5.chpl:5: called from here
   testreadln5.chpl:5: uncaught here

--- a/test/io/marybeth/testreadln5.no-local.good
+++ b/test/io/marybeth/testreadln5.no-local.good
@@ -1,0 +1,1 @@
+testreadln5.good

--- a/test/io/serializers/out-of-order.default.no-local.good
+++ b/test/io/serializers/out-of-order.default.no-local.good
@@ -1,0 +1,1 @@
+out-of-order.default.good

--- a/test/library/packages/Python/correctness/myTupleTypeTooSmall.good
+++ b/test/library/packages/Python/correctness/myTupleTypeTooSmall.good
@@ -3,4 +3,5 @@ t[0:2] (no type) (2, 3)
 uncaught ChapelException: type specified was smaller than returned value
   myTupleTypeTooSmall.chpl:22: thrown here
   myTupleTypeTooSmall.chpl:22: called from here
+  myTupleTypeTooSmall.chpl:22: called from here
   myTupleTypeTooSmall.chpl:22: uncaught here

--- a/test/library/packages/Yaml/percent-q.bad
+++ b/test/library/packages/Yaml/percent-q.bad
@@ -15,4 +15,5 @@ uncaught SystemError: Invalid argument: reset not supported for marked channel
   percent-q.chpl:21: called from here
   percent-q.chpl:21: called from here
   percent-q.chpl:21: called from here
+  percent-q.chpl:21: called from here
   percent-q.chpl:21: uncaught here

--- a/test/library/packages/Yaml/percent-q.skipif
+++ b/test/library/packages/Yaml/percent-q.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM != none
+COMPOPTS <= --no-local

--- a/test/library/standard/FileSystem/fsouza/chdir/no_such_directory.good
+++ b/test/library/standard/FileSystem/fsouza/chdir/no_such_directory.good
@@ -1,4 +1,5 @@
 uncaught FileNotFoundError: No such file or directory (in chdir with path "no-such-dir")
   no_such_directory.chpl:3: thrown here
   no_such_directory.chpl:3: called from here
+  no_such_directory.chpl:3: called from here
   no_such_directory.chpl:3: uncaught here

--- a/test/library/standard/FileSystem/fsouza/chown/no_such_file.good
+++ b/test/library/standard/FileSystem/fsouza/chown/no_such_file.good
@@ -1,4 +1,5 @@
 uncaught FileNotFoundError: No such file or directory (in chown with path "unknown_file.txt")
   no_such_file.chpl:2: thrown here
   no_such_file.chpl:2: called from here
+  no_such_file.chpl:2: called from here
   no_such_file.chpl:2: uncaught here

--- a/test/library/standard/FileSystem/fsouza/chown/permission_error.good
+++ b/test/library/standard/FileSystem/fsouza/chown/permission_error.good
@@ -1,4 +1,5 @@
 uncaught PermissionError: SYS_ERR (in chown with path "file.txt")
   permission_error.chpl:9: thrown here
   permission_error.chpl:9: called from here
+  permission_error.chpl:9: called from here
   permission_error.chpl:9: uncaught here

--- a/test/library/standard/FileSystem/lydia/copyTree/dest_existed.good
+++ b/test/library/standard/FileSystem/lydia/copyTree/dest_existed.good
@@ -1,4 +1,5 @@
 uncaught FileExistsError: File exists (in copyTree(a, existing_dir))
   dest_existed.chpl:3: thrown here
   dest_existed.chpl:3: called from here
+  dest_existed.chpl:3: called from here
   dest_existed.chpl:3: uncaught here

--- a/test/library/standard/FileSystem/lydia/copyTree/no_src.good
+++ b/test/library/standard/FileSystem/lydia/copyTree/no_src.good
@@ -1,4 +1,5 @@
 uncaught NotADirectoryError: Not a directory (in copyTree(shesNotThere, pleaseDontBotherTryingToFindHer))
   no_src.chpl:3: thrown here
   no_src.chpl:3: called from here
+  no_src.chpl:3: called from here
   no_src.chpl:3: uncaught here

--- a/test/library/standard/FileSystem/lydia/copyTree/src_not_dir.good
+++ b/test/library/standard/FileSystem/lydia/copyTree/src_not_dir.good
@@ -1,4 +1,5 @@
 uncaught NotADirectoryError: Not a directory (in copyTree(blah.txt, thatWasntADirectory))
   src_not_dir.chpl:3: thrown here
   src_not_dir.chpl:3: called from here
+  src_not_dir.chpl:3: called from here
   src_not_dir.chpl:3: uncaught here

--- a/test/library/standard/FileSystem/lydia/getSize/no_such_file.good
+++ b/test/library/standard/FileSystem/lydia/getSize/no_such_file.good
@@ -1,4 +1,5 @@
 uncaught FileNotFoundError: No such file or directory (in getFileSize with path "no_such_file.txt")
   no_such_file.chpl:3: thrown here
   no_such_file.chpl:3: called from here
+  no_such_file.chpl:3: called from here
   no_such_file.chpl:3: uncaught here

--- a/test/library/standard/FileSystem/lydia/mkdir/makeAlreadyPresent.good
+++ b/test/library/standard/FileSystem/lydia/mkdir/makeAlreadyPresent.good
@@ -1,4 +1,5 @@
 uncaught FileExistsError: File exists (in mkdir with path "already_present")
   makeAlreadyPresent.chpl:5: thrown here
   makeAlreadyPresent.chpl:5: called from here
+  makeAlreadyPresent.chpl:5: called from here
   makeAlreadyPresent.chpl:5: uncaught here

--- a/test/library/standard/FileSystem/lydia/mkdir/makeDeepNoParent.good
+++ b/test/library/standard/FileSystem/lydia/mkdir/makeDeepNoParent.good
@@ -1,4 +1,5 @@
 uncaught FileNotFoundError: No such file or directory (in mkdir with path "make/deep/no/parent")
   makeDeepNoParent.chpl:5: thrown here
   makeDeepNoParent.chpl:5: called from here
+  makeDeepNoParent.chpl:5: called from here
   makeDeepNoParent.chpl:5: uncaught here

--- a/test/library/standard/FileSystem/lydia/moveDir/moveOverFile.good
+++ b/test/library/standard/FileSystem/lydia/moveDir/moveOverFile.good
@@ -1,4 +1,5 @@
 uncaught NotADirectoryError: Not a directory (in moveDir(foo, existed.txt))
   moveOverFile.chpl:14: thrown here
   moveOverFile.chpl:14: called from here
+  moveOverFile.chpl:14: called from here
   moveOverFile.chpl:14: uncaught here

--- a/test/library/standard/FileSystem/lydia/remove/nonempty_dir.good
+++ b/test/library/standard/FileSystem/lydia/remove/nonempty_dir.good
@@ -1,5 +1,6 @@
 uncaught SystemError: Directory not empty (in remove with path "nonempty")
   nonempty_dir.chpl:4: thrown here
   nonempty_dir.chpl:4: called from here
+  nonempty_dir.chpl:4: called from here
   nonempty_dir.chpl:4: uncaught here
 cat: nonempty: Is a directory

--- a/test/library/standard/FileSystem/lydia/remove/nonexistent_file.good
+++ b/test/library/standard/FileSystem/lydia/remove/nonexistent_file.good
@@ -1,4 +1,5 @@
 uncaught FileNotFoundError: No such file or directory (in remove with path "nonexistent_file.txt")
   nonexistent_file.chpl:4: thrown here
   nonexistent_file.chpl:4: called from here
+  nonexistent_file.chpl:4: called from here
   nonexistent_file.chpl:4: uncaught here

--- a/test/library/standard/FileSystem/lydia/rename/no_such_file.good
+++ b/test/library/standard/FileSystem/lydia/rename/no_such_file.good
@@ -1,4 +1,5 @@
 uncaught FileNotFoundError: No such file or directory (in rename with path "no_such_fileOld.txt")
   no_such_file.chpl:6: thrown here
   no_such_file.chpl:6: called from here
+  no_such_file.chpl:6: called from here
   no_such_file.chpl:6: uncaught here

--- a/test/library/standard/FileSystem/lydia/sameFile/brokenSymlink.good
+++ b/test/library/standard/FileSystem/lydia/sameFile/brokenSymlink.good
@@ -1,4 +1,5 @@
 uncaught FileNotFoundError: No such file or directory (in sameFile(moved.txt, linkToIt))
   brokenSymlink.chpl:25: thrown here
   brokenSymlink.chpl:25: called from here
+  brokenSymlink.chpl:25: called from here
   brokenSymlink.chpl:25: uncaught here

--- a/test/library/standard/FileSystem/lydia/sameFile/dir_nonexistent.good
+++ b/test/library/standard/FileSystem/lydia/sameFile/dir_nonexistent.good
@@ -1,4 +1,5 @@
 uncaught FileNotFoundError: No such file or directory (in sameFile(../, foo/))
   dir_nonexistent.chpl:3: thrown here
   dir_nonexistent.chpl:3: called from here
+  dir_nonexistent.chpl:3: called from here
   dir_nonexistent.chpl:3: uncaught here

--- a/test/library/standard/FileSystem/lydia/sameFile/file_nonexistent.good
+++ b/test/library/standard/FileSystem/lydia/sameFile/file_nonexistent.good
@@ -1,4 +1,5 @@
 uncaught FileNotFoundError: No such file or directory (in sameFile(blah.txt, bar.txt))
   file_nonexistent.chpl:3: thrown here
   file_nonexistent.chpl:3: called from here
+  file_nonexistent.chpl:3: called from here
   file_nonexistent.chpl:3: uncaught here

--- a/test/library/standard/IO/fileWriterBadRegion.good
+++ b/test/library/standard/IO/fileWriterBadRegion.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: illegal argument 'region': file region's lowest accepted bound is 0
   fileWriterBadRegion.chpl:5: thrown here
+  fileWriterBadRegion.chpl:5: called from here
   fileWriterBadRegion.chpl:5: uncaught here

--- a/test/library/standard/IO/filereaderBadRegion.good
+++ b/test/library/standard/IO/filereaderBadRegion.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: illegal argument 'region': file region's lowest accepted bound is 0
   filereaderBadRegion.chpl:5: thrown here
+  filereaderBadRegion.chpl:5: called from here
   filereaderBadRegion.chpl:5: uncaught here

--- a/test/library/standard/IO/formatted/no_precision_on_serde.good
+++ b/test/library/standard/IO/formatted/no_precision_on_serde.good
@@ -4,4 +4,5 @@ uncaught SystemError: Invalid argument: '%?' does not support width or precision
   no_precision_on_serde.chpl:1: called from here
   no_precision_on_serde.chpl:1: called from here
   no_precision_on_serde.chpl:1: called from here
+  no_precision_on_serde.chpl:1: called from here
   no_precision_on_serde.chpl:1: uncaught here

--- a/test/library/standard/IO/formatted/no_width_on_serde.good
+++ b/test/library/standard/IO/formatted/no_width_on_serde.good
@@ -4,4 +4,5 @@ uncaught SystemError: Invalid argument: '%?' does not support width or precision
   no_width_on_serde.chpl:1: called from here
   no_width_on_serde.chpl:1: called from here
   no_width_on_serde.chpl:1: called from here
+  no_width_on_serde.chpl:1: called from here
   no_width_on_serde.chpl:1: uncaught here

--- a/test/library/standard/IO/openreaderBadRegion.good
+++ b/test/library/standard/IO/openreaderBadRegion.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: illegal argument 'region': file region's lowest accepted bound is 0
   openreaderBadRegion.chpl:4: thrown here
+  openreaderBadRegion.chpl:4: called from here
   openreaderBadRegion.chpl:4: uncaught here

--- a/test/library/standard/IO/readThrough/regex/readThroughMaxSizeString.bad
+++ b/test/library/standard/IO/readThrough/regex/readThroughMaxSizeString.bad
@@ -10,4 +10,5 @@ uncaught BadFormatError: bad format (in readThrough(regex(string)) with path "ma
   readThroughMaxSizeString.chpl:30: called from here
   readThroughMaxSizeString.chpl:30: called from here
   readThroughMaxSizeString.chpl:30: called from here
+  readThroughMaxSizeString.chpl:30: called from here
   readThroughMaxSizeString.chpl:30: uncaught here

--- a/test/library/standard/IO/readThrough/regex/readThroughMaxSizeString.skipif
+++ b/test/library/standard/IO/readThrough/regex/readThroughMaxSizeString.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM != none
+COMPOPTS <= --no-local

--- a/test/library/standard/MemMove/moveArrayElements-errors.sizeMismatch.good
+++ b/test/library/standard/MemMove/moveArrayElements-errors.sizeMismatch.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: Destination and source specify a different number of elements to move: 5 vs. 6
   moveArrayElements-errors.chpl:nnnn: thrown here
+  moveArrayElements-errors.chpl:nnnn: called from here
   moveArrayElements-errors.chpl:nnnn: uncaught here

--- a/test/library/standard/OS/POSIX/chmod/chmod_invalidarg.good
+++ b/test/library/standard/OS/POSIX/chmod/chmod_invalidarg.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: bad cast from string 'xyz' to int(32)
   <command line setting of 'permissions'>:0: thrown here
+  <command line setting of 'permissions'>:0: called from here
   <command line setting of 'permissions'>:0: uncaught here

--- a/test/library/standard/Path/lydia/realpath/doesNotExist.good
+++ b/test/library/standard/Path/lydia/realpath/doesNotExist.good
@@ -1,4 +1,5 @@
 uncaught FileNotFoundError: No such file or directory (realPath with path "foo.txt")
   doesNotExist.chpl:4: thrown here
   doesNotExist.chpl:4: called from here
+  doesNotExist.chpl:4: called from here
   doesNotExist.chpl:4: uncaught here

--- a/test/library/standard/Path/lydia/realpath/fileNotValid.good
+++ b/test/library/standard/Path/lydia/realpath/fileNotValid.good
@@ -1,4 +1,5 @@
 uncaught SystemError: Bad file descriptor (in realPath with a file argument)
   fileNotValid.chpl:5: thrown here
   fileNotValid.chpl:5: called from here
+  fileNotValid.chpl:5: called from here
   fileNotValid.chpl:5: uncaught here

--- a/test/library/standard/Random/checkWriteThis.good
+++ b/test/library/standard/Random/checkWriteThis.good
@@ -3,4 +3,5 @@ uncaught SystemError: Invalid argument: Argument type mismatch in argument 0 (in
   checkWriteThis.chpl:34: called from here
   checkWriteThis.chpl:34: called from here
   checkWriteThis.chpl:34: called from here
+  checkWriteThis.chpl:41: called from here
   checkWriteThis.chpl:41: uncaught here

--- a/test/library/standard/Spawn/doc-examples/example_writeBinary.skipif
+++ b/test/library/standard/Spawn/doc-examples/example_writeBinary.skipif
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+if command -v xxd >/dev/null 2>/dev/null; then
+  echo "False";
+else
+  echo "True";
+fi

--- a/test/library/standard/Spawn/doc-examples/example_writeBinary.skipif
+++ b/test/library/standard/Spawn/doc-examples/example_writeBinary.skipif
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-if command -v xxd >/dev/null 2>/dev/null; then
-  echo "False";
-else
-  echo "True";
-fi

--- a/test/memory/shannon/memmaxIntOnly.good
+++ b/test/memory/shannon/memmaxIntOnly.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: bad cast from string '1.1' to uint(64)
   <internal>:0: thrown here
+  <internal>:0: called from here
   <internal>:0: uncaught here

--- a/test/multilocale/bradc/configBadValue.good
+++ b/test/multilocale/bradc/configBadValue.good
@@ -1,3 +1,4 @@
 uncaught IllegalArgumentError: bad cast from string '3.2i' to int(64)
   <command line setting of 'intVal'>:0: thrown here
+  <command line setting of 'intVal'>:0: called from here
   <command line setting of 'intVal'>:0: uncaught here

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/example-pr-13203-b.comm-none.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/example-pr-13203-b.comm-none.good
@@ -2,4 +2,5 @@ uncaught SystemError: Bad file descriptor (Operation attempted on an invalid fil
   example-pr-13203-b.chpl:4: thrown here
   example-pr-13203-b.chpl:4: called from here
   example-pr-13203-b.chpl:4: called from here
+  example-pr-13203-b.chpl:4: called from here
   example-pr-13203-b.chpl:4: uncaught here

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/example-pr-13203-b.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/example-pr-13203-b.good
@@ -3,4 +3,5 @@ uncaught SystemError: Bad file descriptor (Operation attempted on an invalid fil
   example-pr-13203-b.chpl:4: called from here
   example-pr-13203-b.chpl:4: called from here
   example-pr-13203-b.chpl:4: called from here
+  example-pr-13203-b.chpl:4: called from here
   example-pr-13203-b.chpl:4: uncaught here

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/example-pr-13203-b.no-local.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/example-pr-13203-b.no-local.good
@@ -1,0 +1,1 @@
+example-pr-13203-b.good

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1-2.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1-2.good
@@ -1,6 +1,8 @@
 nt 2   nt2 1
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1 ... IllegalArgumentError: 2
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 asdf(1), throwing
 asdf(2), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1-20.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1-20.good
@@ -1,6 +1,8 @@
 nt 20   nt2 1
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1 ... IllegalArgumentError: 20
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 asdf(1), throwing
 asdf(2), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1-2000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1-2000.good
@@ -1,6 +1,8 @@
 nt 2000   nt2 1
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1 ... IllegalArgumentError: 2000
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 asdf(1), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1.good
@@ -1,6 +1,8 @@
 nt 1
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 1
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.10-2.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.10-2.good
@@ -1,6 +1,8 @@
 nt 2   nt2 10
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 10 ... IllegalArgumentError: 2
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 asdf(1), returning
 asdf(10), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.10-20.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.10-20.good
@@ -1,6 +1,8 @@
 nt 20   nt2 10
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 10 ... IllegalArgumentError: 20
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 asdf(1), returning
 asdf(10), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.10-2000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.10-2000.good
@@ -1,6 +1,8 @@
 nt 2000   nt2 10
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 10 ... IllegalArgumentError: 2000
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.10.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.10.good
@@ -1,6 +1,8 @@
 nt 10
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 10
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1000-2.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1000-2.good
@@ -1,6 +1,8 @@
 nt 2   nt2 1000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1000 ... IllegalArgumentError: 2
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1000-20.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1000-20.good
@@ -1,6 +1,8 @@
 nt 20   nt2 1000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1000 ... IllegalArgumentError: 20
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1000-2000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1000-2000.good
@@ -1,6 +1,8 @@
 nt 2000   nt2 1000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1000 ... IllegalArgumentError: 2000
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.1000.good
@@ -1,6 +1,8 @@
 nt 1000
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 1000
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.2.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.2.good
@@ -1,6 +1,8 @@
 nt 2
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 2
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.20.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.20.good
@@ -1,6 +1,8 @@
 nt 20
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 20
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.2000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-no-tlvy.2000.good
@@ -1,6 +1,8 @@
 nt 2000
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 2000
   int-no-tlvy.chpl:44: thrown here
+  int-no-tlvy.chpl:44: called from here
+  int-no-tlvy.chpl:44: called from here
   int-no-tlvy.chpl:44: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.1.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.1.good
@@ -1,5 +1,5 @@
 nt 1
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 1
-  :0: thrown here
+  int-tpvs.chpl:44: thrown here
   int-tpvs.chpl:44: uncaught here
 asdf(1), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.10.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.10.good
@@ -1,6 +1,6 @@
 nt 10
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 10
-  :0: thrown here
+  int-tpvs.chpl:44: thrown here
   int-tpvs.chpl:44: uncaught here
 asdf(1), returning
 asdf(10), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.1000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.1000.good
@@ -1,6 +1,6 @@
 nt 1000
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 1000
-  :0: thrown here
+  int-tpvs.chpl:44: thrown here
   int-tpvs.chpl:44: uncaught here
 asdf(1), returning
 asdf(10), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2-3.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2-3.good
@@ -1,6 +1,8 @@
 nt 3   nt2 2
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2 ... IllegalArgumentError: 3
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 asdf(1), returning
 asdf(10), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2-30.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2-30.good
@@ -1,6 +1,8 @@
 nt 30   nt2 2
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2 ... IllegalArgumentError: 30
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 asdf(1), returning
 asdf(10), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2-3000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2-3000.good
@@ -1,6 +1,8 @@
 nt 3000   nt2 2
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2 ... IllegalArgumentError: 3000
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2.good
@@ -1,6 +1,8 @@
 nt 2
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 2
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.20-3.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.20-3.good
@@ -1,6 +1,8 @@
 nt 3   nt2 20
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 20 ... IllegalArgumentError: 3
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 asdf(1), returning
 asdf(10), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.20-30.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.20-30.good
@@ -1,6 +1,8 @@
 nt 30   nt2 20
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 20 ... IllegalArgumentError: 30
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 asdf(1), returning
 asdf(10), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.20-3000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.20-3000.good
@@ -1,6 +1,8 @@
 nt 3000   nt2 20
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 20 ... IllegalArgumentError: 3000
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.20.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.20.good
@@ -1,6 +1,8 @@
 nt 20
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 20
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2000-3.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2000-3.good
@@ -1,6 +1,8 @@
 nt 3   nt2 2000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2000 ... IllegalArgumentError: 3
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2000-30.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2000-30.good
@@ -1,6 +1,8 @@
 nt 30   nt2 2000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2000 ... IllegalArgumentError: 30
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2000-3000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2000-3000.good
@@ -1,6 +1,8 @@
 nt 3000   nt2 2000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2000 ... IllegalArgumentError: 3000
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.2000.good
@@ -1,6 +1,8 @@
 nt 2000
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 2000
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.3.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.3.good
@@ -1,6 +1,8 @@
 nt 3
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 3
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.30.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.30.good
@@ -1,6 +1,8 @@
 nt 30
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 30
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.3000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/int-tpvs.3000.good
@@ -1,6 +1,8 @@
 nt 3000
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 3000
   int-tpvs.chpl:44: thrown here
+  int-tpvs.chpl:44: called from here
+  int-tpvs.chpl:44: called from here
   int-tpvs.chpl:44: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1-2.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1-2.good
@@ -1,6 +1,8 @@
 nt 2   nt2 1
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1 ... IllegalArgumentError: 2
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 asdf(1), throwing
 asdf(2), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1-20.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1-20.good
@@ -1,6 +1,8 @@
 nt 20   nt2 1
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1 ... IllegalArgumentError: 20
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 asdf(1), throwing
 asdf(2), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1-2000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1-2000.good
@@ -1,6 +1,8 @@
 nt 2000   nt2 1
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1 ... IllegalArgumentError: 2000
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 asdf(1), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1.good
@@ -1,6 +1,8 @@
 nt 1
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 1
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.10-2.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.10-2.good
@@ -1,6 +1,8 @@
 nt 2   nt2 10
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 10 ... IllegalArgumentError: 2
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 asdf(1), returning
 asdf(10), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.10-20.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.10-20.good
@@ -1,6 +1,8 @@
 nt 20   nt2 10
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 10 ... IllegalArgumentError: 20
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 asdf(1), returning
 asdf(10), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.10-2000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.10-2000.good
@@ -1,6 +1,8 @@
 nt 2000   nt2 10
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 10 ... IllegalArgumentError: 2000
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.10.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.10.good
@@ -1,6 +1,8 @@
 nt 10
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 10
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1000-2.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1000-2.good
@@ -1,6 +1,8 @@
 nt 2   nt2 1000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1000 ... IllegalArgumentError: 2
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1000-20.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1000-20.good
@@ -1,6 +1,8 @@
 nt 20   nt2 1000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1000 ... IllegalArgumentError: 20
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1000-2000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1000-2000.good
@@ -1,6 +1,8 @@
 nt 2000   nt2 1000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 1000 ... IllegalArgumentError: 2000
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.1000.good
@@ -1,6 +1,8 @@
 nt 1000
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 1000
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.2.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.2.good
@@ -1,6 +1,8 @@
 nt 2
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 2
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.20.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.20.good
@@ -1,6 +1,8 @@
 nt 20
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 20
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.2000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-no-tlvy.2000.good
@@ -1,6 +1,8 @@
 nt 2000
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 2000
   pod-no-tlvy.chpl:48: thrown here
+  pod-no-tlvy.chpl:48: called from here
+  pod-no-tlvy.chpl:48: called from here
   pod-no-tlvy.chpl:48: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.1.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.1.good
@@ -1,5 +1,5 @@
 nt 1
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 1
-  :0: thrown here
+  pod-tpvs.chpl:48: thrown here
   pod-tpvs.chpl:48: uncaught here
 asdf(1), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.10.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.10.good
@@ -1,6 +1,6 @@
 nt 10
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 10
-  :0: thrown here
+  pod-tpvs.chpl:48: thrown here
   pod-tpvs.chpl:48: uncaught here
 asdf(1), returning
 asdf(10), throwing

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.1000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.1000.good
@@ -1,6 +1,6 @@
 nt 1000
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 1000
-  :0: thrown here
+  pod-tpvs.chpl:48: thrown here
   pod-tpvs.chpl:48: uncaught here
 asdf(1), returning
 asdf(10), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2-3.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2-3.good
@@ -1,6 +1,8 @@
 nt 3   nt2 2
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2 ... IllegalArgumentError: 3
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 asdf(1), returning
 asdf(10), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2-30.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2-30.good
@@ -1,6 +1,8 @@
 nt 30   nt2 2
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2 ... IllegalArgumentError: 30
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 asdf(1), returning
 asdf(10), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2-3000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2-3000.good
@@ -1,6 +1,8 @@
 nt 3000   nt2 2
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2 ... IllegalArgumentError: 3000
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2.good
@@ -1,6 +1,8 @@
 nt 2
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 2
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.20-3.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.20-3.good
@@ -1,6 +1,8 @@
 nt 3   nt2 20
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 20 ... IllegalArgumentError: 3
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 asdf(1), returning
 asdf(10), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.20-30.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.20-30.good
@@ -1,6 +1,8 @@
 nt 30   nt2 20
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 20 ... IllegalArgumentError: 30
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 asdf(1), returning
 asdf(10), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.20-3000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.20-3000.good
@@ -1,6 +1,8 @@
 nt 3000   nt2 20
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 20 ... IllegalArgumentError: 3000
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.20.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.20.good
@@ -1,6 +1,8 @@
 nt 20
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 20
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2000-3.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2000-3.good
@@ -1,6 +1,8 @@
 nt 3   nt2 2000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2000 ... IllegalArgumentError: 3
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2000-30.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2000-30.good
@@ -1,6 +1,8 @@
 nt 30   nt2 2000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2000 ... IllegalArgumentError: 30
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 asdf(1), returning

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2000-3000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2000-3000.good
@@ -1,6 +1,8 @@
 nt 3000   nt2 2000
 uncaught TaskErrors: 2 errors: IllegalArgumentError: 2000 ... IllegalArgumentError: 3000
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.2000.good
@@ -1,6 +1,8 @@
 nt 2000
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 2000
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 starting task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.3.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.3.good
@@ -1,6 +1,8 @@
 nt 3
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 3
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.30.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.30.good
@@ -1,6 +1,8 @@
 nt 30
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 30
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 finished task

--- a/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.3000.good
+++ b/test/parallel/forall/task-private-vars/throwing-init-exprs/pod-tpvs.3000.good
@@ -1,6 +1,8 @@
 nt 3000
 uncaught TaskErrors: 1 errors: IllegalArgumentError: 3000
   pod-tpvs.chpl:48: thrown here
+  pod-tpvs.chpl:48: called from here
+  pod-tpvs.chpl:48: called from here
   pod-tpvs.chpl:48: uncaught here
 starting task
 starting task

--- a/test/statements/manage/CanAlwaysThrowWithinManage.good
+++ b/test/statements/manage/CanAlwaysThrowWithinManage.good
@@ -8,4 +8,5 @@ uncaught Error: It halts at the 'manage'!
   CanAlwaysThrowWithinManage.chpl:16: called from here
   CanAlwaysThrowWithinManage.chpl:6: called from here
   CanAlwaysThrowWithinManage.chpl:14: called from here
+  CanAlwaysThrowWithinManage.chpl:14: called from here
   CanAlwaysThrowWithinManage.chpl:14: uncaught here

--- a/test/studies/adventOfCode/2022/bugs/day02.bad
+++ b/test/studies/adventOfCode/2022/bugs/day02.bad
@@ -10,4 +10,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading ent
   day02.chpl:11: called from here
   day02.chpl:11: called from here
   day02.chpl:11: called from here
+  day02.chpl:11: called from here
   day02.chpl:11: uncaught here

--- a/test/studies/adventOfCode/2022/bugs/day02.skipif
+++ b/test/studies/adventOfCode/2022/bugs/day02.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM != none
+COMPOPTS <= --no-local

--- a/test/technotes/doc-examples/ErrorHandlingStrictMode.good
+++ b/test/technotes/doc-examples/ErrorHandlingStrictMode.good
@@ -1,3 +1,4 @@
 uncaught Error: ALWAYS
   ErrorHandlingStrictMode.chpl:22: thrown here
+  ErrorHandlingStrictMode.chpl:22: called from here
   ErrorHandlingStrictMode.chpl:22: uncaught here

--- a/test/trivial/shannon/readWriteBool.comm-none.good
+++ b/test/trivial/shannon/readWriteBool.comm-none.good
@@ -11,4 +11,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading boo
   readWriteBool.chpl:11: called from here
   readWriteBool.chpl:11: called from here
   readWriteBool.chpl:11: called from here
+  readWriteBool.chpl:11: called from here
   readWriteBool.chpl:11: uncaught here

--- a/test/trivial/shannon/readWriteBool.good
+++ b/test/trivial/shannon/readWriteBool.good
@@ -12,4 +12,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading boo
   readWriteBool.chpl:11: called from here
   readWriteBool.chpl:11: called from here
   readWriteBool.chpl:11: called from here
+  readWriteBool.chpl:11: called from here
   readWriteBool.chpl:11: uncaught here

--- a/test/trivial/shannon/readWriteBool.no-local.good
+++ b/test/trivial/shannon/readWriteBool.no-local.good
@@ -1,0 +1,1 @@
+readWriteBool.good

--- a/test/trivial/shannon/readWriteComplex.comm-none.good
+++ b/test/trivial/shannon/readWriteComplex.comm-none.good
@@ -14,4 +14,5 @@ uncaught BadFormatError: bad format: missing i when reading #.# + #.#i complex (
   readWriteComplex.chpl:8: called from here
   readWriteComplex.chpl:8: called from here
   readWriteComplex.chpl:8: called from here
+  readWriteComplex.chpl:8: called from here
   readWriteComplex.chpl:8: uncaught here

--- a/test/trivial/shannon/readWriteComplex.good
+++ b/test/trivial/shannon/readWriteComplex.good
@@ -15,4 +15,5 @@ uncaught BadFormatError: bad format: missing i when reading #.# + #.#i complex (
   readWriteComplex.chpl:8: called from here
   readWriteComplex.chpl:8: called from here
   readWriteComplex.chpl:8: called from here
+  readWriteComplex.chpl:8: called from here
   readWriteComplex.chpl:8: uncaught here

--- a/test/trivial/shannon/readWriteComplex.no-local.good
+++ b/test/trivial/shannon/readWriteComplex.no-local.good
@@ -1,0 +1,1 @@
+readWriteComplex.good

--- a/test/trivial/shannon/readWriteEnum.comm-none.good
+++ b/test/trivial/shannon/readWriteEnum.comm-none.good
@@ -10,4 +10,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading wee
   readWriteEnum.chpl:8: called from here
   readWriteEnum.chpl:8: called from here
   readWriteEnum.chpl:8: called from here
+  readWriteEnum.chpl:8: called from here
   readWriteEnum.chpl:8: uncaught here

--- a/test/trivial/shannon/readWriteEnum.good
+++ b/test/trivial/shannon/readWriteEnum.good
@@ -11,4 +11,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading wee
   readWriteEnum.chpl:8: called from here
   readWriteEnum.chpl:8: called from here
   readWriteEnum.chpl:8: called from here
+  readWriteEnum.chpl:8: called from here
   readWriteEnum.chpl:8: uncaught here

--- a/test/trivial/shannon/readWriteEnum.no-local.good
+++ b/test/trivial/shannon/readWriteEnum.no-local.good
@@ -1,0 +1,1 @@
+readWriteEnum.good

--- a/test/types/enum/readAbstractEnum.good
+++ b/test/types/enum/readAbstractEnum.good
@@ -3,4 +3,5 @@ F1
 uncaught SystemError: Invalid argument: Argument type mismatch in argument 0 (in string.format)
   readAbstractEnum.chpl:6: thrown here
   readAbstractEnum.chpl:6: called from here
+  readAbstractEnum.chpl:6: called from here
   readAbstractEnum.chpl:6: uncaught here

--- a/test/types/enum/readSemiAbstractEnumAsValue.1.no-local.good
+++ b/test/types/enum/readSemiAbstractEnumAsValue.1.no-local.good
@@ -1,0 +1,1 @@
+readSemiAbstractEnumAsValue.1.good

--- a/test/types/enum/readSemiAbstractEnumAsValue.2.no-local.good
+++ b/test/types/enum/readSemiAbstractEnumAsValue.2.no-local.good
@@ -1,0 +1,1 @@
+readSemiAbstractEnumAsValue.2.good

--- a/test/types/enum/writeAbstractEnumAsValue.good
+++ b/test/types/enum/writeAbstractEnumAsValue.good
@@ -4,4 +4,5 @@ F1
 uncaught SystemError: Invalid argument: Argument type mismatch in argument 0 (in string.format)
   writeAbstractEnumAsValue.chpl:6: thrown here
   writeAbstractEnumAsValue.chpl:6: called from here
+  writeAbstractEnumAsValue.chpl:6: called from here
   writeAbstractEnumAsValue.chpl:6: uncaught here

--- a/test/types/enum/writeSemiAbstractEnumAsValue.2.no-local.good
+++ b/test/types/enum/writeSemiAbstractEnumAsValue.2.no-local.good
@@ -1,0 +1,1 @@
+writeSemiAbstractEnumAsValue.2.good

--- a/test/types/enum/writeSemiAbstractEnumAsValue.no-local.good
+++ b/test/types/enum/writeSemiAbstractEnumAsValue.no-local.good
@@ -1,0 +1,1 @@
+writeSemiAbstractEnumAsValue.good

--- a/test/types/file/freadComplex.chpl
+++ b/test/types/file/freadComplex.chpl
@@ -6,7 +6,7 @@ var i: int = 0;
 var numTestCases: int = 8;
 
 while (i <= numTestCases) {
-  f.read(complexNumber);         
+  f.read(complexNumber);
   writeln(complexNumber);
   i += 1;
-}	
+}

--- a/test/types/file/freadComplex.comm-none.good
+++ b/test/types/file/freadComplex.comm-none.good
@@ -14,4 +14,5 @@ uncaught BadFormatError: bad format: missing i when reading #.# + #.#i complex (
   freadComplex.chpl:9: called from here
   freadComplex.chpl:9: called from here
   freadComplex.chpl:9: called from here
+  freadComplex.chpl:9: called from here
   freadComplex.chpl:9: uncaught here

--- a/test/types/file/freadComplex.good
+++ b/test/types/file/freadComplex.good
@@ -15,4 +15,5 @@ uncaught BadFormatError: bad format: missing i when reading #.# + #.#i complex (
   freadComplex.chpl:9: called from here
   freadComplex.chpl:9: called from here
   freadComplex.chpl:9: called from here
+  freadComplex.chpl:9: called from here
   freadComplex.chpl:9: uncaught here

--- a/test/types/file/freadComplex.no-local.good
+++ b/test/types/file/freadComplex.no-local.good
@@ -1,0 +1,1 @@
+freadComplex.good

--- a/test/types/file/freadIntFailed.good
+++ b/test/types/file/freadIntFailed.good
@@ -2,4 +2,5 @@ uncaught SystemError: Bad file descriptor: not readable (in file.reader with pat
   freadIntFailed.chpl:4: thrown here
   freadIntFailed.chpl:4: called from here
   freadIntFailed.chpl:4: called from here
+  freadIntFailed.chpl:4: called from here
   freadIntFailed.chpl:4: uncaught here

--- a/test/types/file/freadIntUnopenedFile.comm-none.good
+++ b/test/types/file/freadIntUnopenedFile.comm-none.good
@@ -2,4 +2,5 @@ uncaught SystemError: Bad file descriptor (Operation attempted on an invalid fil
   freadIntUnopenedFile.chpl:6: thrown here
   freadIntUnopenedFile.chpl:6: called from here
   freadIntUnopenedFile.chpl:6: called from here
+  freadIntUnopenedFile.chpl:6: called from here
   freadIntUnopenedFile.chpl:6: uncaught here

--- a/test/types/file/freadIntUnopenedFile.good
+++ b/test/types/file/freadIntUnopenedFile.good
@@ -3,4 +3,5 @@ uncaught SystemError: Bad file descriptor (Operation attempted on an invalid fil
   freadIntUnopenedFile.chpl:6: called from here
   freadIntUnopenedFile.chpl:6: called from here
   freadIntUnopenedFile.chpl:6: called from here
+  freadIntUnopenedFile.chpl:6: called from here
   freadIntUnopenedFile.chpl:6: uncaught here

--- a/test/types/file/freadIntUnopenedFile.no-local.good
+++ b/test/types/file/freadIntUnopenedFile.no-local.good
@@ -1,0 +1,1 @@
+freadIntUnopenedFile.good

--- a/test/types/file/freadNoFloat.comm-none.good
+++ b/test/types/file/freadNoFloat.comm-none.good
@@ -3,7 +3,7 @@ uncaught BadFormatError: bad format: malformed number (while reading real(64) wi
   freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here
-  freadNoFloat.chpl:6: called from here
+  freadNoFloat.chpl:6: caalled from here
   freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here

--- a/test/types/file/freadNoFloat.comm-none.good
+++ b/test/types/file/freadNoFloat.comm-none.good
@@ -3,7 +3,8 @@ uncaught BadFormatError: bad format: malformed number (while reading real(64) wi
   freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here
-  freadNoFloat.chpl:6: caalled from here
+  freadNoFloat.chpl:6: called from here
+  freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here

--- a/test/types/file/freadNoFloat.good
+++ b/test/types/file/freadNoFloat.good
@@ -9,4 +9,5 @@ uncaught BadFormatError: bad format: malformed number (while reading real(64) wi
   freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: called from here
+  freadNoFloat.chpl:6: called from here
   freadNoFloat.chpl:6: uncaught here

--- a/test/types/file/freadNoFloat.no-local.good
+++ b/test/types/file/freadNoFloat.no-local.good
@@ -1,0 +1,1 @@
+freadNoFloat.good

--- a/test/types/file/freadNoInt.comm-none.good
+++ b/test/types/file/freadNoInt.comm-none.good
@@ -8,4 +8,5 @@ uncaught BadFormatError: bad format: malformed number (while reading int(64) wit
   freadNoInt.chpl:6: called from here
   freadNoInt.chpl:6: called from here
   freadNoInt.chpl:6: called from here
+  freadNoInt.chpl:6: called from here
   freadNoInt.chpl:6: uncaught here

--- a/test/types/file/freadNoInt.good
+++ b/test/types/file/freadNoInt.good
@@ -9,4 +9,5 @@ uncaught BadFormatError: bad format: malformed number (while reading int(64) wit
   freadNoInt.chpl:6: called from here
   freadNoInt.chpl:6: called from here
   freadNoInt.chpl:6: called from here
+  freadNoInt.chpl:6: called from here
   freadNoInt.chpl:6: uncaught here

--- a/test/types/file/freadNoInt.no-local.good
+++ b/test/types/file/freadNoInt.no-local.good
@@ -1,0 +1,1 @@
+freadNoInt.good

--- a/test/types/file/freadNotABoolean.comm-none.good
+++ b/test/types/file/freadNotABoolean.comm-none.good
@@ -8,4 +8,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading boo
   freadNotABoolean.chpl:7: called from here
   freadNotABoolean.chpl:7: called from here
   freadNotABoolean.chpl:7: called from here
+  freadNotABoolean.chpl:7: called from here
   freadNotABoolean.chpl:7: uncaught here

--- a/test/types/file/freadNotABoolean.good
+++ b/test/types/file/freadNotABoolean.good
@@ -9,4 +9,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading boo
   freadNotABoolean.chpl:7: called from here
   freadNotABoolean.chpl:7: called from here
   freadNotABoolean.chpl:7: called from here
+  freadNotABoolean.chpl:7: called from here
   freadNotABoolean.chpl:7: uncaught here

--- a/test/types/file/freadNotABoolean.no-local.good
+++ b/test/types/file/freadNotABoolean.no-local.good
@@ -1,0 +1,1 @@
+freadNotABoolean.good

--- a/test/types/file/fwriteIntFailed.good
+++ b/test/types/file/fwriteIntFailed.good
@@ -2,4 +2,5 @@ uncaught SystemError: Bad file descriptor: not writeable (in file.writer with pa
   fwriteIntFailed.chpl:4: thrown here
   fwriteIntFailed.chpl:4: called from here
   fwriteIntFailed.chpl:4: called from here
+  fwriteIntFailed.chpl:4: called from here
   fwriteIntFailed.chpl:4: uncaught here

--- a/test/types/file/unableToOpenFile.good
+++ b/test/types/file/unableToOpenFile.good
@@ -2,4 +2,5 @@ uncaught FileNotFoundError: No such file or directory (in open with path "_test_
   unableToOpenFile.chpl:3: thrown here
   unableToOpenFile.chpl:3: called from here
   unableToOpenFile.chpl:3: called from here
+  unableToOpenFile.chpl:3: called from here
   unableToOpenFile.chpl:3: uncaught here

--- a/test/types/string/ilseqByteSlice.good
+++ b/test/types/string/ilseqByteSlice.good
@@ -5,4 +5,5 @@ Türkçe
 uncaught CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 2 is not the first byte of a UTF-8 codepoint
   ilseqByteSlice.chpl:4: thrown here
   ilseqByteSlice.chpl:4: called from here
+  ilseqByteSlice.chpl:4: called from here
   ilseqByteSlice.chpl:4: uncaught here

--- a/test/types/string/ilseqByteSlice2.good
+++ b/test/types/string/ilseqByteSlice2.good
@@ -1,4 +1,5 @@
 uncaught CodepointSplitError: Attempting to split a multi-byte codepoint. Byte-based string slice is not aligned to codepoint boundaries. The byte at low boundary 4 is not the first byte of a UTF-8 codepoint
   ilseqByteSlice2.chpl:4: thrown here
   ilseqByteSlice2.chpl:4: called from here
+  ilseqByteSlice2.chpl:4: called from here
   ilseqByteSlice2.chpl:4: uncaught here

--- a/test/types/unions/union-init-throws.good
+++ b/test/types/unions/union-init-throws.good
@@ -6,4 +6,5 @@ u8 got DupFieldError:
 u9 got DupFieldError: 
 uncaught DupFieldError: 
   union-init-throws.chpl:31: thrown here
-  union-init-throws.chpl:22: uncaught here
+  union-init-throws.chpl:22: called from here
+  union-init-throws.chpl:92: uncaught here

--- a/test/types/unions/union-readWrite.bad
+++ b/test/types/unions/union-readWrite.bad
@@ -16,4 +16,5 @@ uncaught BadFormatError: bad format: missing expected literal (while reading str
   union-readWrite.chpl:38: called from here
   union-readWrite.chpl:38: called from here
   union-readWrite.chpl:38: called from here
+  union-readWrite.chpl:38: called from here
   union-readWrite.chpl:38: uncaught here

--- a/test/types/unions/union-readWrite.skipif
+++ b/test/types/unions/union-readWrite.skipif
@@ -1,0 +1,2 @@
+CHPL_COMM != none
+COMPOPTS <= --no-local

--- a/test/unstable/assertEof.good
+++ b/test/unstable/assertEof.good
@@ -5,4 +5,5 @@ uncaught IoError: Input/output error (assert failed - Not at EOF with path "asse
   assertEof.chpl:30: thrown here
   assertEof.chpl:30: called from here
   assertEof.chpl:30: called from here
+  assertEof.chpl:30: called from here
   assertEof.chpl:30: uncaught here


### PR DESCRIPTION
Improves the stacktraces for Errors from aggregates like unions and records, which were not being properly tracked

- [x] paratest w/wo gasnet, paratest -no-local

[Reviewed by @benharsh]