### PR TITLE
dlopen: Fix linking errors that could occur when building `libchpl.so`

### DIFF
--- a/runtime/Makefile.help
+++ b/runtime/Makefile.help
@@ -184,14 +184,23 @@ else
   # RUNTIME_SHARED_LIB_CXX_LINK_FLAGS=-Wl,--no-undefined
 endif
 
+PRINTCHPLENV_WRAPPER= \
+  CHPL_HOST_COMPILER='$(CHPL_MAKE_HOST_COMPILER)' \
+  CHPL_HOST_CC='$(CHPL_MAKE_HOST_CC)' \
+  CHPL_HOST_CXX='$(CHPL_MAKE_HOST_CXX)' \
+  CHPL_TARGET_COMPILER='$(CHPL_MAKE_TARGET_COMPILER)' \
+  CHPL_TARGET_CC='$(CHPL_MAKE_TARGET_CC)' \
+  CHPL_TARGET_CXX='$(CHPL_MAKE_TARGET_CXX)' \
+  $(CHPL_MAKE_HOME)/util/printchplenv
+
 # NOTE: Need to recompute the link arguments since they were inherited from
 #       make/Makefile.base, and it is possible that third-party packages were
 #       not installed when they were computed (and thus they do not show up
 #       in the linking arguments, which breaks the build).
 RUNTIME_SHARED_LIB_BUNDLED_LINK_ARGS= \
-	$(shell $(CHPL_MAKE_HOME)/util/printchplenv --value --only=CHPL_TARGET_BUNDLED_RUNTIME_LINK_ARGS)
+	$(shell $(PRINTCHPLENV_WRAPPER) --value --only=CHPL_TARGET_BUNDLED_RUNTIME_LINK_ARGS)
 RUNTIME_SHARED_LIB_SYSTEM_LINK_ARGS= \
-	$(shell $(CHPL_MAKE_HOME)/util/printchplenv --value --only=CHPL_TARGET_SYSTEM_RUNTIME_LINK_ARGS)
+	$(shell $(PRINTCHPLENV_WRAPPER) --value --only=CHPL_TARGET_SYSTEM_RUNTIME_LINK_ARGS)
 
 $(RUNTIME_SHARED_LIB): $(SHARED_RUNTIME_OBJS) \
                        $(RUNTIME_DIR_TIMESTAMP) \
@@ -216,13 +225,7 @@ $(RUNTIME_STATIC_LIB): $(STATIC_RUNTIME_OBJS) $(RUNTIME_DIR_TIMESTAMP) \
 	$(AR) -rc $@ $(STATIC_RUNTIME_OBJS)
 	$(RANLIB) $@
 	$(TAGS_COMMAND)
-	CHPL_HOST_COMPILER='$(CHPL_MAKE_HOST_COMPILER)' \
-	CHPL_HOST_CC='$(CHPL_MAKE_HOST_CC)' \
-	CHPL_HOST_CXX='$(CHPL_MAKE_HOST_CXX)' \
-	CHPL_TARGET_COMPILER='$(CHPL_MAKE_TARGET_COMPILER)' \
-	CHPL_TARGET_CC='$(CHPL_MAKE_TARGET_CC)' \
-	CHPL_TARGET_CXX='$(CHPL_MAKE_TARGET_CXX)' \
-	../util/printchplenv --runtime --no-tidy --anonymize --simple > $(RUNTIME_CHPLCONFIG)
+	$(PRINTCHPLENV_WRAPPER) --runtime --no-tidy --anonymize --simple > $(RUNTIME_CHPLCONFIG)
 
 $(RUNTIME_LIST_INCLUDESANDDEFINES): $(COMMON_RUNTIME_OBJS) $(RUNTIME_DIR_TIMESTAMP)
 	$(MAKE) -f Makefile.config printincludesanddefines > $(RUNTIME_LIST_INCLUDESANDDEFINES)

--- a/runtime/Makefile.help
+++ b/runtime/Makefile.help
@@ -175,26 +175,37 @@ ifeq ($(CHPL_MAKE_PLATFORM),darwin)
   # the runtime have all been removed. By default, the OSX linker will emit
   # an error if any symbol does not have a definition at link time. While we
   # are developing, we want lazy resolution like on linux. When we are done,
-  # we want strict mode to catch issues at compile-time.
+  # we want strict mode to catch issues at link-time.
   RUNTIME_SHARED_LIB_CXX_LINK_FLAGS=-Wl,-undefined,dynamic_lookup
 else
   # NOTE: Uncomment when direct references to program symbols in the runtime
   # have all been removed. By default, the linux linker will mark unresolved
