### PR TITLE
Fix assorted typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -360,7 +360,7 @@ Developer-oriented changes: Testing System
 Developer-oriented changes: Tool Improvements
 ---------------------------------------------
 * improved the handling of Chapel breakpoints in LLDB 22+
-* modernized the `c2chapel` testing infastructure
+* modernized the `c2chapel` testing infrastructure
 * rewrote the Mason build system to allow for external dependencies
 * rewrote the Mason build system to work independently of Chapel's
 * rewrote `mason new` and `mason init` to be more robust

--- a/compiler/AST/AggregateType.cpp
+++ b/compiler/AST/AggregateType.cpp
@@ -347,7 +347,7 @@ static bool isFieldTypeExprGeneric(Expr* typeExpr,
         // make this type generic.
         //
         // Create a new 'visited' for each recursive call here to avoid
-        // polluting subseqeunt fields that oughtn't be marked recursive.
+        // polluting subsequent fields that oughtn't be marked recursive.
         // Only types we've seen "on the path" to the current type should
         // be in the visited set.
         bool foundGenericWithoutInit = false;

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -970,7 +970,7 @@ static void genFilenameTable() {
 //    -- If the the Chapel name starts with 'chpl_', then omit that function.
 //    -- If the the C name starts with 'chpl_', then omit that function.
 //    -- A non-extern function can always be renamed.
-//    -- An extern function can be renamed only if there is 1 occurence.
+//    -- An extern function can be renamed only if there is 1 occurrence.
 //
 class UnwindTable {
   // Use an ordered map to sort the table contents in alphabetical order.

--- a/compiler/include/pass-manager-passes.h
+++ b/compiler/include/pass-manager-passes.h
@@ -250,7 +250,7 @@ class AdjustSymbolTypes : public PassTU<Symbol*, SymExpr*> {
 
 /**
   This pass adjusts any symbol with a procedure-pointer type so that it is
-  a new, similiar type that has line/file formals appended.
+  a new, similar type that has line/file formals appended.
 
   After this pass the AST will be in an inconsistent state, and the pass
   'InsertLineNumbers' must be run in order to fix it up.
@@ -322,7 +322,7 @@ class StreamlineProcPtrTypesForCodegen : public AdjustSymbolTypes {
 
 /**
   This pass adjusts any symbol with a procedure-pointer type so that it is
-  a new, similiar type where all of its widenable components are widened.
+  a new, similar type where all of its widenable components are widened.
   A widenable component is e.g., a 'ref' formal or a 'class' formal.
 
   After this pass the AST will be in an inconsistent state, and the pass

--- a/compiler/llvm/clangUtil.cpp
+++ b/compiler/llvm/clangUtil.cpp
@@ -2001,7 +2001,7 @@ static llvm::TargetOptions getTargetOptions(
 #if LLVM_VERSION_MAJOR < 22
     // NOTE (Jade 3-18-26): its not clear why LLVM removed "UnsafeFPMath", and
     // what the proper replacement is, if any.
-    // They may have removed it due to it being redudant and so
+    // They may have removed it due to it being redundant and so
     // everything may just work fine
     Options.UnsafeFPMath = 1; // e.g. FSIN instruction
 #endif
@@ -2961,7 +2961,7 @@ static void helpComputeClangArgs(std::string& clangCC,
   }
 
   // add a -iquote. so we can find headers named on command line in same dir
-  // using iquote over I to prevent accidently overriding system headers
+  // using iquote over I to prevent accidentally overriding system headers
   clangCCArgs.push_back("-iquote.");
 
   // add a -I for the generated code directory

--- a/compiler/llvm/llvmDebug.cpp
+++ b/compiler/llvm/llvmDebug.cpp
@@ -639,7 +639,7 @@ struct ConstructObject : public ConstructDIType {
       debugData->getType(CLASS_ID_TYPE)
     );
     EltTys.push_back(cidDITy);
-    // since dtObject has a single field, we can directly assume the size and alignent to
+    // since dtObject has a single field, we can directly assume the size and alignment to
     // be the same as its single field
     llvm::DIType* N = DIB->createStructType(
       defInfo.maybeScope(),
@@ -796,7 +796,7 @@ struct ConstructEnum : public ConstructDIType {
 #if LLVM_VERSION_MAJOR >= 18
     RuntimeLang,
 #endif
-      "", /* UniqueIdentifer */
+      "", /* UniqueIdentifier */
       true /* isScoped */
     );
     enumType->symbol->llvmDIType = N;

--- a/compiler/passes/convert-typed-uast.cpp
+++ b/compiler/passes/convert-typed-uast.cpp
@@ -470,7 +470,7 @@ struct TConverter final : UastConverter,
   std::vector<const uast::Module*> submodulesEncountered;
 
   // Handles for standard/internal modules (these are not global
-  // variables in case we'd like to remove those somewhow later).
+  // variables in case we'd like to remove those somehow later).
   ModuleSymbol* modChapelBase = nullptr;
   ModuleSymbol* modChapelTuple = nullptr;
   ModuleSymbol* modIO = nullptr;
@@ -2668,7 +2668,7 @@ struct ConvertTypeHelper {
         d = addNilableToDecorator(d);
       }
 
-      ret = at->getDecoratedClass(d); // unamanged / borrowed is just the class type at this point
+      ret = at->getDecoratedClass(d); // unmanaged / borrowed is just the class type at this point
     } else {
       // owned/shared should have had a substitution for chpl_t
       INT_ASSERT(!manager->substitutions().empty());
@@ -4395,7 +4395,7 @@ Expr* TConverter::codegenGetField(const AstNode* recvAst,
 }
 
 // Gets its own little helper for now in the event that finding the implicit
-// this becomes more compilcated down the road, e.g., for nested functions
+// this becomes more complicated down the road, e.g., for nested functions
 Expr* TConverter::codegenImplicitThis(RV& rv) {
   INT_ASSERT(cur.fnSymbol && cur.fnSymbol->isMethod());
   return new SymExpr(cur.fnSymbol->_this);
@@ -4869,7 +4869,7 @@ Expr* TConverter::convertNamedCallOrNull(const Call* node, RV& rv) {
     actualAsts.insert(actualAsts.begin(), fn->thisFormal());
   }
 
-  // No need to resolve assignment betwen types
+  // No need to resolve assignment between types
   if (ci.name() == USTR("=") &&
       (ci.actual(0).type().isType() || ci.actual(0).type().isParam())) {
     return TC_ELIDED(this, node);

--- a/compiler/passes/flattenFunctions.cpp
+++ b/compiler/passes/flattenFunctions.cpp
@@ -142,7 +142,7 @@ shouldPropagateOuterArg(Symbol* sym, FnSymbol* parentFn, FnSymbol* calledFn) {
 }
 
 // Does this look like an outer variable, but won't end up being one?
-// Specifcially, toLeader and toFollower might insert references to
+// Specifically, toLeader and toFollower might insert references to
 // the iterator fn's formals, but those will turn into field access and
 // stop being outer uses. Replacing them with an alias when flattening
 // would preclude this eventual transformation and cause issues.

--- a/compiler/passes/parallel.cpp
+++ b/compiler/passes/parallel.cpp
@@ -1147,7 +1147,7 @@ makeHeapAllocations() {
           call->getStmtExpr()->insertBefore(new CallExpr(PRIM_MOVE, tmp, new CallExpr(PRIM_GET_MEMBER_VALUE, use->symbol(), heapType->getField(1))));
           use->replace(new SymExpr(tmp));
           if (call->isPrimitive(PRIM_ZERO_VARIABLE)) {
-            // aftering zeroing the value, we need to set it back
+            // after zeroing the value, we need to set it back
             // otherwise its a dead store
             call->getStmtExpr()->insertAfter(
               new CallExpr(PRIM_SET_MEMBER, use->symbol(), heapType->getField(1), tmp));

--- a/compiler/passes/splitInit.cpp
+++ b/compiler/passes/splitInit.cpp
@@ -787,7 +787,7 @@ static ReturnInfo doFindCopyElisionPoints(Expr* start,
   if (start == NULL)
     return false;
 
-  // Process defers after we're done with 'start', in reverse order of appearence
+  // Process defers after we're done with 'start', in reverse order of appearance
   llvm::SmallVector<DeferStmt*, 4> defers;
   auto clearDefers = [&]() {
     while (!defers.empty()) {

--- a/compiler/resolution/callDestructors.cpp
+++ b/compiler/resolution/callDestructors.cpp
@@ -849,7 +849,7 @@ void ReturnByRef::transformMove(CallExpr* moveExpr)
         // will need to deep-copy the result in non-'ref' situations
         // e.g., var B = A[2..n-1]; or var B = A.reshape(2..n-1) so
         // will need to autodestroy the result at the end of the scope
-        // and recgonize it as an array view in other situations.  Mark
+        // and recognize it as an array view in other situations.  Mark
         // it as an array view to help with this in later passes.
         //
         SymExpr* rhsExpr = toSymExpr(copyExpr->get(1));

--- a/compiler/resolution/functionResolution.cpp
+++ b/compiler/resolution/functionResolution.cpp
@@ -3592,7 +3592,7 @@ struct CandidateSearchState {
   // so that we can revisit them for error reporting. The lists (
   // visible -> most applicable -> candidates) trickle down into the next.
   // All of them only ever grow, with numVisitedVis and numVisitedMA tracking
-  // the point up to which all candiddates have been moved to the successive list
+  // the point up to which all candidates have been moved to the successive list
   // if they needed to be. The flow is as follows:
   //   1. In each potential scope (call and POI(s)), visible functions get
   //      placed into `visibleFns`.
@@ -3615,7 +3615,7 @@ struct CandidateSearchState {
     INT_ASSERT(visInfo.poiDepth == -1); // we have not used it
   }
 
-  bool tryFindVisibileCandidatesForExplicitFn();
+  bool tryFindVisibleCandidatesForExplicitFn();
   void searchOnePoiLevel();
   void skipOnePoiLevel();
   void findVisibleFunctionsAndCandidates();
@@ -4362,7 +4362,7 @@ static FnSymbol* resolveNormalCall(CallInfo& info, check_state_t checkState, Poi
   bool considerNonPoi = (poiMode != PoiSearchMode::POI_ONLY);
   bool considerPoi = (poiMode != PoiSearchMode::NON_POI_ONLY);
 
-  if (searchState.tryFindVisibileCandidatesForExplicitFn()) {
+  if (searchState.tryFindVisibleCandidatesForExplicitFn()) {
     /* the function was explicitly specified via FnSymbol*. Don't search
        for others and don't consider POI */
     poiMode = PoiSearchMode::NON_POI_ONLY;
@@ -4373,7 +4373,7 @@ static FnSymbol* resolveNormalCall(CallInfo& info, check_state_t checkState, Poi
   } else {
     /* At this point, the top-level POI level is the regular scope of the call
        (so it's not really POI). This was configured as part of searchState's
-       constructor. So, this brach is the non-POI candidate search, which
+       constructor. So, this branch is the non-POI candidate search, which
        always happens. */
     searchState.searchOnePoiLevel();
   }
@@ -4408,7 +4408,7 @@ static FnSymbol* resolveNormalCall(CallInfo& info, check_state_t checkState, Poi
   // At this point, we have found no non-POI candidates, neither in the
   // original type nor in any fields it forwards. Time to move on to POI.
   if (considerPoi) {
-    // Ok, no forwaring candidates found without POI. Now move on to
+    // Ok, no forwarding candidates found without POI. Now move on to
     // our POI candidates.
     if (candidates.n == 0 && visInfo.currStart != nullptr && scopeUsed != visInfo.currStart) {
       searchState.findVisibleFunctionsAndCandidates();
@@ -5633,7 +5633,7 @@ void advanceCurrStart(VisibilityInfo& visInfo) {
   visInfo.nextPOI = NULL;
 }
 
-bool CandidateSearchState::tryFindVisibileCandidatesForExplicitFn() {
+bool CandidateSearchState::tryFindVisibleCandidatesForExplicitFn() {
   CallExpr* call = info.call;
   FnSymbol* fn   = call->resolvedFunction();
   Vec<FnSymbol*> visibleFns;

--- a/compiler/resolution/generics.cpp
+++ b/compiler/resolution/generics.cpp
@@ -694,7 +694,7 @@ Symbol* getSubstitutionFromDefaultValue(ArgSymbol* formal,
     // 2. Other formals. These formals cannot be generic, but they do allow
     //    coercions (e.g., passing 'nil' to 'borrowed C?'). However, since
     //    getInstantiationType returned NULL, even if a coercion is possible,
-    //    it doesn't provide enough type information to isntantiate the formal,
+    //    it doesn't provide enough type information to instantiate the formal,
     //    leaving it generic.
     //
     // We will issue an error for these, but later. That way, if this

--- a/doc/rst/language/spec/expressions.rst
+++ b/doc/rst/language/spec/expressions.rst
@@ -947,7 +947,7 @@ Exponentiation Operators
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The exponentiation operator, ``**``, computes the value of the first
-operand raised to the power of the second, potentially appoximated by
+operand raised to the power of the second, potentially approximated by
 the limits of the numeric representations.
 
 .. code-block:: chapel

--- a/doc/rst/language/spec/types.rst
+++ b/doc/rst/language/spec/types.rst
@@ -420,7 +420,7 @@ include ``imag(32)`` and ``imag(64)``.
 
    The imaginary type is included as a distinct type from ``real`` and
    ``complex`` types for a number of reasons. Primarily, it allows for direct,
-   efficent computation between ``real`` or ``imag`` values. Developers do not
+   efficient computation between ``real`` or ``imag`` values. Developers do not
    need to manually track which floating point values are ``real`` vs.
    ``imag``, nor do they need to promote everything to a ``complex`` value with
    a zero component. This avoids numeric instabilities, maintains more precise

--- a/doc/rst/language/spec/variables.rst
+++ b/doc/rst/language/spec/variables.rst
@@ -675,7 +675,7 @@ Parameter expressions are restricted to the following constructs:
 Parameter values and non-parameter values may be mixed in the same expression,
 but the result of the expression will only be a parameter if all of its
 sub-expressions are parameters. The notable exception are the two
-short-cuirting logical operators ``&&`` and ``||``. They will not evaluate
+short-circuiting logical operators ``&&`` and ``||``. They will not evaluate
 their second operand if the first operand is sufficient to determine the result
 of the expression. In such cases, the result of the expression will be a
 parameter even if the second operand is not a parameter.

--- a/doc/rst/platforms/networks/infiniband.rst
+++ b/doc/rst/platforms/networks/infiniband.rst
@@ -376,7 +376,7 @@ allows the blocking progress thread to be bound to a specific core:
 This combination dedicates a core for the receive progress thread (as
 well as the PSHM progress thread, if using co-locales). That core will be
 dedicated to improving communication performance and will not be
-avaliable for other computation. Note that it is possible to dedicate a
+available for other computation. Note that it is possible to dedicate a
 core for the PSHM progress thread without changing the receive progress
 thread by setting only the first of these.
 

--- a/doc/rst/platforms/riscv.rst
+++ b/doc/rst/platforms/riscv.rst
@@ -26,7 +26,7 @@ One working example for building Chapel on RISC-V is:
     make -j
 
 The mimalloc and cstdlib allocators are confirmed to work, jemalloc currently does not.
-To learn more about the different alloocators available in Chapel, see :ref:`readme-chplenv.CHPL_HOST_MEM` and :ref:`readme-chplenv.CHPL_TARGET_MEM`.
+To learn more about the different allocators available in Chapel, see :ref:`readme-chplenv.CHPL_HOST_MEM` and :ref:`readme-chplenv.CHPL_TARGET_MEM`.
 Using mimalloc (instead of cstdlib) and enabling LLVM is expected to give better performance.
 This particular example builds the bundled copy of LLVM included with the Chapel source, but the mechanisms for using another installation of LLVM will also work.
 See :ref:`readme-chplenv.CHPL_LLVM` for details on how to do that.

--- a/doc/rst/technotes/optimization.rst
+++ b/doc/rst/technotes/optimization.rst
@@ -248,7 +248,7 @@ highest-performing configuration for your system.
 
      * if you are using ``CHPL_LLVM=system``, it's a good idea to match the
        version of LLVM bundled in the Chapel release if possible as this
-       has recieved the most attention and testing (see also
+       has received the most attention and testing (see also
        :ref:`readme-chplenv.CHPL_LLVM`)
 
  * For multi-locale programs, use a high-performance networking configuration
@@ -340,7 +340,7 @@ Network-specific communication settings
       offers a similar capability for InfiniBand
 
 ..
-  comment: cover ``--llvm-wide-opt`` when it becomes less experemental
+  comment: cover ``--llvm-wide-opt`` when it becomes less experimental
 
 Fundamental Issues
 ------------------
@@ -649,7 +649,7 @@ How can load imbalance be identified?
 
 How can load imbalance be addressed?
 
- * There are often ways to improve the algorthim to address load
+ * There are often ways to improve the algorithm to address load
    imbalance. For example, graph partitioners are an important technology
    that can help one balance the storage of a data structure and the
    computation that goes with it. More generally, you might be able to

--- a/doc/rst/tools/chplcheck/chplcheck.rst
+++ b/doc/rst/tools/chplcheck/chplcheck.rst
@@ -452,7 +452,7 @@ Settings
 Some rules may need to be configurable from the command line. For example, a
 ``TabSize`` rule might need to know what the tab size is set to. Rules can
 declare what settings they need with the ``settings`` argument, which is a list
-of setting names. Settings that begin with ``.`` are consided local to the rule,
+of setting names. Settings that begin with ``.`` are considered local to the rule,
 while settings that do not are considered global. For example, the following
 rule declares rule ``TabSize`` with a setting ``Size``:
 

--- a/doc/rst/tools/mason/guide/ci.rst
+++ b/doc/rst/tools/mason/guide/ci.rst
@@ -22,7 +22,7 @@ applied to other CI systems as well.
 Using Containers
 ~~~~~~~~~~~~~~~~
 
-Using the prebuild Chapel Dockerhub images is a very easy way to get started
+Using the prebuilt Chapel Dockerhub images is a very easy way to get started
 with CI testing of Mason packages. A very simple CI workflow using the
 Dockerhub images might look like the following:
 

--- a/doc/rst/usingchapel/chplenv.rst
+++ b/doc/rst/usingchapel/chplenv.rst
@@ -657,7 +657,7 @@ CHPL_NETWORK_ATOMICS
    ``CHPL_COMM``. Note that with ``CHPL_NETWORK_ATOMICS=ofi`` support for
    network atomics is provider-specific, and the provider is selected at
    runtime. If the selected provider does not support network atomics then
-   atomics will be implemeted using active messages and processor atomics.
+   atomics will be implemented using active messages and processor atomics.
 
    Current options are:
 

--- a/doc/rst/usingchapel/launcher.rst
+++ b/doc/rst/usingchapel/launcher.rst
@@ -294,7 +294,7 @@ Common Slurm Settings
     export CHPL_LAUNCHER_WALLTIME=00:10:00
 
 * If you need to pass more arguments to slurm, you can use the slurm environment
-  variable for the option. Alternatibvey, you can pass extra arguments through
+  variable for the option. Alternatively, you can pass extra arguments through
   the ``--system-launcher-flags`` flag. For example, to pass ``--account=acct`` to
   slurm, you can use:
 

--- a/frontend/include/chpl/framework/query-impl.h
+++ b/frontend/include/chpl/framework/query-impl.h
@@ -730,7 +730,7 @@ Context::querySetterUpdateResult(
 
   To do this in a way that works out of the box using the query system,
   use the QUERY_STORE_RESULT macro, which sets certain flags to avoid
-  running into these issues (but could result in redunant recomputations).
+  running into these issues (but could result in redundant recomputations).
  */
 #define QUERY_UNSAFE_STORE_RESULT(func, context, result, ...) \
   context->querySetterUpdateResult(func, \

--- a/frontend/include/chpl/resolution/BranchSensitiveVisitor.h
+++ b/frontend/include/chpl/resolution/BranchSensitiveVisitor.h
@@ -32,7 +32,7 @@ namespace resolution {
   Specifically, it tracks whether the program has returned, thrown, invoked 'break',
   or invoked 'continue'. This is used in various program analyses to avoid
   reasoning about code that's unreachable. It is also used in some analyses
-  for other reasons (e.g. if a frame doesn't initialze a split-init'ed variable,
+  for other reasons (e.g. if a frame doesn't initialize a split-init'ed variable,
   but throws, that variable is still eligible for split-init).
  */
 struct ControlFlowInfo {
@@ -236,7 +236,7 @@ struct DefaultFrame : public BaseFrame<DefaultFrame> {
   are intended to perform that work. For other visitors which operates on
   results of the resolution process, these methods are intended to simply
   access that (pre-computed) information. Finally, 'traverseNode' is used
-  when "comitting" to a 'param'-known path.
+  when "committing" to a 'param'-known path.
 
   To call into the conditional/select logic, use 'branchSensitivelyTraverse'.
 
@@ -594,18 +594,18 @@ struct BranchSensitiveVisitor {
     return false;
   }
 
-  /** Overriden by subclasses to determine the value of a when case expression.
+  /** Overridden by subclasses to determine the value of a when case expression.
       This is used for evaluating short-circuited / 'param' known (or not) When statements. */
   virtual const types::Param* determineWhenCaseValue(const uast::AstNode* ast, ExtraData extraData) = 0;
 
-  /** Overriden by subclasses to determine the value of an if condition.
+  /** Overridden by subclasses to determine the value of an if condition.
       This is used for evaluating short-circuited / 'param known' (or not) Conditional statements. */
   virtual const types::Param* determineIfValue(const uast::AstNode* ast, ExtraData extraData) = 0;
 
   bool isParamTrue(const types::Param* param) { return param && param->isNonZero(); }
   bool isParamFalse(const types::Param* param) { return param && param->isZero(); }
 
-  /** Overriden by subclasses to traverse a node using their visitor startegy.
+  /** Overridden by subclasses to traverse a node using their visitor strategy.
       This is used for entering bodies of 'param'-known branches. */
   virtual void traverseNode(const uast::AstNode* ast, ExtraData extraData) = 0;
 

--- a/frontend/include/chpl/resolution/can-pass.h
+++ b/frontend/include/chpl/resolution/can-pass.h
@@ -236,7 +236,7 @@ CanPassResult canPassScalar(Context* context,
    'instances' is an instantiation of a type with substitutions 'generics'.
 
    If 'allowMissing' is true, considers missing substitutions in 'generics'
-   to be "any type". Otherwise, requires that each susbtitution in
+   to be "any type". Otherwise, requires that each substitution in
    instances is matched by an existing substitution in generics. */
 bool canInstantiateSubstitutions(Context* context,
                                  const SubstitutionsMap& instances,

--- a/frontend/include/chpl/resolution/resolution-queries.h
+++ b/frontend/include/chpl/resolution/resolution-queries.h
@@ -117,7 +117,7 @@ static constexpr RequiredSignedness RS_NONE = 0, RS_SIGNED = 1, RS_UNSIGNED = 2;
 
   To help bridge the gap (fetch enum numeric value, to use it in an initialization
   expression for another enum, before the type of the numeric value is known),
-  this query provides the "intial guess", which is aware only of information
+  this query provides the "initial guess", which is aware only of information
   preceding the given element's declaration.
  */
 std::pair<optional<types::QualifiedType>, RequiredSignedness> const&
@@ -430,10 +430,10 @@ const ResolvedFunction* resolveFunctionIfPossible(ResolutionContext* rc,
   implementation points for a particular interface.
  */
 const std::vector<const ImplementationPoint*>*
-visibileImplementationPointsForInterface(Context* context,
-                                         const Scope* scope,
-                                         const PoiScope* poiScope,
-                                         ID interfaceId);
+visibleImplementationPointsForInterface(Context* context,
+                                        const Scope* scope,
+                                        const PoiScope* poiScope,
+                                        ID interfaceId);
 
 /**
   Helper to resolve a concrete function using the above queries.

--- a/frontend/include/chpl/resolution/resolution-types.h
+++ b/frontend/include/chpl/resolution/resolution-types.h
@@ -704,7 +704,7 @@ class CallInfo {
   static CallInfo copyAndRename(const CallInfo& ci, UniqueString rename);
 
   /** Copy and mark the selected actuals as "only having been allowed in
-      in oder to support split-init". */
+      in order to support split-init". */
   static CallInfo copyAndMarkSplitInitActuals(const CallInfo& ci, const std::unordered_set<int>& actualIndices);
 
   /** Prepare actuals for a call for later use in creating a CallInfo.
@@ -1294,7 +1294,7 @@ class TypedFnSignature {
     For initial signatures, returns 'true' if resolving the where clause
     produced an error.
    */
-  bool whereClausePrducedError() const {
+  bool whereClauseProducedError() const {
     if (formalsErrored_.size() == 0) return false;
     return formalsErrored_[numFormals()];
   }

--- a/frontend/include/chpl/types/InterfaceType.h
+++ b/frontend/include/chpl/types/InterfaceType.h
@@ -58,7 +58,7 @@ class InterfaceType final : public Type {
   SubstitutionsMap subs_;
 
   // check that the substitutions are valid for the given interface.
-  // executed from an assertion, so does not haev an impact in release mode.
+  // executed from an assertion, so does not have an impact in release mode.
   static bool validateSubstitutions(Context* context,
                                     const ID& id,
                                     SubstitutionsMap& subs);

--- a/frontend/include/chpl/types/type-classes-list-adapter.h
+++ b/frontend/include/chpl/types/type-classes-list-adapter.h
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-// this is a convenient wrapper around type-clases-list.h. See that file
+// this is a convenient wrapper around type-classes-list.h. See that file
 // for documentation on how to use it. This file simplifies using the
 // header by auto-defining undefined X-macros to sensible defaults, and
 // by clearing the macro definitions at the end of the file.

--- a/frontend/lib/resolution/InitResolver.cpp
+++ b/frontend/lib/resolution/InitResolver.cpp
@@ -141,7 +141,7 @@ void InitResolver::resolveImplicitSuperInit() {
     };
 
     // Capture the errors emitted here and defer them until we know we haven't
-    // found a "real" super.init call (which means a different error supercedes
+    // found a "real" super.init call (which means a different error supersedes
     // these).
     auto cAndErrors = ctx_->runAndCaptureErrors([&c](Context* ctx) {
       c.noteResultPrintCandidates(nullptr);
@@ -548,7 +548,7 @@ static const Type* ctFromSubs(ResolutionContext* rc,
 const Type* InitResolver::computeReceiverTypeConsideringState(void) {
   auto ctInitial = initialRecvType_->getCompositeType();
 
-  // for the purposes of determing if subs are needed, we want to inspect the
+  // for the purposes of determining if subs are needed, we want to inspect the
   // base type.
   if (auto ctInitialBase = ctInitial->instantiatedFromCompositeType()) {
     ctInitial = ctInitialBase;

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -818,8 +818,8 @@ isOuterVariable(Resolver& rv, const Identifier* ident, const ID& target) {
       }
     */
     // Return 'false' if the module is not the most immediate parent AST.
-    auto enclosingMutliDecl = parsing::idToContainingMultiDeclId(context, target);
-    auto targetParentAstId = parsing::idToParentId(context, enclosingMutliDecl);
+    auto enclosingMultiDecl = parsing::idToContainingMultiDeclId(context, target);
+    auto targetParentAstId = parsing::idToParentId(context, enclosingMultiDecl);
     return targetParentSymbolId != targetParentAstId;
   }
 
@@ -1791,7 +1791,7 @@ QualifiedType Resolver::getTypeForDecl(const AstNode* decl,
     } else if (!got.instantiates() || declaredType.type()->isUnknownType()) {
       // use the declared type since no conversion/promotion was needed.
       // alternatively, if declared type is present but unknown, we don't
-      // know what was intended in the declaratiom, so we leave it as unknown.
+      // know what was intended in the declaration, so we leave it as unknown.
       typePtr = declaredType.type();
     } else {
       // instantiation is needed
@@ -2249,7 +2249,7 @@ void Resolver::computeFormalIntent(const uast::NamedDecl *decl,
   qtKind = resolveIntent(formalQt, isThis, isInit);
 }
 
-// Peformance: this re-computes the vector each time it is called.
+// Performance: this re-computes the vector each time it is called.
 // We could make it a query, or try writing an iterator that handles this.
 // In the meantime, though, I'll keep it as is.
 static std::vector<CompilerDiagnostic>
@@ -2452,7 +2452,7 @@ bool Resolver::CallResultWrapper::noteResultWithoutError(
     // issued its own error, so we shouldn't emit a general error.
     return !result.speciallyHandled() || needsErrors;
   } else {
-    // mark compiler-geneated tuple casts with an associated action
+    // mark compiler-generated tuple casts with an associated action
     if (result.speciallyHandled() && ci &&
         ci->name() == USTR(":") &&
         ci->numActuals() == 2 && ci->actual(1).type().type()->isTupleType()) {
@@ -4260,7 +4260,7 @@ void Resolver::setToBuiltin(ResolvedExpression& r, UniqueString name) {
     }
   }
   r.setToId(builtinId); // note: circumvents validateAndSetToId since it should
-                        //       not be triggered by builtns.
+                        //       not be triggered by builtins.
   r.setType(type);
 }
 
@@ -4561,7 +4561,7 @@ static QualifiedType computeDefaultsIfNecessary(Resolver& rv,
 
   // If we're referring to variable-ish thing, don't instantiate
   // generics. This way, `type t = someGeneric(?); t` doesn't instantiate.
-  // Peformance: finding the AST is pretty expensive. Can we fold
+  // Performance: finding the AST is pretty expensive. Can we fold
   // the knowledge into IdAndFlags?
   if (id && asttags::isVarLikeDecl(parsing::idToTag(rv.context, id))) {
     computeDefaults = false;
@@ -4814,7 +4814,7 @@ bool Resolver::enter(const TypeQuery* tq) {
   if (usePlaceholders) {
     // If we're resolving an interface, create a placeholder for the type
     // query. This way, we get a concrete type for `foo(?x)`, which is
-    // desireable when validating user-provided functions against the
+    // desirable when validating user-provided functions against the
     // interface signature.
     ResolvedExpression& result = byPostorder.byAst(tq);
     result.setType(QualifiedType(QualifiedType::TYPE,
@@ -5169,7 +5169,7 @@ void Resolver::exit(const MultiDecl* decl) {
     }
 
     // even if the last decl doesn't have a type/init, we should
-    // resovle it, because `var x: int, y, z;` means `y` and `z`
+    // resolve it, because `var x: int, y, z;` means `y` and `z`
     // are generic.
     bool isLast = std::next(it) == decl->decls().end();
 
@@ -5627,7 +5627,7 @@ rerunCallInfoWithIteratorTag(ResolutionContext* rc,
 
   std::vector<CallInfoActual> actuals;
   for (const auto& actual : ci.actuals()) {
-    // If the user explictly specified a tag, we can't re-run with a different tag.
+    // If the user explicitly specified a tag, we can't re-run with a different tag.
     if (actual.byName() == USTR("tag")) {
       return empty;
     }
@@ -6328,7 +6328,7 @@ class IterandComponent {
     bool isUnpack = (opCall = iterand->toOpCall()) && opCall->op() == USTR("...");
 
     // This is an expression in the form (...someTuple). Each element of the
-    // tuple should b ecome its own iterand component. In this case,
+    // tuple should become its own iterand component. In this case,
     // we don't have an exact iterator fn (and thus, we're not a tagged call),
     // since there are several elements to iterate over.
     if (isUnpack) {
@@ -6976,7 +6976,7 @@ static bool resolveParamForLoop(Resolver& rv, const For* forLoop, BoundInfo&& bo
     loopControlFlow.resetContinue(forLoop);
 
     // Loop execution has ended somehow (throw, break, return). No need to push
-    // loop resutls for skipped iterations.
+    // loop results for skipped iterations.
     if (loopControlFlow.isDoneExecuting()) break;
 
     ResolutionResultByPostorderID bodyResults;
@@ -7031,7 +7031,7 @@ static bool resolveParamForLoop(Resolver& rv, const For* forLoop) {
   return resolveParamForLoop(rv, forLoop, std::move(iterandInfo));
 }
 
-static bool resolveHeterogenousTupleForLoop(Resolver& rv, const For* forLoop, const TupleType* tupleType) {
+static bool resolveHeterogeneousTupleForLoop(Resolver& rv, const For* forLoop, const TupleType* tupleType) {
   auto tupleInfo = TupleInfo { tupleType };
   return resolveParamForLoop(rv, forLoop, &tupleInfo);
 }
@@ -7046,11 +7046,11 @@ resolveZipExpression(Resolver& rv, const AstNode* anchor, bool requiresParallel,
 
   // Compute iterator components to resolve as part of zippering. This
   // handles unpacking any iterands in the form (...bla) into a flattened
-  // repersentation.
+  // representation.
   for (auto actual : zip->actuals()) {
     if (!IterandComponent::unpackIterand(rv, outIcs, actual, actual)) {
       // Couldn't make sense of the iterand, we can't go on. An error
-      // was already emitted, but contruct an ErroneousType to return.
+      // was already emitted, but construct an ErroneousType to return.
       return QualifiedType(QualifiedType::UNKNOWN, ErroneousType::get(context));
     }
   }
@@ -7138,7 +7138,7 @@ static bool isShapedLikeArray(const IndexableLoop* loop) {
 // concrete, like `[1..4] int`, which is a default-rectangular array over
 // a default-rectangular domain, we allow them to capture other types
 // of arrays (e.g., block distributed ones). So, because (1) in typed
-// signautres we might want to build an array type with a generic element type,
+// signatures we might want to build an array type with a generic element type,
 // which would break the buildRuntimeType assumption, and (2) array type expressions
 // in formals are effectively generic, we treat them specially, throw
 // away their _instance field, and allow generic element types. We want to only
@@ -7425,7 +7425,7 @@ bool Resolver::enter(const IndexableLoop* loop) {
     }
   }
 
-  // iteration over non-homogenous tuples is handled directly by
+  // iteration over non-homogeneous tuples is handled directly by
   // the compiler, very much like a param loop.
   if (forLoop && !scopeResolveOnly && !iterand->isZip()) {
     auto iterandRe = byPostorder.byAst(iterand);
@@ -7433,7 +7433,7 @@ bool Resolver::enter(const IndexableLoop* loop) {
       if (auto tt = iterandRe.type().type()->toTupleType()) {
         if (!tt->isStarTuple()) {
           enterScope(loop);
-          return resolveHeterogenousTupleForLoop(*this, forLoop, tt);
+          return resolveHeterogeneousTupleForLoop(*this, forLoop, tt);
         }
       }
     }

--- a/frontend/lib/resolution/VarScopeVisitor.cpp
+++ b/frontend/lib/resolution/VarScopeVisitor.cpp
@@ -694,7 +694,7 @@ bool VarScopeVisitor::resolvedCallHelper(const Call* callAst, RV& rv) {
     // TODO: we could consider a more general way to signal how a particular
     // call was resolved (like, "hey, this was resolved by a compiler-generated
     // elided cast!") so that we don't have to pattern match. However, there
-    // aren't a lot of different casses like this, so for now I'm leaving
+    // aren't a lot of different cases like this, so for now I'm leaving
     // the special case. - D.F.
     if (auto op = callAst->toOpCall()) {
       if (op->op() == USTR(":")) {
@@ -751,7 +751,7 @@ bool VarScopeVisitor::resolvedCallHelper(const Call* callAst, RV& rv) {
                                actualPromoted, promoCtx);
 
     // for a given actual index, returns:
-    // * nullptr if no promotion ocurred
+    // * nullptr if no promotion occurred
     // * the scalar type of the given actual was used in promotion
     // * the actual type itself if it was not
     // This can be used to signal to handleInFormal() etc. to adjust

--- a/frontend/lib/resolution/call-init-deinit.cpp
+++ b/frontend/lib/resolution/call-init-deinit.cpp
@@ -441,7 +441,7 @@ void CallInitDeinit::processDeinitsAndPropagate(VarFrame* frame,
       // don't deinit reference variables
       if (!isValue(type.kind())) continue;
 
-      // don't deinit generic variables (asuming error issued elsewhere)
+      // don't deinit generic variables (assuming error issued elsewhere)
       auto g = getTypeGenericity(context, type);
       if (g != Type::CONCRETE) {
         return;
@@ -1049,7 +1049,7 @@ void CallInitDeinit::handleDeclaration(const VarLikeDecl* ast,
         }
       }
 
-      // 'manage bla as reg x' means to capture the 'enterContext' clal by ref,
+      // 'manage bla as reg x' means to capture the 'enterContext' call by ref,
       // no need to initialize it.
     } else if (parent->isAs()) {
       if (auto grandparent = parsing::parentAst(context, parent)) {

--- a/frontend/lib/resolution/default-functions.cpp
+++ b/frontend/lib/resolution/default-functions.cpp
@@ -535,7 +535,7 @@ bool needCompilerGeneratedBinaryOp(Context* context,
                                    const types::QualifiedType& rhs,
                                    UniqueString name) {
   // check if the regular call (e.g., lhs + rhs) would work, but also allow
-  // for the posibility of promotion (e.g., effectively [lhsScalar in lhs] lhs + rhs).
+  // for the possibility of promotion (e.g., effectively [lhsScalar in lhs] lhs + rhs).
   // This leads to a total of 4 cases.
 
   for (int i : { 0b00, 0b01, 0b10, 0b11 }) {

--- a/frontend/lib/resolution/default-functions.h
+++ b/frontend/lib/resolution/default-functions.h
@@ -47,8 +47,8 @@ bool needCompilerGeneratedMethod(Context* context, const types::Type* type,
 
 /**
   Same as getCompilerGeneratedMethod, but for operators. Here, we are more
-  discerning: the other argument to the oeprator is also considered when
-  determing if compiler generation is needed.
+  discerning: the other argument to the operator is also considered when
+  determining if compiler generation is needed.
  */
 bool needCompilerGeneratedBinaryOp(Context* context,
                                    const types::QualifiedType& lhs,

--- a/frontend/lib/resolution/disambiguation.cpp
+++ b/frontend/lib/resolution/disambiguation.cpp
@@ -1784,13 +1784,13 @@ static bool isFormalInstantiatedAny(const DisambiguationCandidate& candidate,
 static bool isFormalPartiallyGeneric(const DisambiguationCandidate& candidate,
                                      const FormalActual* fa) {
 
-  // Production determines "partially generic" when it desugars type epxressions.
+  // Production determines "partially generic" when it desugars type expressions.
   // Specifically, it desugars things like 'x : foo(?t, s)' to ' x : foo' and a
   // 'where' clause in which 'x.type.secondField' must be a subtype of 's'.
   // For the purposes of _only_ determining whether a formal is partially generic,
   // we don't need to match that logic in full; any one 'where' clause is
   // enough for a formal to be considered partially generic. So, the below
-  // list is a simplifcation of the logic. You may re-derive it by tracing
+  // list is a simplification of the logic. You may re-derive it by tracing
   // 'addToWhereClause' in normalize.cpp.
   //
   // * a variadic argument has a size specifier
@@ -1799,7 +1799,7 @@ static bool isFormalPartiallyGeneric(const DisambiguationCandidate& candidate,
   //   * any tuple expression (because it constrains .size)
   //   * any N*t expression (because it constrains .size)
   //   * 'shared' or 'owned'. I think we should also use 'borrowed' and 'unmanaged'.
-  // * gated on 'formal contains genric expression', in the actuals of a call:
+  // * gated on 'formal contains generic expression', in the actuals of a call:
   //   * any actual that isn't '?' or '?t'
   //
   // Here, make an assumption that since this function is called,
@@ -1813,7 +1813,7 @@ static bool isFormalPartiallyGeneric(const DisambiguationCandidate& candidate,
   } else if (auto nf = faDecl->toVarLikeDecl()) {
     faTypeExpr = nf->typeExpression();
   } else if (faDecl->isTupleDecl()) {
-    // implicitly constrained, since the number of decls constrants its size
+    // implicitly constrained, since the number of decls constrains its size
     return true;
   }
 

--- a/frontend/lib/resolution/resolution-queries.cpp
+++ b/frontend/lib/resolution/resolution-queries.cpp
@@ -3328,7 +3328,7 @@ resolveFunctionByInfoImpl(ResolutionContext* rc, const TypedFnSignature* sig,
     auto re = rr.byAst(linkageName);
     auto& qt = re.type();
     if (qt.isErroneousType()) {
-      // coudn't compute linkage name, error already issued
+      // couldn't compute linkage name, error already issued
     } else if (qt.isUnknownOrErroneous()) {
       context->error(linkageName,
                      "could not determine linkage name for function '%s'",
@@ -3528,7 +3528,7 @@ resolveFunctionByPoisQuery(ResolutionContext* rc, PoiInfo::Trace poiTrace) {
 //
 // Unresolved PoI infos simply contain a PoI scope in which a function's
 // body should be resolved. Caching these queries would prevent having
-// to re-resolve a function called mutliple times from the same scope, but
+// to re-resolve a function called multiple times from the same scope, but
 // it will not do anything clever about PoI compatibility (see see PR #16261, e.g.).
 //
 // Resolved PoI infos don't contain the scope in which they were resolved; instead,
@@ -3892,10 +3892,10 @@ collectImplementationPointsInScope(Context* context,
 }
 
 static void
-helpCollectVisibileImplementationPoints(Context* context,
-                                        const Scope* scope,
-                                        std::unordered_set<const Scope*>& seen,
-                                        std::map<ID, std::vector<const ImplementationPoint*>>& into) {
+helpCollectVisibleImplementationPoints(Context* context,
+                                       const Scope* scope,
+                                       std::unordered_set<const Scope*>& seen,
+                                       std::map<ID, std::vector<const ImplementationPoint*>>& into) {
   auto insertResult = seen.insert(scope);
   if (!insertResult.second) return;
 
@@ -3911,7 +3911,7 @@ helpCollectVisibileImplementationPoints(Context* context,
     for (auto visClause : visStmts->visibilityClauses()) {
       auto nextScope = visClause.scope();
       if (nextScope && asttags::isModule(nextScope->tag())) {
-        helpCollectVisibileImplementationPoints(context, nextScope, seen, into);
+        helpCollectVisibleImplementationPoints(context, nextScope, seen, into);
       }
     }
   }
@@ -3924,19 +3924,19 @@ visibleImplementationPoints(Context* context,
   QUERY_BEGIN(visibleImplementationPoints, context, scope, poiScope);
   std::map<ID, std::vector<const ImplementationPoint*>> result;
   std::unordered_set<const Scope*> seen;
-  helpCollectVisibileImplementationPoints(context, scope->moduleScope(), seen, result);
+  helpCollectVisibleImplementationPoints(context, scope->moduleScope(), seen, result);
   for (; poiScope; poiScope = poiScope->inFnPoi()) {
     auto inScope = poiScope->inScope()->moduleScope();
-    helpCollectVisibileImplementationPoints(context, inScope, seen, result);
+    helpCollectVisibleImplementationPoints(context, inScope, seen, result);
   }
   return QUERY_END(result);
 }
 
 const std::vector<const ImplementationPoint*>*
-visibileImplementationPointsForInterface(Context* context,
-                                         const Scope* scope,
-                                         const PoiScope* poiScope,
-                                         ID id) {
+visibleImplementationPointsForInterface(Context* context,
+                                        const Scope* scope,
+                                        const PoiScope* poiScope,
+                                        ID id) {
   auto& allInstantiationPoints = visibleImplementationPoints(context, scope, poiScope);
   auto it = allInstantiationPoints.find(id);
   if (it != allInstantiationPoints.end()) {
@@ -4123,7 +4123,7 @@ isInitialTypedSignatureApplicable(Context* context,
       // Either we're partially instantiating a type `R(x, ?)`, in which any subsequent generic type
       // fields are defaulted, or we are using defaults, in which case
       // there should be a 'hasDefault' entry here. We allow (but warn about)
-      // partial instnatiations without '?', if it's a type constructor.
+      // partial instantiations without '?', if it's a type constructor.
       //
       // One other niche case is that the 'this' formal of operators is unused.
       CHPL_ASSERT(tfs->untyped()->isTypeConstructor() || entry.hasDefault() ||
@@ -4356,7 +4356,7 @@ doIsCandidateApplicableInitial(ResolutionContext* rc,
     if (ret->formalProducedError(i))
       return ApplicabilityResult::failureErrorInFormal(ret, i);
   }
-  if (ret->whereClausePrducedError())
+  if (ret->whereClauseProducedError())
     return ApplicabilityResult::failureErrorInWhereClause(ret);
 
   auto faMap = FormalActualMap(ufs, ci);
@@ -4694,7 +4694,7 @@ static const Type* getNumericType(Context* context,
         // bool used to support custom widths, but now it doesn't. Now,
         // there's no bool(..) type constructor.
         context->error(astForErr, "the 'bool' type is not generic and only has one width, so"
-                       " it doen't take type constructor arguments.");
+                       " it doesn't take type constructor arguments.");
         return ErroneousType::get(context);
       }
 
@@ -7265,7 +7265,7 @@ const ImplementationWitness* findMatchingImplementationPoint(ResolutionContext* 
                                                             const types::InterfaceType* ift,
                                                             const CallScopeInfo& inScopes) {
   auto implPoints =
-    visibileImplementationPointsForInterface(rc->context(), inScopes.lookupScope(), inScopes.poiScope(), ift->id());
+    visibleImplementationPointsForInterface(rc->context(), inScopes.lookupScope(), inScopes.poiScope(), ift->id());
 
   // TODO: this matches production, in which the first matching generic
   // implementation is used if no concrete one is found. It's probably
@@ -8537,7 +8537,7 @@ shapeForIteratorQuery(Context* context,
     // Resolve this using  call, and make that call a query because typed
     // conversion might eventually require access to it for the purposes
     // of runtime types. Some additional wrangling will be needed to avoid
-    // re-extracing leaderType (could we have a set-only query that computes
+    // re-extracting leaderType (could we have a set-only query that computes
     // the CallResolutionResult from iter, that we set right here?) but I
     // leave that to you, O brave future implementer.
 

--- a/frontend/lib/resolution/resolution-types.cpp
+++ b/frontend/lib/resolution/resolution-types.cpp
@@ -1475,7 +1475,7 @@ MostSpecificCandidate::fromTypedFnSignature(ResolutionContext* rc,
   // initializer, it can have substitution-producing statements such
   // as `this.typeField = int`. Now that we have picked this candidate
   // as most specific, it's safe to resolve the body without worrying about
-  // spurious errors from other andidates.
+  // spurious errors from other candidates.
   if (fn->isInitializer()) {
     auto instantiationPoiScope =
       Resolver::poiScopeOrNull(rc->context(), fn, scope, poiScope);

--- a/frontend/lib/resolution/try-catch-analysis.cpp
+++ b/frontend/lib/resolution/try-catch-analysis.cpp
@@ -415,7 +415,7 @@ namespace resolution {
     while (!moduleId.isEmpty()) {
       auto ag = parsing::idToAttributeGroup(context, moduleId);
       if (!ag) {
-        // no attibute group on this module; is there a parent module?
+        // no attribute group on this module; is there a parent module?
       } else if (ag->hasPragma(pragmatags::PRAGMA_ERROR_MODE_FATAL)) {
         return ErrorCheckingMode::FATAL;
       } else if (ag->hasPragma(pragmatags::PRAGMA_ERROR_MODE_STRICT)) {

--- a/frontend/lib/uast/Builder.cpp
+++ b/frontend/lib/uast/Builder.cpp
@@ -382,7 +382,7 @@ void Builder::assignIDs() {
 
   if (topLevelRepeatOffset_) {
     // this is a special way to get a builder that creates a numbered overload
-    // for a particular function when compler-generating AST. Thus,
+    // for a particular function when compiler-generating AST. Thus,
     // ensure we are marked as generated, and that there's only one symbol,
     // whose offset we are now going to adjust.
     CHPL_ASSERT(isGenerated());

--- a/modules/internal/ChapelArray.chpl
+++ b/modules/internal/ChapelArray.chpl
@@ -3135,7 +3135,7 @@ module ChapelArray {
 
   proc chpl__validateReshape(arr, dom) {
     if dom.size != arr.size then
-      halt("Size mismatch: Can't rehape a ", arr.size,
+      halt("Size mismatch: Can't reshape a ", arr.size,
            "-element array into a ", dom.size, "-element array");
 
     if arr.size > 0 && dom.size > 0 {

--- a/modules/internal/ChapelProgramEntrypoints.chpl
+++ b/modules/internal/ChapelProgramEntrypoints.chpl
@@ -51,7 +51,7 @@ module ChapelProgramEntrypoints {
   }
 
   pragma "locale private"   // TODO: May not need this, but...
-  pragma "no init"          // Don't overwite work done later.
+  pragma "no init"          // Don't overwrite work done later.
   private var chpl_genMainArg: chpl_main_argument;
 
   // For the runtime. Get a pointer to the main argument on this locale.

--- a/modules/packages/Python.chpl
+++ b/modules/packages/Python.chpl
@@ -1502,7 +1502,7 @@ module Python {
 
   /*
     Represents an isolated Python sub-interpreter. This is useful for running
-    truly parallel Python code, without the GIL interferring.
+    truly parallel Python code, without the GIL interfering.
   */
   class SubInterpreter: Interpreter {
     @chpldoc.nodoc
@@ -3416,7 +3416,7 @@ module Python {
       compilerError("docs only");
     //
     // TODO: these are meant to prevent users from calling .these on a PyArray
-    // when they probaby wanted .values. But the mere presence of these as
+    // when they probably wanted .values. But the mere presence of these as
     // compiler errors prevents any program using Value.these from
     // compiling. And we can't just make them throw instead because inheritance
     // prevents iterator inlining, which is not yet supported

--- a/modules/standard/FileSystem.chpl
+++ b/modules/standard/FileSystem.chpl
@@ -1605,7 +1605,7 @@ iter walkDirsHelper(path: string, topdown: bool, in depth: int,
 }
 
 // this uses parSafe lists as the stack, which probably
-// makes the parallelism inefficent and pretty useless. This was better
+// makes the parallelism inefficient and pretty useless. This was better
 // when written as a recursive iterator, but recursive iterators are too
 // fragile
 @chpldoc.nodoc

--- a/modules/standard/Sort/Partitioning.chpl
+++ b/modules/standard/Sort/Partitioning.chpl
@@ -835,7 +835,7 @@ record bktCount {
      Bucket i consists of elts with
        split.sortedSplitter(i-1) < elts <= split.sortedSplitter(i)
 
-     Bucket nBuckets-1 consits of elt with
+     Bucket nBuckets-1 consists of elt with
        split.sortedSplitter(numBuckets-2) < elts
 
    If equality buckets are in use:
@@ -856,9 +856,9 @@ record bktCount {
      Bucket i, with i being odd, consists of elts with
        elts == split.sortedSplitter((i-1)/2)
 
-     Bucket nBuckets-2 consits of elt with
+     Bucket nBuckets-2 consists of elt with
        elts == split.sortedSplitter((numBuckets-2)/2) < elts
-     Bucket nBuckets-1 consits of elt with
+     Bucket nBuckets-1 consists of elt with
        split.sortedSplitter((numBuckets-2)/2) < elts
 
  */
@@ -2712,7 +2712,7 @@ proc multiWayMerge(Input: [] ?eltType,
   while true {
     //writeln("looping");
     //writeln("InternalNodes ", InternalNodes);
-    //writeln("ExtarnalNodes[InternalNodes] ", ExternalNodes[InternalNodes]);
+    //writeln("ExternalNodes[InternalNodes] ", ExternalNodes[InternalNodes]);
 
     var championAddr = InternalNodes[0]; // index of external node in P..<2*P
     if championAddr == inf {

--- a/runtime/include/chpl-rt-math.h
+++ b/runtime/include/chpl-rt-math.h
@@ -27,12 +27,12 @@
 
 /*
   Define a saturating add on signed arithmetic.
-  * res, x, and y should be plain identifers of type __stype
+  * res, x, and y should be plain identifiers of type __stype
   * __utype should be the unsigned version of __stype
   * __smax should be the maximum representable value in __stype
 
   __builtin_elementwise_add_sat is a clang extension, use that if available.
-  Its more efficent to use __builtin_add_overflow (gcc/clang) but if not available
+  Its more efficient to use __builtin_add_overflow (gcc/clang) but if not available
   the fall back is OK.
 
   Note: on clang before 21, __builtin_elementwise_add_sat applied the usual

--- a/runtime/src/chpl-cache.c
+++ b/runtime/src/chpl-cache.c
@@ -2023,7 +2023,7 @@ int try_reserve_entry(struct rdcache_s* cache,
                       chpl_cache_taskPrvData_t* task_local,
                       struct cache_entry_s* entry) {
 
-  // read and do an aquire fence
+  // read and do an acquire fence
   chpl_cache_taskPrvData_t* v = read_reservedByTask(entry);
 
   if (v != NULL) {

--- a/runtime/src/chpl-unwind.c
+++ b/runtime/src/chpl-unwind.c
@@ -220,7 +220,7 @@ static int chpl_unwind_refineGetLineNum(void *addr) {
   if (!chpl_get_command_output(buf, buf, sizeof(buf)))
     return 0;
 
-  // format is '<FN_NAME> (in <REL_EXEC_NAME>) (<FILENAME>:<LINENUME>)
+  // format is '<FN_NAME> (in <REL_EXEC_NAME>) (<FILENAME>:<LINENUM>)
   // search from the end of the string backwards for ':'
   char* bufPtr = buf + strlen(buf) - 1;
   while (bufPtr > buf && *bufPtr != ':') { bufPtr--; }

--- a/runtime/src/launch/slurm-srun/launch-slurm-srun.c
+++ b/runtime/src/launch/slurm-srun/launch-slurm-srun.c
@@ -381,7 +381,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
                               snprintf(NULL, 0, "%d", (int)mypid) + 1;
 
     if (filename_size <= 0) {
-      chpl_internal_error("An unexpected error occured while computing \
+      chpl_internal_error("An unexpected error occurred while computing \
                           sbatch filename size");
     }
 
@@ -393,7 +393,7 @@ static char* chpl_launch_create_command(int argc, char* argv[],
                              baseSBATCHFilename, (int)mypid);
 
     if (ret <= 0) {
-      chpl_internal_error("An unexpected error occured while generating \
+      chpl_internal_error("An unexpected error occurred while generating \
                           sbatch filename");
     }
 

--- a/runtime/src/mem/jemalloc/mem-jemalloc.c
+++ b/runtime/src/mem/jemalloc/mem-jemalloc.c
@@ -605,11 +605,11 @@ static void initializeSharedHeap(void) {
 
   useUpMemNotInHeap();
 
-  // printf("trying to do an allocagion\n");
+  // printf("trying to do an allocation\n");
   // void* p = CHPL_JE_MALLOCX(2 * 1024 * 1024, MALLOCX_NO_FLAGS);
   // printf("got %p\n", p);
 
-  // printf("trying to do an allocagion\n");
+  // printf("trying to do an allocation\n");
   // p = CHPL_JE_MALLOCX(57344, MALLOCX_NO_FLAGS);
   // printf("got %p\n", p);
 }

--- a/runtime/src/topo/hwloc/topo-hwloc.c
+++ b/runtime/src/topo/hwloc/topo-hwloc.c
@@ -603,7 +603,7 @@ static void partitionResources(void) {
   if (numColocales > 0) {
     if (numLocalesOnNode <= numColocales) {
       // There are fewer colocales than there should be, probably because the
-      // number of locales isn't evenly divisable by the number of nodes.
+      // number of locales isn't evenly divisible by the number of nodes.
       // Partition resources as if there are the full complement of
       // colocales, but set the number of colocales to the actual number.
       numPartitions = numColocales;
@@ -686,10 +686,10 @@ static void partitionResources(void) {
           logAccSets[i] = s;
         }
 
-        // logAccSets has the cores each parition can use. If they don't have
+        // logAccSets has the cores each partition can use. If they don't have
         // the same number of cores, then we can't proceed with this
         // partitioning scheme.
-        // we also want to avoid the situation where all the paritions
+        // we also want to avoid the situation where all the partitions
         // end up having 0 cores.
         assert(numPartitions > 0);
         int firstSetSize = hwloc_bitmap_weight(logAccSets[0]);
@@ -757,7 +757,7 @@ static void partitionResources(void) {
         if (!chpl_env_rt_get_bool("SILENCE_UNUSED_CORES", false)) {
 
           // TODO: on a hybrid arch like M3 or alderlake with all the
-          // efficency cores in one L2 and all the performance cores in
+          // efficiency cores in one L2 and all the performance cores in
           // another, this can be misleading. For example, currently
           // trying to pin to 'core' on alderlake will report unused cores
           // for all cores, instead of just the ones selected by CHPL_RT_USE_PU_KIND.

--- a/test/arrays/reshape/new-edition/reshapeSizeMismatch.good
+++ b/test/arrays/reshape/new-edition/reshapeSizeMismatch.good
@@ -1,1 +1,1 @@
-reshapeSizeMismatch.chpl:3: error: halt reached - Size mismatch: Can't rehape a 4-element array into a 1-element array
+reshapeSizeMismatch.chpl:3: error: halt reached - Size mismatch: Can't reshape a 4-element array into a 1-element array

--- a/test/arrays/reshape/new-edition/reshapeSizeMismatch.n=3.good
+++ b/test/arrays/reshape/new-edition/reshapeSizeMismatch.n=3.good
@@ -1,1 +1,1 @@
-reshapeSizeMismatch.chpl:3: error: halt reached - Size mismatch: Can't rehape a 4-element array into a 9-element array
+reshapeSizeMismatch.chpl:3: error: halt reached - Size mismatch: Can't reshape a 4-element array into a 9-element array

--- a/test/release/examples/primers/forallLoops.chpl
+++ b/test/release/examples/primers/forallLoops.chpl
@@ -346,7 +346,7 @@ task-private variable is an alias for.
 
 The next example highlights some uses of task-private variables
 and their syntactic differences from explicit task intents for
-shadow varialbes.
+shadow variables.
 */
 
 outerAtomicVariable.write(1);


### PR DESCRIPTION
Fix assorted typos

I tested by rebuilding the compiler and testing only test/arrays/reshape/new-edition which contains the good files this PR modifies.

[Contributed by @cassella. Reviewed and merged by @jabraham17]