### PR TITLE
Don't report on skipped jobs in failure mail

### DIFF
--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -58,8 +58,8 @@ jobs:
           EOF
       - name: generate email body
         run: |
-          gh api /repos/chapel-lang/chapel/commits/${{ github.sha }} | tee commit.json
-          gh api --paginate /repos/chapel-lang/chapel/actions/runs/${{ github.run_id }}/jobs | tee jobs_raw.json
+          gh api /repos/chapel-lang/chapel/commits/${{ github.sha }} | jq '.' | tee commit.json
+          gh api --paginate /repos/chapel-lang/chapel/actions/runs/${{ github.run_id }}/jobs | jq '.' | tee jobs_raw.json
           # Combine pages of job results into one array
           jq '.jobs[]' jobs_raw.json | jq --slurp '.' | tee jobs_array.json
 
@@ -69,7 +69,7 @@ jobs:
 
           failed_jobs_html=""
           for id in "${failed_job_ids[@]}"; do
-            gh api "/repos/chapel-lang/chapel/actions/jobs/$id" | tee "job_$id.json"
+            gh api "/repos/chapel-lang/chapel/actions/jobs/$id" | jq '.' | tee "job_$id.json"
             sleep 0.25
             failed_jobs_html+=$(jq -r '{html_url, name, first_bad_step: ([.steps[] | select(.conclusion != "success")] | first).name} | "<li><a href=\"\(.html_url)\">\(.name)</a>, step: \"\(.first_bad_step)\"</li>"' "job_$id.json")
           done

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -65,7 +65,7 @@ jobs:
 
           message=$(jq -r '.commit.message' commit.json | head -n 1)
           num_jobs=$(jq 'length' jobs_array.json)
-          readarray -t failed_job_ids < <(jq '.[] | select(.status != "completed" or .conclusion != "success" ) | .id' jobs_array.json)
+          readarray -t failed_job_ids < <(jq '.[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped")) | .id' jobs_array.json)
 
           failed_jobs_html=""
           for id in "${failed_job_ids[@]}"; do

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -69,7 +69,7 @@ jobs:
 
           failed_jobs_html=""
           for id in "${failed_job_ids[@]}"; do
-            gh api "/repos/chapel-lang/chapel/actions/jobs/$id" > "job_$id.json"
+            gh api "/repos/chapel-lang/chapel/actions/jobs/$id" | tee "job_$id.json"
             sleep 0.25
             failed_jobs_html+=$(jq -r '{html_url, name, first_bad_step: ([.steps[] | select(.conclusion != "success")] | first).name} | "<li><a href=\"\(.html_url)\">\(.name)</a>, step: \"\(.first_bad_step)\"</li>"' "job_$id.json")
           done


### PR DESCRIPTION
Exclude `skipped` jobs from the list of failed jobs in the nightly failure mail.

While here, also make GH API responses pretty with `jq '.'` before outputting them to the console (and storing).

[reviewed by @jabraham17 , thanks!]