### PR TITLE
Set -exuo pipefail in portability testing shell scripts

### DIFF
--- a/util/devel/test/portability/apptainer/chapel-clean.sh
+++ b/util/devel/test/portability/apptainer/chapel-clean.sh
@@ -2,6 +2,8 @@
 
 # Git cleans the chapel checkout in each image's directory
 
+set -exuo pipefail
+
 if [ -z "$APPTAINER_IMAGE" ]
 then
   echo "Please set the APPTAINER_IMAGE environment variable to the name of the config you want to run this on."

--- a/util/devel/test/portability/apptainer/chapel-default-fresh.sh
+++ b/util/devel/test/portability/apptainer/chapel-default-fresh.sh
@@ -3,6 +3,8 @@
 # Checks if a fresh default build passes make check
 # Prints a summary at the end.
 
+set -exuo pipefail
+
 # apptainer forwards env vars to container by default, so unset
 # CHPL_DEVELOPER b/c it can change warning behavior
 unset CHPL_DEVELOPER

--- a/util/devel/test/portability/apptainer/chapel-default.sh
+++ b/util/devel/test/portability/apptainer/chapel-default.sh
@@ -3,6 +3,8 @@
 # Checks if a default build passes make check
 # Prints a summary at the end.
 
+set -exuo pipefail
+
 # apptainer forwards env vars to container by default, so unset
 # CHPL_DEVELOPER b/c it can change warning behavior
 unset CHPL_DEVELOPER

--- a/util/devel/test/portability/apptainer/chapel-delete-all.sh
+++ b/util/devel/test/portability/apptainer/chapel-delete-all.sh
@@ -2,6 +2,8 @@
 
 # Deletes the chapel checkout in each image's directory
 
