### PR TITLE
Fix flipped condition for grabbing failed jobs

### DIFF
--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -64,7 +64,7 @@ jobs:
 
           message=$(jq -r '.commit.message' commit.json | head -n 1)
           num_jobs=$(jq '.jobs | length' jobs.json)
-          readarray -t failed_job_ids < <(jq '.jobs[] | select(.status != "completed" or .conclusion == "success" ) | .id' jobs.json)
+          readarray -t failed_job_ids < <(jq '.jobs[] | select(.status != "completed" or .conclusion != "success" ) | .id' jobs.json)
 
           failed_jobs_html=""
           for id in "${failed_job_ids[@]}"; do


### PR DESCRIPTION
Fix incorrect condition for finding failed GA jobs, which was actually grabbing succeeded jobs.

Follow up to https://github.com/chapel-lang/chapel/pull/29263.

[trivial, not reviewed]