### PR TITLE
Add automatic retries of GCC and LLVM installs

### DIFF
--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   NIGHTLY_TEST_SETTINGS: true
+  APT_INSTALL_TIMEOUT_MINS: 5
 
 defaults:
   run:
@@ -43,7 +44,7 @@ jobs:
       with:
         persist-credentials: false
     - name: install fluid and libfltk-dev
-      timeout-minutes: 10
+      timeout-minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
       run: |
         apt update && apt install -y \
           fluid \
@@ -429,7 +430,7 @@ jobs:
         with:
           persist-credentials: false
       - name: install deps
-        timeout-minutes: 10
+        timeout-minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
         run: |
           if [[ "$OS" == "macos"* ]] ; then
             brew install llvm

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         persist-credentials: false
     - name: install fluid and libfltk-dev
-      timeout-minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
+      timeout-minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
       run: |
         apt update && apt install -y \
           fluid \
@@ -430,7 +430,7 @@ jobs:
         with:
           persist-credentials: false
       - name: install deps
-        timeout-minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
+        timeout-minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
         run: |
           if [[ "$OS" == "macos"* ]] ; then
             brew install llvm

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -70,6 +70,9 @@ jobs:
           timeout_seconds: 300
           retry_wait_seconds: 60
           command: |
+            sudo update-alternatives --remove-all gcc
+            sudo update-alternatives --remove-all g++
+
             sudo add-apt-repository --yes --update ppa:ubuntu-toolchain-r/test
             sudo apt update
             sudo apt install -y \

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -86,6 +86,8 @@ jobs:
               libgcc-$VERSION-dev \
               libstdc++-$VERSION-dev
 
+            sudo update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-$VERSION" 100
+            sudo update-alternatives --install /usr/bin/g++ g++ "/usr/bin/g++-$VERSION" 100
       - name: Check desired GCC version is default
         run: |
           actual_gcc_version=$(gcc -dumpversion)

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -172,18 +172,22 @@ jobs:
         llvm_version: [15, 16, 17, 18, 19, 20, 21, 22]
     runs-on: ${{ matrix.llvm_version >= 17 && 'ubuntu-latest' || 'ubuntu-22.04' }}
     steps:
-      - name: Install LLVM ${{ matrix.llvm_version }} from official convenience script
-        timeout-minutes: 10
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
+      - name: Install LLVM ${{ matrix.llvm_version }} from official convenience script (retrying)
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 3
+          timeout_seconds: 300
+          retry_wait_seconds: 60
+          command: |
+            wget https://apt.llvm.org/llvm.sh
+            chmod +x llvm.sh
 
-          # Work around https://github.com/llvm/llvm-project/issues/62152
-          set_var=${{ matrix.llvm_version == 15 && 'DPKG_FORCE=overwrite' || '' }}
+            # Work around https://github.com/llvm/llvm-project/issues/62152
+            set_var=${{ matrix.llvm_version == 15 && 'DPKG_FORCE=overwrite' || '' }}
 
-          sudo $set_var ./llvm.sh "${{ matrix.llvm_version }}" all
+            sudo $set_var ./llvm.sh "${{ matrix.llvm_version }}" all
 
-          echo "CHPL_LLVM_CONFIG=$(which llvm-config-${{ matrix.llvm_version }})" >> "$GITHUB_ENV"
+            echo "CHPL_LLVM_CONFIG=$(which llvm-config-${{ matrix.llvm_version }})" >> "$GITHUB_ENV"
       - name: Check desired LLVM version is default
         run: |
           set -exuo pipefail

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -77,12 +77,9 @@ jobs:
             sudo apt update
             sudo apt install -y \
               cpp-$VERSION \
-              cpp-$VERSION-x86-64-linux-gnu \
               g++-$VERSION \
-              g++-$VERSION-x86-64-linux-gnu \
               gcc-$VERSION \
               gcc-$VERSION-base \
-              gcc-$VERSION-x86-64-linux-gnu \
               libgcc-$VERSION-dev \
               libstdc++-$VERSION-dev
 

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -72,7 +72,7 @@ jobs:
           command: |
             sudo add-apt-repository --yes --update ppa:ubuntu-toolchain-r/test
             sudo apt update
-            sudo apt install -y "gcc-$VERSION"
+            sudo apt install -y "gcc-$VERSION" "g++-$VERSION"
       - name: Check desired GCC version is default
         run: |
           actual_gcc_version=$(gcc -dumpversion)

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -72,7 +72,17 @@ jobs:
           command: |
             sudo add-apt-repository --yes --update ppa:ubuntu-toolchain-r/test
             sudo apt update
