### PR TITLE
Add GA paratest for gasnet-everything

### DIFF
--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -322,4 +322,4 @@ jobs:
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv
       test-dirs: |
-        test/arrays/slices/commCounts
+        test/arrays

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -330,3 +330,10 @@ jobs:
       cron-script: util/cron/test-darwin.bash
       pre-build-steps: |
         brew install llvm
+  paratest-linux64-gasnet-everything:
+    name: Chapel paratest on linux64 with gasnet-everything
+    uses: ./.github/workflows/ga-paratest.yml
+    with:
+      configuration: linux64-gasnet-everything
+      cron-script: util/cron/test-gasnet-everything.bash
+      start-test-args: --futures

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -310,26 +310,6 @@ jobs:
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv chpldoc mason protoc-gen-chpl
       max-parallel: 50
-  paratest-linux64-c-backend:
-    name: Chapel paratest on linux64 with C backend
-    uses: ./.github/workflows/ga-paratest.yml
-    with:
-      configuration: linux64-c-backend
-      cron-script: util/cron/test-c-backend.bash
-      build-steps: |
-        num_procs=$(util/buildRelease/chpl-make-cpu_count)
-        make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
-          all test-venv mason
-  paratest-darwin:
-    name: Chapel paratest on darwin
-    uses: ./.github/workflows/ga-paratest.yml
-    with:
-      configuration: darwin
-      runner: macos-latest
-      use-container: false
-      cron-script: util/cron/test-darwin.bash
-      pre-build-steps: |
-        brew install llvm
   paratest-linux64-gasnet-everything:
     name: Chapel paratest on linux64 with gasnet-everything
     uses: ./.github/workflows/ga-paratest.yml

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -337,3 +337,7 @@ jobs:
       configuration: linux64-gasnet-everything
       cron-script: util/cron/test-gasnet-everything.bash
       start-test-args: --futures
+      build-steps: |
+        num_procs=$(util/buildRelease/chpl-make-cpu_count)
+        make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
+          all test-venv

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -298,18 +298,18 @@ jobs:
       run: |
         ./util/cron/test-c2chapel.bash
 
-  # paratest-linux64:
-  #   name: Chapel paratest on linux64
-  #   uses: ./.github/workflows/ga-paratest.yml
-  #   with:
-  #     configuration: linux64
-  #     cron-script: util/cron/test-linux64.bash
-  #     start-test-args: --futures
-  #     build-steps: |
-  #       num_procs=$(util/buildRelease/chpl-make-cpu_count)
-  #       make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
-  #         all test-venv chpldoc mason protoc-gen-chpl
-  #     max-parallel: 50
+  paratest-linux64:
+    name: Chapel paratest on linux64
+    uses: ./.github/workflows/ga-paratest.yml
+    with:
+      configuration: linux64
+      cron-script: util/cron/test-linux64.bash
+      start-test-args: --futures
+      build-steps: |
+        num_procs=$(util/buildRelease/chpl-make-cpu_count)
+        make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
+          all test-venv chpldoc mason protoc-gen-chpl
+      max-parallel: 50
   paratest-linux64-gasnet-everything:
     name: Chapel paratest on linux64 with gasnet-everything
     uses: ./.github/workflows/ga-paratest.yml
@@ -321,5 +321,3 @@ jobs:
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv
-      test-dirs: |
-        test/arrays

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -298,18 +298,18 @@ jobs:
       run: |
         ./util/cron/test-c2chapel.bash
 
-  paratest-linux64:
-    name: Chapel paratest on linux64
-    uses: ./.github/workflows/ga-paratest.yml
-    with:
-      configuration: linux64
-      cron-script: util/cron/test-linux64.bash
-      start-test-args: --futures
-      build-steps: |
-        num_procs=$(util/buildRelease/chpl-make-cpu_count)
-        make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
-          all test-venv chpldoc mason protoc-gen-chpl
-      max-parallel: 50
+  # paratest-linux64:
+  #   name: Chapel paratest on linux64
+  #   uses: ./.github/workflows/ga-paratest.yml
+  #   with:
+  #     configuration: linux64
+  #     cron-script: util/cron/test-linux64.bash
+  #     start-test-args: --futures
+  #     build-steps: |
+  #       num_procs=$(util/buildRelease/chpl-make-cpu_count)
+  #       make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
+  #         all test-venv chpldoc mason protoc-gen-chpl
+  #     max-parallel: 50
   paratest-linux64-gasnet-everything:
     name: Chapel paratest on linux64 with gasnet-everything
     uses: ./.github/workflows/ga-paratest.yml