-  # symbols at link-time to use dynamic resolution.
+  # symbols at library load-time. We want eager resolution at link-time.
   # RUNTIME_SHARED_LIB_CXX_LINK_FLAGS=-Wl,--no-undefined
 endif
 
-$(RUNTIME_SHARED_LIB): $(SHARED_RUNTIME_OBJS) $(RUNTIME_DIR_TIMESTAMP) \
+# NOTE: Need to recompute the link arguments since they were inherited from
+#       make/Makefile.base, and it is possible that third-party packages were
+#       not installed when they were computed (and thus they do not show up
+#       in the linking arguments, which breaks the build).
+RUNTIME_SHARED_LIB_BUNDLED_LINK_ARGS= \
+	$(shell $(CHPL_MAKE_HOME)/util/printchplenv --value --only=CHPL_TARGET_BUNDLED_RUNTIME_LINK_ARGS)
+RUNTIME_SHARED_LIB_SYSTEM_LINK_ARGS= \
+	$(shell $(CHPL_MAKE_HOME)/util/printchplenv --value --only=CHPL_TARGET_SYSTEM_RUNTIME_LINK_ARGS)
+
+$(RUNTIME_SHARED_LIB): $(SHARED_RUNTIME_OBJS) \
+                       $(RUNTIME_DIR_TIMESTAMP) \
                        $(RUNTIME_LIST_INCLUDESANDDEFINES) \
                        $(RUNTIME_LIST_LIBRARIES) \
                        $(RUNTIME_OVERRIDE_LD)
 ifneq ($(CHPL_MAKE_LIB_PIC),pic)
 	@echo "note: Skipping creation of '$(RUNTIME_SHARED_LIB_NAME)' because 'CHPL_LIB_PIC' != 'pic'"
 else
-	$(CHPL_MAKE_TARGET_CXX) -shared -o $@ $(SHARED_RUNTIME_OBJS) $(LIBS) \
-		$(RUNTIME_SHARED_LIB_CXX_LINK_FLAGS) \
-		$(CHPL_MAKE_TARGET_BUNDLED_RUNTIME_LINK_ARGS) \
-		$(CHPL_MAKE_TARGET_SYSTEM_RUNTIME_LINK_ARGS)
+	$(CHPL_MAKE_TARGET_CXX) -shared -o $@ $(RUNTIME_SHARED_LIB_CXX_LINK_FLAGS) \
+		$(SHARED_RUNTIME_OBJS) \
+		$(LIBS) \
+		$(RUNTIME_SHARED_LIB_BUNDLED_LINK_ARGS) \
+		$(RUNTIME_SHARED_LIB_SYSTEM_LINK_ARGS)
 endif
 
 $(RUNTIME_STATIC_LIB): $(STATIC_RUNTIME_OBJS) $(RUNTIME_DIR_TIMESTAMP) \


### PR DESCRIPTION
This PR hopefully fixes a bug that causes the user to be hit with a barrage of linking errors when building `libchpl.so` in a fresh environment (where at least one third-party package used by the runtime needs to be installed).

Note that for these linking errors to consistently occur, I think the runtime dynamic library needs to be built with _eager_ linking. Mac linkers use eager linking by default, but Linux linkers need to throw a flag. You'll need to tweak parts of `runtime/Makefile.help` today if you want to turn that setting on/off (it's currently forced to lazy linking).

When I originally discovered this bug, I noticed that touching a runtime source file and rebuilding it usually fixed the issue. This turned out to be a red herring - I think the real issue is something like this:

- The user types `make` in an environment where 1 or more third-party packages is unbuilt/uninstalled
- The make session starts and inherits `CHPL_MAKE_` environment variables
- The linking arguments needed by the runtime are stored in one of these variables
- Because 1 or more third-party packages are not _installed_, their `-l/-L` paths cannot be computed
- Linking fails with a lot of linking errors

Anyhow, the fix is to recompute the affected variables while the Make recipe for `libchpl.so` is running via variables storing the output of `shell` commands. Since the third-party packages are guaranteed to be installed by that point, the linking arguments contain the correct paths and everything builds the first time around.

Future work will enable eager linking of `libchpl.so` by default, which requires fixing up the last remaining relocation errors and addressing problems with `CHPL_CACHE_REMOTE`.

Reviewed by @jabraham17. Thanks!