### PR TITLE
Ensure nightly failure mail sends when generating mail fails

### DIFF
--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -67,7 +67,7 @@ jobs:
 
           [[ $num_jobs -eq 1 ]] && plural="" || plural="s"
 
-          cat << EOF > ${{ env.EMAIL_BODY_FILENAME }}
+          cat << EOF > "$EMAIL_BODY_FILENAME"
           <h3>The following GitHub Actions job$plural failed:</h3>
 
           <ul>
@@ -88,7 +88,7 @@ jobs:
           </ul>
           EOF
 
-          cat ${{ env.EMAIL_BODY_FILENAME }}
+          cat "$EMAIL_BODY_FILENAME"
       - name: Send mail
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
         with:

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -90,6 +90,7 @@ jobs:
 
           cat "$EMAIL_BODY_FILENAME"
       - name: Send mail
+        if: always()
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
         with:
            # Required mail server address if not connection_url:

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -88,7 +88,7 @@ jobs:
           </ul>
           EOF
 
-          cat email.html
+          cat ${{ env.EMAIL_BODY_FILENAME }}
       - name: Send mail
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
         with:

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -99,7 +99,7 @@ jobs:
         if: always()
         run: |
           cat "$EMAIL_BODY_FILENAME"
-      - name: Send mail
+      - name: send mail
         if: always()
         uses: dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59 # v18
         with:

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -95,7 +95,9 @@ jobs:
             <li>Triggering event name: ${{ github.event_name }}</li>
           </ul>
           EOF
-
+      - name: print email body
+        if: always()
+        run: |
           cat "$EMAIL_BODY_FILENAME"
       - name: Send mail
         if: always()

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -49,6 +49,14 @@ jobs:
       - name: determine date
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+      - name: generate fallback email body
+        run: |
+          cat << EOF > "$EMAIL_BODY_FILENAME"
+          GitHub Actions nightly run failed, and an additional failure was
+          encountered in generating a failure mail.
+
+          Run ID: ${{ github.run_id }}
+          EOF
       - name: generate email body
         run: |
           gh api /repos/chapel-lang/chapel/commits/${{ github.sha }} | tee commit.json

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -88,9 +88,9 @@ jobs:
 
           <p>GitHub Actions run info:</p>
           <ul>
-            <li>SHA: ${{ github.sha }}</li>
+            <li>SHA: <a href="https://github.com/chapel-lang/chapel/commit/${{ github.sha }}">${{ github.sha }}</a></li>
             <li>Run ID: ${{ github.run_id }}</li>
-            <li>Run attempt #: ${{ github.run_attempt }}</li>
+            <li>Run attempt: <a href="https://github.com/chapel-lang/chapel/actions/runs/${{ github.run_attempt }}">${{ github.run_attempt }}</a></li>
             <li>Run number: ${{ github.run_number }}</li>
             <li>Triggering event name: ${{ github.event_name }}</li>
           </ul>


### PR DESCRIPTION
Adjust the `send-failure-mail` job to send a (simplified and less useful) mail when generating the email body fails.

Since the email body generation relies on calls to the GitHub API, it might fail, but we don't want this failure to go unnoticed.

While at it, also add some useful links (to the commit we ran on, and to the run in GA) to the typical email body.

[iterating on prototype, not reviewed]