@@ -321,3 +321,5 @@ jobs:
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv
+      test-dirs: |
+        test/arrays/slices/commCounts

--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -233,7 +233,7 @@ jobs:
           path: ${{ env.out_dir }}/*
           archive: false
           if-no-files-found: error
-  
+
   paratest-linux64-c-backend:
     name: Chapel paratest on linux64 with C backend
     uses: ./.github/workflows/ga-paratest.yml

--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -233,3 +233,24 @@ jobs:
           path: ${{ env.out_dir }}/*
           archive: false
           if-no-files-found: error
+  
+  paratest-linux64-c-backend:
+    name: Chapel paratest on linux64 with C backend
+    uses: ./.github/workflows/ga-paratest.yml
+    with:
+      configuration: linux64-c-backend
+      cron-script: util/cron/test-c-backend.bash
+      build-steps: |
+        num_procs=$(util/buildRelease/chpl-make-cpu_count)
+        make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
+          all test-venv mason
+  paratest-darwin:
+    name: Chapel paratest on darwin
+    uses: ./.github/workflows/ga-paratest.yml
+    with:
+      configuration: darwin
+      runner: macos-latest
+      use-container: false
+      cron-script: util/cron/test-darwin.bash
+      pre-build-steps: |
+        brew install llvm

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -11,8 +11,7 @@ on:
         description: Pre-build commands, defaults to nothing
         required: false
         type: string
-        default: |
-          set -u
+        default: ""
       cron-script:
         description: Cron script to source before building and running tests
         required: false
@@ -76,6 +75,8 @@ env:
   PARATEST_RESULTS_DIR: paratest-results
   AGGREGATED_RESULTS_DIR: aggregated-results
   CHAPEL_BUILD_FILES_SLUG: chapel-build-files
+  CRON_SCRIPT: ${{ inputs.cron-script }}
+  PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
 
 # note: no -x, its not actually that useful here and there is plenty of other output
 defaults:
@@ -96,9 +97,6 @@ jobs:
     outputs:
       matrix: ${{ steps.test-directories.outputs.matrix }}
       test-count: ${{ steps.test-directories.outputs.test-count }}
-    env:
-      CRON_SCRIPT: ${{ inputs.cron-script }}
-      PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -276,9 +274,6 @@ jobs:
       fail-fast: false
       max-parallel: ${{ inputs.max-parallel }}
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
-    env:
-      CRON_SCRIPT: ${{ inputs.cron-script }}
-      PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -95,6 +95,9 @@ jobs:
     outputs:
       matrix: ${{ steps.test-directories.outputs.matrix }}
       test-count: ${{ steps.test-directories.outputs.test-count }}
+    env:
+      CRON_SCRIPT: ${{ inputs.cron-script }}
+      PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -103,8 +106,6 @@ jobs:
       - name: build Chapel
         env:
           BUILD_STEPS: ${{ inputs.build-steps }}
-          CRON_SCRIPT: ${{ inputs.cron-script }}
-          PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
         run: |
           rm -f "$RUNNER_TEMP/chapel-build.log" "$RUNNER_TEMP/printchplenv.txt"
           {
@@ -158,8 +159,6 @@ jobs:
       - name: determine test directories
         env:
           TEST_DIRS: ${{ inputs.test-dirs }}
-          PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
-          CRON_SCRIPT: ${{ inputs.cron-script }}
         run: |
           if [[ -n "$PRE_BUILD_STEPS" ]]; then
             echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
@@ -280,6 +279,9 @@ jobs:
       fail-fast: false
       max-parallel: ${{ inputs.max-parallel }}
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
+    env:
+      CRON_SCRIPT: ${{ inputs.cron-script }}
+      PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
     steps:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -298,8 +300,6 @@ jobs:
       - name: run tests
         env:
           CONFIGURATION: ${{ inputs.configuration }}
-          CRON_SCRIPT: ${{ inputs.cron-script }}
-          PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
           START_TEST_ARGS: ${{ inputs.start-test-args }}
           TEST_DIR: ${{ matrix.dir }}
           TEST_FLAGS: ${{ matrix.flags }}

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -11,7 +11,8 @@ on:
         description: Pre-build commands, defaults to nothing
         required: false
         type: string
-        default: ""
+        default: |
+          set -u
       cron-script:
         description: Cron script to source before building and running tests
         required: false
@@ -109,11 +110,9 @@ jobs:
         run: |
           rm -f "$RUNNER_TEMP/chapel-build.log" "$RUNNER_TEMP/printchplenv.txt"
           {
-            if [[ -n "$PRE_BUILD_STEPS" ]]; then
-              echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
-              # shellcheck source=/dev/null
-              source "$RUNNER_TEMP/pre-build-steps.bash"
-            fi
+            echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
+            # shellcheck source=/dev/null
+            source "$RUNNER_TEMP/pre-build-steps.bash"
             if [[ -n "$CRON_SCRIPT" ]]; then
               # shellcheck source=/dev/null
               source "$CRON_SCRIPT"
@@ -160,11 +159,9 @@ jobs:
         env:
           TEST_DIRS: ${{ inputs.test-dirs }}
         run: |
-          if [[ -n "$PRE_BUILD_STEPS" ]]; then
-            echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
-            # shellcheck source=/dev/null
-            source "$RUNNER_TEMP/pre-build-steps.bash"
-          fi
+          echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
+          # shellcheck source=/dev/null
+          source "$RUNNER_TEMP/pre-build-steps.bash"
           # do pre-build and cron before running start_test
           if [[ -n "$CRON_SCRIPT" ]]; then
             # shellcheck source=/dev/null
@@ -305,11 +302,9 @@ jobs:
           TEST_FLAGS: ${{ matrix.flags }}
           TEST_ID: ${{ matrix.id }}
         run: |
-          if [[ -n "$PRE_BUILD_STEPS" ]]; then
-            echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
-            # shellcheck source=/dev/null
-            source "$RUNNER_TEMP/pre-build-steps.bash"
-          fi
+          echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
+          # shellcheck source=/dev/null
+          source "$RUNNER_TEMP/pre-build-steps.bash"
           if [[ -n "$CRON_SCRIPT" ]]; then
             # shellcheck source=/dev/null
             source "$CRON_SCRIPT"

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -100,21 +100,19 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: run pre-build steps
-        if: ${{ inputs.pre-build-steps != '' }}
-        env:
-          PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
-        run: |
-          echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
-          # shellcheck source=/dev/null
-          source "$RUNNER_TEMP/pre-build-steps.bash"
       - name: build Chapel
         env:
           BUILD_STEPS: ${{ inputs.build-steps }}
           CRON_SCRIPT: ${{ inputs.cron-script }}
+          PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
         run: |
           rm -f "$RUNNER_TEMP/chapel-build.log" "$RUNNER_TEMP/printchplenv.txt"
           {
+            if [[ -n "$PRE_BUILD_STEPS" ]]; then
+              echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
+              # shellcheck source=/dev/null
+              source "$RUNNER_TEMP/pre-build-steps.bash"
+            fi
             if [[ -n "$CRON_SCRIPT" ]]; then
               # shellcheck source=/dev/null
               source "$CRON_SCRIPT"
@@ -291,23 +289,21 @@ jobs:
           # Some tests assume git has been properly configured, so configure it here for the test runner.
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-      - name: run pre-build steps
-        if: ${{ inputs.pre-build-steps != '' }}
-        env:
-          PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
-        run: |
-          echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
-          # shellcheck source=/dev/null
-          source "$RUNNER_TEMP/pre-build-steps.bash"
       - name: run tests
         env:
           CONFIGURATION: ${{ inputs.configuration }}
           CRON_SCRIPT: ${{ inputs.cron-script }}
+          PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
           START_TEST_ARGS: ${{ inputs.start-test-args }}
           TEST_DIR: ${{ matrix.dir }}
           TEST_FLAGS: ${{ matrix.flags }}
           TEST_ID: ${{ matrix.id }}
         run: |
+          if [[ -n "$PRE_BUILD_STEPS" ]]; then
+            echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
+            # shellcheck source=/dev/null
+            source "$RUNNER_TEMP/pre-build-steps.bash"
+          fi
           if [[ -n "$CRON_SCRIPT" ]]; then
             # shellcheck source=/dev/null
             source "$CRON_SCRIPT"

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -158,9 +158,15 @@ jobs:
       - name: determine test directories
         env:
           TEST_DIRS: ${{ inputs.test-dirs }}
+          PRE_BUILD_STEPS: ${{ inputs.pre-build-steps }}
           CRON_SCRIPT: ${{ inputs.cron-script }}
         run: |
-          # source cron script before running start_test
+          if [[ -n "$PRE_BUILD_STEPS" ]]; then
+            echo "$PRE_BUILD_STEPS" > "$RUNNER_TEMP/pre-build-steps.bash"
+            # shellcheck source=/dev/null
+            source "$RUNNER_TEMP/pre-build-steps.bash"
+          fi
+          # do pre-build and cron before running start_test
           if [[ -n "$CRON_SCRIPT" ]]; then
             # shellcheck source=/dev/null
             source "$CRON_SCRIPT"

--- a/test/arrays/slices/commCounts/sliceLocDist.execopts
+++ b/test/arrays/slices/commCounts/sliceLocDist.execopts
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# force minimum threads on small core systems, otherwise comm counts are unstable
+min_threads=4
+num_cores=$(python3 -c 'import multiprocessing as mp; print(mp.cpu_count())')
+if [ $num_cores -lt $min_threads ]; then
+  echo "--dataParTasksPerLocale=$min_threads"
+fi

--- a/test/arrays/slices/commCounts/sliceLocDist.execopts
+++ b/test/arrays/slices/commCounts/sliceLocDist.execopts
@@ -3,6 +3,6 @@
 # force minimum threads on small core systems, otherwise comm counts are unstable
 min_threads=4
 num_cores=$(python3 -c 'import multiprocessing as mp; print(mp.cpu_count())')
-if [ $num_cores -lt $min_threads ]; then
+if [ $num_cores -le $min_threads ]; then
   echo "--dataParTasksPerLocale=$min_threads"
 fi

--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -21,10 +21,15 @@ def main():
     chpldoc = chpl + 'doc'
 
     # Test chpl
+    _msg('Info', 'Checking man page for', chpl)
     results.append( check_man_page(chpl, ['--no-devel']) )
 
-    # Test chpldoc
-    results.append( check_man_page(chpldoc) )
+    # Test chpldoc - only if its exists
+    if os.path.exists(chpldoc):
+        _msg('Info', 'Checking man page for', chpldoc)
+        results.append( check_man_page(chpldoc) )
+    else:
+        _warn('Skipping man page check for', chpldoc, '- chpldoc is not built')
 
     # Exit clean if no errors.
     if not reduce(operator.and_, results):

--- a/test/optimizations/bulkcomm/block/exchange.prediff
+++ b/test/optimizations/bulkcomm/block/exchange.prediff
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [[ -z ${CHPL_TEST_PERF} ]]; then
   sed -n "s/.*\(Will do parallel transfer\).*/\1/p" <$2 >$2.tmp


### PR DESCRIPTION
Add GA paratest for gasnet-everything

This PR also moves c-backend and darwin paratests to be run nightly instead of in the merge queue to reduce the compute cycles per merge. The most important configs to test are linux64 COMM=none and linux64 COMM=gasnet

This PR also refactors ga-paratest a bit in prep for other work

[Reviewed by @arifthpe]