+set -exuo pipefail
+
 for name in current/*
 do
   if [ -f $name/image.def ]

--- a/util/devel/test/portability/apptainer/chapel-quickstart-delete.sh
+++ b/util/devel/test/portability/apptainer/chapel-quickstart-delete.sh
@@ -3,6 +3,8 @@
 # Checks if a fresh Quickstart build passes make check
 # Prints a summary at the end.
 
+set -exuo pipefail
+
 # apptainer forwards env vars to container by default, so unset
 # CHPL_DEVELOPER b/c it can change warning behavior
 unset CHPL_DEVELOPER

--- a/util/devel/test/portability/apptainer/chapel-quickstart-fresh.sh
+++ b/util/devel/test/portability/apptainer/chapel-quickstart-fresh.sh
@@ -3,6 +3,8 @@
 # Checks if a fresh Quickstart build passes make check
 # Prints a summary at the end.
 
+set -exuo pipefail
+
 # apptainer forwards env vars to container by default, so unset
 # CHPL_DEVELOPER b/c it can change warning behavior
 unset CHPL_DEVELOPER

--- a/util/devel/test/portability/apptainer/chapel-quickstart.sh
+++ b/util/devel/test/portability/apptainer/chapel-quickstart.sh
@@ -3,6 +3,8 @@
 # Checks if a Quickstart build passes make check
 # Prints a summary at the end.
 
+set -exuo pipefail
+
 # apptainer forwards env vars to container by default, so unset
 # CHPL_DEVELOPER b/c it can change warning behavior
 unset CHPL_DEVELOPER

--- a/util/devel/test/portability/apptainer/chapel-showcommit.sh
+++ b/util/devel/test/portability/apptainer/chapel-showcommit.sh
@@ -2,4 +2,6 @@
 
 # Shows the commit on each image.
 
+set -exuo pipefail
+
 ./tryit.py "$@" ../../provision-scripts/chapel-showcommit.sh

--- a/util/devel/test/portability/apptainer/chapel-update.sh
+++ b/util/devel/test/portability/apptainer/chapel-update.sh
@@ -3,4 +3,6 @@
 # Updates the chapel checkout to be 'main' (makes sure it exists)
 # Prints a summary at the end.
 
+set -exuo pipefail
+
 ./tryit.py "$@" ../../provision-scripts/chapel-update.sh

--- a/util/devel/test/portability/apptainer/image-delete-all.sh
+++ b/util/devel/test/portability/apptainer/image-delete-all.sh
@@ -2,6 +2,8 @@
 
 # Deletes the apptainer image in each current subdirectory
 
+set -exuo pipefail
+
 for name in current/*
 do
   if [ -f $name/image.def ]

--- a/util/devel/test/portability/apptainer/image-rebuild-all.sh
+++ b/util/devel/test/portability/apptainer/image-rebuild-all.sh
@@ -2,6 +2,8 @@
 
 # Rebuilds the apptainer image in each current subdirectory
 
+set -exuo pipefail
+
 for name in current/*
 do
   if [ -f $name/image.def ]

--- a/util/devel/test/portability/apptainer/image-rebuild.sh
+++ b/util/devel/test/portability/apptainer/image-rebuild.sh
@@ -2,6 +2,8 @@
 
 # Rebuilds the apptainer image in each current subdirectory
 
+set -exuo pipefail
+
 if [ -z "$APPTAINER_IMAGE" ]
 then
   echo "Please set the APPTAINER_IMAGE environment variable to the name of the config you want to run this on."

--- a/util/devel/test/portability/vagrant/chapelbranch.sh
+++ b/util/devel/test/portability/vagrant/chapelbranch.sh
@@ -6,6 +6,8 @@
 #   ./chapelbranch.sh <github-user-name> <github-branch-name>
 #
 
+set -exuo pipefail
+
 GITHUB_USER=$1
 GITHUB_BRANCH=$2
 

--- a/util/devel/test/portability/vagrant/chapeldefaultcheck.sh
+++ b/util/devel/test/portability/vagrant/chapeldefaultcheck.sh
@@ -3,4 +3,6 @@
 # Check if default (util/setchplenv) Chapel build passes make check
 # Prints summary at the end
 
+set -exuo pipefail
+
 ./tryit.sh 'bash -c '\''cd chapel && source util/setchplenv.bash && export GMAKE=`which gmake` && export MAKE=${GMAKE:-make} && $MAKE $MAKEJ && $MAKE $MAKEJ check'\'

--- a/util/devel/test/portability/vagrant/chapelfullcheck.sh
+++ b/util/devel/test/portability/vagrant/chapelfullcheck.sh
@@ -3,4 +3,6 @@
 # Check if full (util/setchplenv + GMP/RE2) Chapel build passes make check
 # Prints summary at the end
 
+set -exuo pipefail
+
 ./tryit.sh 'bash -c '\''cd chapel && source util/setchplenv.bash && export CHPL_GMP=bundled && export CHPL_RE2=`./util/devel/test/portability/vagrant/re2-supported.py` && export GMAKE=`which gmake` && export MAKE=${GMAKE:-make} && $MAKE && $MAKE check'\'

--- a/util/devel/test/portability/vagrant/chapelquickcheck.sh
+++ b/util/devel/test/portability/vagrant/chapelquickcheck.sh
@@ -3,4 +3,6 @@
 # Checks if a Quickstart build passes make check
 # Prints a summary at the end.
 
+set -exuo pipefail
+
 ./tryit.sh 'bash -c '\''cd chapel && source util/quickstart/setchplenv.bash && export GMAKE=`which gmake` && export MAKE=${GMAKE:-make} && $MAKE && $MAKE check'\'

--- a/util/devel/test/portability/vagrant/chapelshowcommit.sh
+++ b/util/devel/test/portability/vagrant/chapelshowcommit.sh
@@ -2,5 +2,7 @@
 
 # Show the current commit of VM's chapel git repository
 
+set -exuo pipefail
+
 ./tryit.sh "cd chapel && GIT_PAGER=cat git log --oneline -n 1 && GIT_PAGER=cat git diff"
 

--- a/util/devel/test/portability/vagrant/chapelupdate.sh
+++ b/util/devel/test/portability/vagrant/chapelupdate.sh
@@ -2,5 +2,7 @@
 
 # Update the Chapel git repository in VM to main
 
+set -exuo pipefail
+
 ./tryit.sh "cd chapel && git fetch origin --depth=1 && git checkout origin/main && GIT_PAGER=cat git log --oneline -n 1 && GIT_PAGER=cat git diff"
 

--- a/util/devel/test/portability/vagrant/clobber.sh
+++ b/util/devel/test/portability/vagrant/clobber.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -exuo pipefail
+
 ./tryit.sh "cd chapel && export GMAKE=`which gmake` && export MAKE=${GMAKE:-make} && $MAKE clobber"

--- a/util/devel/test/portability/vagrant/destroy.sh
+++ b/util/devel/test/portability/vagrant/destroy.sh
@@ -4,6 +4,8 @@
 # Removes space occupied by each VM
 # Don't do this if you have work you want to save in the VMs!
 
+set -exuo pipefail
+
 if [ -z "$VM_NAME" ]
 then
   echo "Please set the VM_NAME environment variable to the name of the VM you want to run this on."

--- a/util/devel/test/portability/vagrant/gitclean.sh
+++ b/util/devel/test/portability/vagrant/gitclean.sh
@@ -2,4 +2,6 @@
 
 # git clean in VM's chapel directory
 
+set -exuo pipefail
+
 ./tryit.sh "cd chapel && GIT_PAGER=cat git clean -fdx"

--- a/util/devel/test/portability/vagrant/halt.sh
+++ b/util/devel/test/portability/vagrant/halt.sh
@@ -2,6 +2,8 @@
 
 # Stop a running VM
 
+set -exuo pipefail
+
 if [ -z "$VM_NAME" ]
 then
   echo "Please set the VM_NAME environment variable to the name of the VM you want to run this on."

--- a/util/devel/test/portability/vagrant/interact.sh
+++ b/util/devel/test/portability/vagrant/interact.sh
@@ -3,6 +3,8 @@
 # Log into VMs to run commands manually
 # Assumes VM is up and leaves it running
 
+set -exuo pipefail
+
 if [ -z "$VM_NAME" ]
 then
   echo "Please set the VM_NAME environment variable to the name of the VM you want to run this on."

--- a/util/devel/test/portability/vagrant/rebuild-all.sh
+++ b/util/devel/test/portability/vagrant/rebuild-all.sh
@@ -3,6 +3,8 @@
 # Rebuild all of the VMs. This will delete all data on the VMs.
 # Don't do that if you have data you want to keep in any VM!
 
+set -exuo pipefail
+
 # enable resizing disks to get
 #  config.vm.disk to work
 #  (to resize the disk for some VMs that come too small)

--- a/util/devel/test/portability/vagrant/tryit.sh
+++ b/util/devel/test/portability/vagrant/tryit.sh
@@ -8,6 +8,8 @@
 # Expects the VM name to be given as an environment variable. The special name
 # "all" can be used to run the command on all VMs.
 
+set -exuo pipefail
+
 if [ -z "$VM_NAME" ]
 then
   echo "Please set the VM_NAME environment variable to the name of the VM you want to run this on."

--- a/util/devel/test/portability/vagrant/up-all.sh
+++ b/util/devel/test/portability/vagrant/up-all.sh
@@ -2,6 +2,8 @@
 
 # Bring each VM up and leave it running.
 
+set -exuo pipefail
+
 for name in current/*
 do
   if [ -f $name/Vagrantfile ]

--- a/util/devel/test/portability/vagrant/updown-all.sh
+++ b/util/devel/test/portability/vagrant/updown-all.sh
@@ -3,6 +3,8 @@
 # Bring each VM up and then shut it down.
 # Useful for making sure they are basically working.
 
+set -exuo pipefail
+
 for name in current/*
 do
   if [ -f $name/Vagrantfile ]


### PR DESCRIPTION
Add `set -exuo pipefail` to each shell script in the Vagrant and Apptainer portability testing dirs.

I noticed in https://github.com/chapel-lang/chapel/actions/runs/32869975126/job/97901896995 that a failure to install `git` (and other packages) in `image-rebuild.sh` was not causing the step to fail.

[reviewed by @jabraham17 , thanks!]