-            sudo apt install -y "gcc-$VERSION" "g++-$VERSION"
+            sudo apt install -y \
+              cpp-$VERSION \
+              cpp-$VERSION-x86-64-linux-gnu \
+              g++-$VERSION \
+              g++-$VERSION-x86-64-linux-gnu \
+              gcc-$VERSION \
+              gcc-$VERSION-base \
+              gcc-$VERSION-x86-64-linux-gnu \
+              libgcc-$VERSION-dev \
+              libstdc++-$VERSION-dev
+
       - name: Check desired GCC version is default
         run: |
           actual_gcc_version=$(gcc -dumpversion)

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python
-        timeout-minutes: 10
+        timeout-minutes: 5
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python_version }}

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   NIGHTLY_TEST_SETTINGS: true
+  APT_INSTALL_TIMEOUT_MINS: 5
 
 defaults:
   run:
@@ -67,7 +68,7 @@ jobs:
           VERSION: ${{ matrix.gcc_version }}
         with:
           max_attempts: 3
-          timeout_seconds: 300
+          timeout_minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
           retry_wait_seconds: 60
           command: |
             sudo update-alternatives --remove-all gcc
@@ -131,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python
-        timeout-minutes: 5
+        timeout-minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python_version }}
@@ -143,7 +144,7 @@ jobs:
           source util/cron/common-python.bash
           check_python_version "${{ matrix.python_version }}"
       - name: Install LLVM dependency
-        timeout-minutes: 10
+        timeout-minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
         run: |
           sudo apt install \
             clang \
@@ -176,7 +177,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 3
-          timeout_seconds: 300
+          timeout_minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
           retry_wait_seconds: 60
           command: |
             wget https://apt.llvm.org/llvm.sh

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -68,7 +68,7 @@ jobs:
           VERSION: ${{ matrix.gcc_version }}
         with:
           max_attempts: 3
-          timeout_minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
+          timeout_minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
           retry_wait_seconds: 60
           command: |
             sudo update-alternatives --remove-all gcc
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python
-        timeout-minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
+        timeout-minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python_version }}
@@ -144,7 +144,7 @@ jobs:
           source util/cron/common-python.bash
           check_python_version "${{ matrix.python_version }}"
       - name: Install LLVM dependency
-        timeout-minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
+        timeout-minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
         run: |
           sudo apt install \
             clang \
@@ -177,7 +177,7 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 3
-          timeout_minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
+          timeout_minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
           retry_wait_seconds: 60
           command: |
             wget https://apt.llvm.org/llvm.sh

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -61,11 +61,18 @@ jobs:
       - name: save matrix properties to env
         run: |
           echo "GCC_VERSION=${{ matrix.gcc_version }}" >> "$GITHUB_ENV"
-      - name: Install GCC
-        timeout-minutes: 10
-        uses: egor-tensin/setup-gcc@a2861a8b8538f49cf2850980acccf6b05a1b2ae4 # v2
+      - name: Install GCC ${{ matrix.gcc_version }} (retrying)
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          VERSION: ${{ matrix.gcc_version }}
         with:
-          version: ${{ matrix.gcc_version }}
+          max_attempts: 3
+          timeout_seconds: 300
+          retry_wait_seconds: 60
+          command: |
+            sudo add-apt-repository --yes --update ppa:ubuntu-toolchain-r/test
+            sudo apt update
+            sudo apt install -y "gcc-$VERSION"
       - name: Check desired GCC version is default
         run: |
           actual_gcc_version=$(gcc -dumpversion)

--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -63,7 +63,7 @@ jobs:
       apptainer_dir: ./util/devel/test/portability/apptainer
     steps:
       - name: install Apptainer
-        timeout-minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
+        timeout-minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
         run: |
           sudo add-apt-repository -y ppa:apptainer/ppa
           sudo apt update

--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   NIGHTLY_TEST_SETTINGS: true
+  APT_INSTALL_TIMEOUT_MINS: 5
 
 defaults:
   run:
@@ -62,7 +63,7 @@ jobs:
       apptainer_dir: ./util/devel/test/portability/apptainer
     steps:
       - name: install Apptainer
-        timeout-minutes: 10
+        timeout-minutes: ${{ env.APT_INSTALL_TIMEOUT_MINS }}
         run: |
           sudo add-apt-repository -y ppa:apptainer/ppa
           sudo apt update


### PR DESCRIPTION
Use https://github.com/nick-fields/retry to retry GCC and LLVM install steps up to 3 times, to smooth over transient network issues.

Also reduces the timeout for these and the Python jobs to just 5 minutes for the install step, as that should still be more than enough.

Since this action can only wrap shell command steps, also replaces the use of https://github.com/egor-tensin/setup-gcc with directly installing GCC in the shell.

[reviewed by @jabraham17 , thanks!]