### PR TITLE
Apply `black` format check to more extensionless Python files

### DIFF
--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -337,7 +337,8 @@ jobs:
   check-python-format:
     runs-on: ubuntu-slim
     env:
-      EXTENSIONLESS_PYTHON_FILES: ""
+      EXTENSIONLESS_PYTHON_FILES: |
+        test/mason/MasonBashSubTest
       BLACK_OPTIONS: "--check --verbose --line-length 80"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -358,6 +358,7 @@ jobs:
       - name: Find extensionless Python files in util/
         run: |
           EXTENSIONLESS_PYTHON_FILES+="$(find util/ -type f ! -name '*.py' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)"
+          echo "$EXTENSIONLESS_PYTHON_FILES"
           {
             echo "EXTENSIONLESS_PYTHON_FILES<<EOF"
             echo "$EXTENSIONLESS_PYTHON_FILES"

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -342,6 +342,7 @@ jobs:
       # a later step.
       EXTENSIONLESS_PYTHON_FILES: |
         test/mason/MasonBashSubTest
+        test/man/checkManPages
       BLACK_OPTIONS: "--check --verbose --line-length 80"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -360,7 +360,8 @@ jobs:
           src: "third-party/chpl-venv"
       - name: Find extensionless Python files in util/ and Python sub_tests in test/
         run: |
-          EXTENSIONLESS_PYTHON_FILES+="$(find util/ -type f ! -name '*.py' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)"
+          EXTENSIONLESS_PYTHON_FILES+="$(find util/ -type f ! -name '*.py' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)
+          "
           EXTENSIONLESS_PYTHON_FILES+="$(find test/ -type f -name 'sub_test' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)"
           echo "$EXTENSIONLESS_PYTHON_FILES"
           {

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -355,11 +355,9 @@ jobs:
           src: "third-party/chpl-venv"
       - name: Find extensionless Python files in util/
         run: |
-          {
-            echo 'EXTENSIONLESS_PYTHON_FILES<<EOF'
-            find util/ -type f ! -name '*.py' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;
-            echo 'EOF'
-          } >> "$GITHUB_ENV"
+          EXTENSIONLESS_PYTHON_FILES+="$(find util/ -type f ! -name '*.py' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)"
+
+          echo "EXTENSIONLESS_PYTHON_FILES=$EXTENSIONLESS_PYTHON_FILES" >> "$GITHUB_ENV"
       - name: Check extensionless Python files
         uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # 26.5.1
         with:

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -338,6 +338,8 @@ jobs:
   check-python-format:
     runs-on: ubuntu-slim
     env:
+      # Specifically included files for formatting. We will add to this list in
+      # a later step.
       EXTENSIONLESS_PYTHON_FILES: |
         test/mason/MasonBashSubTest
       BLACK_OPTIONS: "--check --verbose --line-length 80"
@@ -355,9 +357,10 @@ jobs:
         with:
           options: "${{ env.BLACK_OPTIONS }} --extend-exclude '(install|build)/'"
           src: "third-party/chpl-venv"
-      - name: Find extensionless Python files in util/ and test/
+      - name: Find extensionless Python files in util/ and Python sub_tests in test/
         run: |
-          EXTENSIONLESS_PYTHON_FILES+="$(find util/ test/ -type f ! -name '*.py' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)"
+          EXTENSIONLESS_PYTHON_FILES+="$(find util/ -type f ! -name '*.py' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)"
+          EXTENSIONLESS_PYTHON_FILES+="$(find test/ -type f -name 'sub_test' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)"
           echo "$EXTENSIONLESS_PYTHON_FILES"
           {
             echo "EXTENSIONLESS_PYTHON_FILES<<EOF"

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -355,9 +355,9 @@ jobs:
         with:
           options: "${{ env.BLACK_OPTIONS }} --extend-exclude '(install|build)/'"
           src: "third-party/chpl-venv"
-      - name: Find extensionless Python files in util/
+      - name: Find extensionless Python files in util/ and test/
         run: |
-          EXTENSIONLESS_PYTHON_FILES+="$(find util/ -type f ! -name '*.py' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)"
+          EXTENSIONLESS_PYTHON_FILES+="$(find util/ test/ -type f ! -name '*.py' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)"
           echo "$EXTENSIONLESS_PYTHON_FILES"
           {
             echo "EXTENSIONLESS_PYTHON_FILES<<EOF"

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -358,8 +358,11 @@ jobs:
       - name: Find extensionless Python files in util/
         run: |
           EXTENSIONLESS_PYTHON_FILES+="$(find util/ -type f ! -name '*.py' -exec grep -Iq . {} \; -exec awk 'FNR == 1 && /^#!.*[[:space:]\/]python([0-9]+([.][0-9]+)*)?([[:space:]]|$)/ { print FILENAME }' {} \;)"
-
-          echo "EXTENSIONLESS_PYTHON_FILES=$EXTENSIONLESS_PYTHON_FILES" >> "$GITHUB_ENV"
+          {
+            echo "EXTENSIONLESS_PYTHON_FILES<<EOF"
+            echo "$EXTENSIONLESS_PYTHON_FILES"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
       - name: Check extensionless Python files
         uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # 26.5.1
         with:

--- a/test/cmake/sub_test
+++ b/test/cmake/sub_test
@@ -108,8 +108,11 @@ def run_build(subdir, build_type):
             finally:
                 print(f"[Finished installing {subdir} with {build_type}]")
 
-
-    print("[Success matching build process for {} with {}]".format(subdir, build_type))
+    print(
+        "[Success matching build process for {} with {}]".format(
+            subdir, build_type
+        )
+    )
     return 0
 
 

--- a/test/compflags/ferguson/default-binary-name/sub_test
+++ b/test/compflags/ferguson/default-binary-name/sub_test
@@ -4,85 +4,112 @@ import subprocess
 import sys
 import os
 
-if len(sys.argv)!=2:
-  print('usage: sub_test COMPILER')
-  sys.exit(0)
+if len(sys.argv) != 2:
+    print("usage: sub_test COMPILER")
+    sys.exit(0)
 
 home = ""
 if "CHPL_HOME" in os.environ:
-  home = os.environ["CHPL_HOME"]
+    home = os.environ["CHPL_HOME"]
 
 platform = "unknown"
 if "CHPL_TARGET_PLATFORM" in os.environ:
-  platform = os.environ["CHPL_TARGET_PLATFORM"]
+    platform = os.environ["CHPL_TARGET_PLATFORM"]
 else:
-  p = subprocess.Popen([home + "/util/chplenv/chpl_platform.py", "--target"],
-                        stdout=subprocess.PIPE)
-  myoutput = p.communicate()[0].decode()
-  if p.returncode != 0:
-    sys.stdout.write("could not run chpl_platform.py")
-    sys.exit(1)
-  else:
-    platform = myoutput
+    p = subprocess.Popen(
+        [home + "/util/chplenv/chpl_platform.py", "--target"],
+        stdout=subprocess.PIPE,
+    )
+    myoutput = p.communicate()[0].decode()
+    if p.returncode != 0:
+        sys.stdout.write("could not run chpl_platform.py")
+        sys.exit(1)
+    else:
+        platform = myoutput
 
 
 # Skip this test on cygwin to avoid sporadic "Device or resource busy" errors
 if platform.startswith("cygwin"):
-  sys.exit(0)
+    sys.exit(0)
 
 # Find the base installation
-compiler=sys.argv[1]
-if not os.access(compiler,os.R_OK|os.X_OK):
-  Fatal('Cannot execute compiler \''+compiler+'\'')
+compiler = sys.argv[1]
+if not os.access(compiler, os.R_OK | os.X_OK):
+    Fatal("Cannot execute compiler '" + compiler + "'")
 
 # find current directory
 
-def run(source, exe_name, compopts, expect): 
-  p = subprocess.Popen([compiler, source] + compopts,
-                       stdout=subprocess.PIPE)
-  myoutput = p.communicate()[0].decode()
-  sys.stdout.write(myoutput)
-  if p.returncode != 0:
-    sys.stdout.write("[Error matching compiler output for %s (%s)]\n"%(source, exe_name))
-    sys.exit(1)
-  else:
-    sys.stdout.write("[Success compiling %s (%s)]\n"%(source, exe_name))
 
-  returncode = -1
-  myoutput = ""
-
-  if os.access(exe_name,os.R_OK|os.X_OK):
-
-    numlocales = "0"
-    if "NUMLOCALES" in os.environ:
-      numlocales = os.environ['NUMLOCALES']
-
-    if numlocales == "0":
-      p = subprocess.Popen(["./%s" % exe_name], stdout=subprocess.PIPE)
-    else:
-      p = subprocess.Popen(["./%s" % exe_name, "-nl%s" % numlocales],
-          stdout=subprocess.PIPE)
-
+def run(source, exe_name, compopts, expect):
+    p = subprocess.Popen([compiler, source] + compopts, stdout=subprocess.PIPE)
     myoutput = p.communicate()[0].decode()
-    returncode = p.returncode
+    sys.stdout.write(myoutput)
+    if p.returncode != 0:
+        sys.stdout.write(
+            "[Error matching compiler output for %s (%s)]\n"
+            % (source, exe_name)
+        )
+        sys.exit(1)
+    else:
+        sys.stdout.write("[Success compiling %s (%s)]\n" % (source, exe_name))
 
-  myoutput = myoutput.strip()
-  if returncode == 0 and myoutput == expect:
-    sys.stdout.write("[Success matching program output for %s (%s)]\n"%(source, exe_name))
-  else:
-    sys.stdout.write("[Error matching program output for %s (%s)]\n"%(source, exe_name))
+    returncode = -1
+    myoutput = ""
 
-  if os.access(exe_name, os.F_OK):
-    os.remove(exe_name)
-  if os.access(exe_name + "_real", os.F_OK):
-    os.remove(exe_name + "_real")
+    if os.access(exe_name, os.R_OK | os.X_OK):
+
+        numlocales = "0"
+        if "NUMLOCALES" in os.environ:
+            numlocales = os.environ["NUMLOCALES"]
+
+        if numlocales == "0":
+            p = subprocess.Popen(["./%s" % exe_name], stdout=subprocess.PIPE)
+        else:
+            p = subprocess.Popen(
+                ["./%s" % exe_name, "-nl%s" % numlocales],
+                stdout=subprocess.PIPE,
+            )
+
+        myoutput = p.communicate()[0].decode()
+        returncode = p.returncode
+
+    myoutput = myoutput.strip()
+    if returncode == 0 and myoutput == expect:
+        sys.stdout.write(
+            "[Success matching program output for %s (%s)]\n"
+            % (source, exe_name)
+        )
+    else:
+        sys.stdout.write(
+            "[Error matching program output for %s (%s)]\n" % (source, exe_name)
+        )
+
+    if os.access(exe_name, os.F_OK):
+        os.remove(exe_name)
+    if os.access(exe_name + "_real", os.F_OK):
+        os.remove(exe_name + "_real")
 
 
 run("test-default-binary-name.chpl", "test-default-binary-name", [], "Hello")
 run("test-default-binary-name.chpl", "test_exe", ["-o", "test_exe"], "Hello")
-run("test-default-binary-name-main-module.chpl", "test-default-binary-name-main-module", ["--main-module", "M1"], "M1 main")
-run("test-default-binary-name-main-module.chpl", "test-default-binary-name-main-module", ["--main-module", "M2"], "M2 main")
-run("test-default-binary-name2.chpl", "test-default-binary-name2", [], "Hi\nHello")
+run(
+    "test-default-binary-name-main-module.chpl",
+    "test-default-binary-name-main-module",
+    ["--main-module", "M1"],
+    "M1 main",
+)
+run(
+    "test-default-binary-name-main-module.chpl",
+    "test-default-binary-name-main-module",
+    ["--main-module", "M2"],
+    "M2 main",
+)
+run(
+    "test-default-binary-name2.chpl",
+    "test-default-binary-name2",
+    [],
+    "Hi\nHello",
+)
 run("test-default-binary-name3.chpl", "test-default-binary-name3", [], "Hi")
 run("test-default-binary-name3.chpl", "M3", ["M3.chpl"], "Hi\nHello")
 run("subdir/testSubDirFile.chpl", "testSubDirFile", [], "Hello")

--- a/test/compflags/oom/sub_test
+++ b/test/compflags/oom/sub_test
@@ -11,7 +11,6 @@ import sys
 import time
 from datetime import datetime
 
-
 # Expected OOM warning message
 oom_message = "warning: A driver phase was killed by signal SIGKILL -- possibly due to running out of memory"
 # Substring of message announcing phase start to search for
@@ -37,6 +36,7 @@ subtest_test_name = '"compflags/oom"'
 
 errored = False
 
+
 def subtest_start():
     global subtest_start_time
     subtest_start_time = datetime.now()
@@ -44,12 +44,16 @@ def subtest_start():
     print(f"[Starting subtest - {datetime.now().strftime('%c')}]")
     print(f"[test: {subtest_test_name}]")
 
+
 def subtest_end():
     subtest_end_time = datetime.now()
     elapsed_time = (subtest_end_time - subtest_start_time).total_seconds()
 
-    print(f"[Elapsed time to compile and execute all versions of {subtest_test_name} - {elapsed_time} seconds]")
+    print(
+        f"[Elapsed time to compile and execute all versions of {subtest_test_name} - {elapsed_time} seconds]"
+    )
     print(f"[Finished subtest {subtest_test_name} - {elapsed_time} seconds]")
+
 
 def subtest_error(msg):
     global errored
@@ -57,6 +61,7 @@ def subtest_error(msg):
     if not errored:
         errored = True
         print(f"[Error running out-of-memory test {subtest_test_name} - {msg}]")
+
 
 ### END sub_test output helper functions ###
 
@@ -82,6 +87,7 @@ def kill_subphase(ppid):
 
     subtest_error("Could not find PID of subphase to kill.")
 
+
 def main():
     subtest_start()
 
@@ -90,7 +96,10 @@ def main():
 
     cmd = [chpl_cmd, "--print-commands", chpl_file]
     process = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
     )
 
     encountered_subphase = False
@@ -111,7 +120,9 @@ def main():
     if not killed_subphase:
         subtest_error("Expected subphase was not found in compiler output.")
     elif not oom_message_found:
-        subtest_error("Did not find expected OOM message in output after killing subphase.")
+        subtest_error(
+            "Did not find expected OOM message in output after killing subphase."
+        )
     else:
         print("Found expected OOM warning message after killing subphase.")
 

--- a/test/functions/ferguson/main/sub_test
+++ b/test/functions/ferguson/main/sub_test
@@ -4,61 +4,65 @@ import subprocess
 import sys
 import os
 
-if len(sys.argv)!=2:
-  print('usage: sub_test COMPILER')
-  sys.exit(0)
+if len(sys.argv) != 2:
+    print("usage: sub_test COMPILER")
+    sys.exit(0)
 
 # Find the base installation
-compiler=sys.argv[1]
-if not os.access(compiler,os.R_OK|os.X_OK):
-  Fatal('Cannot execute compiler \''+compiler+'\'')
+compiler = sys.argv[1]
+if not os.access(compiler, os.R_OK | os.X_OK):
+    Fatal("Cannot execute compiler '" + compiler + "'")
 
 exe_name = "test_main_return"
 
-p = subprocess.Popen([compiler, "-o", exe_name, "main_return.chpl"], 
-    stdout=subprocess.PIPE)
+p = subprocess.Popen(
+    [compiler, "-o", exe_name, "main_return.chpl"], stdout=subprocess.PIPE
+)
 myoutput = p.communicate()[0].decode()
 sys.stdout.write(myoutput)
 if p.returncode != 0:
-  sys.stdout.write("[Error (sub_test): the compile did not exit cleanly]\n")
-  sys.exit(1)
+    sys.stdout.write("[Error (sub_test): the compile did not exit cleanly]\n")
+    sys.exit(1)
 else:
-  sys.stdout.write("[Success compiling main_return.chpl]\n")
+    sys.stdout.write("[Success compiling main_return.chpl]\n")
 
 
-if not os.access(exe_name,os.R_OK|os.X_OK):
-  Fatal('Cannot execute %s' % exe_name)
+if not os.access(exe_name, os.R_OK | os.X_OK):
+    Fatal("Cannot execute %s" % exe_name)
 
-numlocales = os.environ['NUMLOCALES']
+numlocales = os.environ["NUMLOCALES"]
 
 if numlocales == "0":
-  p = subprocess.Popen(["./%s" % exe_name], stdout=subprocess.PIPE)
+    p = subprocess.Popen(["./%s" % exe_name], stdout=subprocess.PIPE)
 else:
-  p = subprocess.Popen(["./%s" % exe_name, "-nl%s" % numlocales],
-      stdout=subprocess.PIPE)
+    p = subprocess.Popen(
+        ["./%s" % exe_name, "-nl%s" % numlocales], stdout=subprocess.PIPE
+    )
 
 myoutput = p.communicate()[0].decode()
 sys.stdout.write(myoutput)
 if p.returncode != 0:
-  sys.stdout.write("[Error (sub_test): exe did not exit with 0]\n" % ENV_VAR)
+    sys.stdout.write("[Error (sub_test): exe did not exit with 0]\n" % ENV_VAR)
 else:
-  sys.stdout.write("[Success matching 0 exit value]\n")
+    sys.stdout.write("[Success matching 0 exit value]\n")
 
 if numlocales == "0":
-  p = subprocess.Popen(["./%s" % exe_name, "--ret_val=42"],
-                       stdout=subprocess.PIPE)
+    p = subprocess.Popen(
+        ["./%s" % exe_name, "--ret_val=42"], stdout=subprocess.PIPE
+    )
 else:
-  p = subprocess.Popen(["./%s" % exe_name,"-nl%s" % numlocales,"--ret_val=42"],
-                        stdout=subprocess.PIPE)
+    p = subprocess.Popen(
+        ["./%s" % exe_name, "-nl%s" % numlocales, "--ret_val=42"],
+        stdout=subprocess.PIPE,
+    )
 
 myoutput = p.communicate()[0].decode()
 sys.stdout.write(myoutput)
 if p.returncode != 42:
-  sys.stdout.write("[Error (sub_test): exe did not exit with 42]\n" % ENV_VAR)
+    sys.stdout.write("[Error (sub_test): exe did not exit with 42]\n" % ENV_VAR)
 else:
-  sys.stdout.write("[Success matching 42 exit value]\n")
+    sys.stdout.write("[Success matching 42 exit value]\n")
 
 os.remove(exe_name)
 if os.access(exe_name + "_real", os.F_OK):
-  os.remove(exe_name + "_real")
-
+    os.remove(exe_name + "_real")

--- a/test/llvm/debugInfo/chpl-parallel-dbg/sub_test
+++ b/test/llvm/debugInfo/chpl-parallel-dbg/sub_test
@@ -16,14 +16,17 @@ if not chpl_home.exists():
     sys.exit(1)
 sys.path.insert(0, str(chpl_home / "util" / "test"))
 import sub_test as sub_test_util
+
 sub_test_util.utildir = str(chpl_home / "util")
 
+
 def timeout():
-    default=300
+    default = 300
     return int(os.getenv("CHPL_TEST_TIMEOUT", default))
 
+
 def chpl() -> Path:
-    sub_dir =  chpl_home / "util" / "chplenv" / "chpl_bin_subdir.py"
+    sub_dir = chpl_home / "util" / "chplenv" / "chpl_bin_subdir.py"
     result = sp.check_output(
         [sys.executable, str(sub_dir), "--host"],
         encoding="utf-8",
@@ -31,8 +34,10 @@ def chpl() -> Path:
     ).strip()
     return chpl_home / "bin" / result / "chpl"
 
+
 def chpl_parallel_dbg() -> Path:
     return chpl_home / "tools" / "chpl-parallel-dbg" / "chpl-parallel-dbg"
+
 
 def FileCheck() -> Path:
     llvm_config_script = chpl_home / "util" / "chplenv" / "chpl_llvm.py"
@@ -58,13 +63,12 @@ def FileCheck() -> Path:
     assert filecheck.exists(), "Could not find FileCheck"
     return filecheck
 
+
 def FileCheckFiles(input_file: Path, pattern: Path) -> int:
     args = ["--input-file", str(input_file), str(pattern)]
-    sys.stdout.write('[Executing FileCheck {}]\n'.format(' '.join(args)))
-    (returncode, myoutput, _) = sub_test_util.run_process(
-        [str(FileCheck())] + args,
-        stdout=sp.PIPE,
-        stderr=sp.STDOUT
+    sys.stdout.write("[Executing FileCheck {}]\n".format(" ".join(args)))
+    returncode, myoutput, _ = sub_test_util.run_process(
+        [str(FileCheck())] + args, stdout=sp.PIPE, stderr=sp.STDOUT
     )
     if returncode != 0:
         sys.stdout.write(sub_test_util.trim_output(myoutput))
@@ -79,6 +83,7 @@ def EXECOPTS(d: Path) -> List[str]:
             execopts.extend(f.read().strip().split())
     return execopts
 
+
 def COMPOPTS(d: Path) -> List[str]:
     compopts_file = d / "COMPOPTS"
     compopts = []
@@ -87,6 +92,7 @@ def COMPOPTS(d: Path) -> List[str]:
             compopts.extend(f.read().strip().split())
     return compopts
 
+
 @dataclass
 class Test:
     """
@@ -94,6 +100,7 @@ class Test:
 
     Currently only supports simple, one line, non-executable compopts/execopts
     """
+
     source_file: Path
     good_file: Path
     dbgcmds_file: Path
@@ -116,10 +123,14 @@ class Test:
         compopts_file = source_file.with_suffix(".compopts")
         execopts_file = source_file.with_suffix(".execopts")
         if not good_file.exists():
-            sys.stdout.write(f"[Warning: missing .good file for {source_file}]\n")
+            sys.stdout.write(
+                f"[Warning: missing .good file for {source_file}]\n"
+            )
             return None
         if not dbgcmds_file.exists():
-            sys.stdout.write(f"[Warning: missing .dbg.cmds file for {source_file}]\n")
+            sys.stdout.write(
+                f"[Warning: missing .dbg.cmds file for {source_file}]\n"
+            )
             return None
         kwargs: Dict[str, Any] = {
             "source_file": source_file,
@@ -148,7 +159,9 @@ class Test:
 
         try:
             cmd = [str(chpl()), str(self.source_file)] + compopts
-            sys.stdout.write('[Executing compiler command: {}]\n'.format(' '.join(cmd)))
+            sys.stdout.write(
+                "[Executing compiler command: {}]\n".format(" ".join(cmd))
+            )
             sys.stdout.flush()
             sp.check_call(cmd)
         except sp.CalledProcessError as e:
@@ -167,7 +180,6 @@ class Test:
                 execopts.extend(f.read().strip().split())
         execopts.append("-nl{}".format(self.numlocales))
 
-
         if not executable.exists():
             sys.stdout.write(f"[Error finding {executable}]\n")
             sys.stdout.flush()
@@ -179,18 +191,34 @@ class Test:
         debugger_fp = open(debugger_output, "w")
 
         cmd = [str(executable.absolute())] + execopts
-        sys.stdout.write('[Executing program: {}]\n'.format(' '.join(cmd)))
+        sys.stdout.write("[Executing program: {}]\n".format(" ".join(cmd)))
         sys.stdout.flush()
         # preexec_fn=os.setsid to allow killing the entire process group later
-        executable_process = sp.Popen(cmd, stdout=executable_fp, stderr=sp.STDOUT, preexec_fn=os.setsid)
+        executable_process = sp.Popen(
+            cmd, stdout=executable_fp, stderr=sp.STDOUT, preexec_fn=os.setsid
+        )
 
         time.sleep(2)
 
-        dbg_cmd = [str(chpl_parallel_dbg()), str(executable), str(self.numlocales), "-o", "settings set interpreter.stop-command-source-on-error false", "-o", "settings set interpreter.prompt-on-quit false"]
-        sys.stdout.write('[Executing debugger: {}]\n'.format(' '.join(dbg_cmd)))
+        dbg_cmd = [
+            str(chpl_parallel_dbg()),
+            str(executable),
+            str(self.numlocales),
+            "-o",
+            "settings set interpreter.stop-command-source-on-error false",
+            "-o",
+            "settings set interpreter.prompt-on-quit false",
+        ]
+        sys.stdout.write("[Executing debugger: {}]\n".format(" ".join(dbg_cmd)))
         sys.stdout.flush()
-        dbg_process = sp.Popen(dbg_cmd, stdout=debugger_fp, stderr=sp.STDOUT, stdin=sp.PIPE, encoding="utf-8")
-        with open (self.dbgcmds_file, "r") as f:
+        dbg_process = sp.Popen(
+            dbg_cmd,
+            stdout=debugger_fp,
+            stderr=sp.STDOUT,
+            stdin=sp.PIPE,
+            encoding="utf-8",
+        )
+        with open(self.dbgcmds_file, "r") as f:
             dbg_commands = f.read()
             for line in dbg_commands.splitlines():
                 if line.strip().startswith("#") or line.strip() == "":
@@ -221,24 +249,44 @@ class Test:
     def _run_prediff(self, prediff: Path, output_file: Path):
         if not prediff.exists():
             return
-        sys.stdout.write(f'[Executing ./{prediff.name}]\n')
+        sys.stdout.write(f"[Executing ./{prediff.name}]\n")
         sys.stdout.flush()
         stdout = sub_test_util.run_process(
-            [str(prediff.absolute()), self.source_file.stem, str(output_file), chpl()],
-            stdout=sp.PIPE, stderr=sp.STDOUT)[1]
+            [
+                str(prediff.absolute()),
+                self.source_file.stem,
+                str(output_file),
+                chpl(),
+            ],
+            stdout=sp.PIPE,
+            stderr=sp.STDOUT,
+        )[1]
         sys.stdout.write(stdout)
         sys.stdout.flush()
 
-    def _compare_output(self, executable_output: Path, debugger_output: Path) -> bool:
+    def _compare_output(
+        self, executable_output: Path, debugger_output: Path
+    ) -> bool:
         # check executable output
-        self._run_prediff(self.source_file.parent / "PREDIFF", executable_output)
-        self._run_prediff(self.source_file.with_suffix(".prediff"), executable_output)
-        if sub_test_util.DiffFiles(str(self.good_file), str(executable_output)) != 0:
-            sys.stdout.write(f"[Error matching executable output for {self.source_file.stem}]\n")
+        self._run_prediff(
+            self.source_file.parent / "PREDIFF", executable_output
+        )
+        self._run_prediff(
+            self.source_file.with_suffix(".prediff"), executable_output
+        )
+        if (
+            sub_test_util.DiffFiles(str(self.good_file), str(executable_output))
+            != 0
+        ):
+            sys.stdout.write(
+                f"[Error matching executable output for {self.source_file.stem}]\n"
+            )
             return False
         # check debugger output with FileCheck
         if FileCheckFiles(debugger_output, self.source_file) != 0:
-            sys.stdout.write(f"[Error matching debugger output for {self.source_file.stem}]\n")
+            sys.stdout.write(
+                f"[Error matching debugger output for {self.source_file.stem}]\n"
+            )
             return False
         return True
 
@@ -263,31 +311,37 @@ class Test:
             else:
                 if self._compare_output(executable_output, debugger_output):
                     self._cleanup(executable_output, debugger_output)
-                    sys.stdout.write("[Success matching output for {}]\n".format(self.source_file.stem))
+                    sys.stdout.write(
+                        "[Success matching output for {}]\n".format(
+                            self.source_file.stem
+                        )
+                    )
         elapsed = time.time() - start_time
         sub_test_util.printEndOfTestMsg(self.source_file, elapsed)
 
+
 def dirSkipIf(d: Path):
     skipif_file = d / "SKIPIF"
-    if skipif_file.exists() and os.getenv('CHPL_TEST_SINGLES')=='0':
-        sys.stdout.write('[Checking SKIPIF]\n')
+    if skipif_file.exists() and os.getenv("CHPL_TEST_SINGLES") == "0":
+        sys.stdout.write("[Checking SKIPIF]\n")
         sys.stdout.flush()
         do_not_test = False
         try:
-            skipme=False
-            skiptest=sub_test_util.runSkipIf(str(skipif_file.name))
+            skipme = False
+            skiptest = sub_test_util.runSkipIf(str(skipif_file.name))
             if skiptest.strip() != "False":
                 skipme = skiptest.strip() == "True" or int(skiptest) == 1
             if skipme:
-                sys.stdout.write('[Skipping test based on SKIPIF]\n')
-                do_not_test=True
+                sys.stdout.write("[Skipping test based on SKIPIF]\n")
+                do_not_test = True
         except (ValueError, RuntimeError) as e:
-            sys.stdout.write(str(e)+'\n')
-            sys.stdout.write('[Error processing SKIPIF file]\n')
-            do_not_test=True
+            sys.stdout.write(str(e) + "\n")
+            sys.stdout.write("[Error processing SKIPIF file]\n")
+            do_not_test = True
         if do_not_test:
             return True
     return False
+
 
 def main():
     sub_test_util.printStartOfTestMsg(time.localtime())

--- a/test/man/checkManPages
+++ b/test/man/checkManPages
@@ -18,18 +18,18 @@ import sys
 def main():
     results = []
     chpl = sys.argv[1]
-    chpldoc = chpl + 'doc'
+    chpldoc = chpl + "doc"
 
     # Test chpl
-    _msg('Info', 'Checking man page for', chpl)
-    results.append( check_man_page(chpl, ['--no-devel']) )
+    _msg("Info", "Checking man page for", chpl)
+    results.append(check_man_page(chpl, ["--no-devel"]))
 
     # Test chpldoc - only if its exists
     if os.path.exists(chpldoc):
-        _msg('Info', 'Checking man page for', chpldoc)
-        results.append( check_man_page(chpldoc) )
+        _msg("Info", "Checking man page for", chpldoc)
+        results.append(check_man_page(chpldoc))
     else:
-        _warn('Skipping man page check for', chpldoc, '- chpldoc is not built')
+        _warn("Skipping man page check for", chpldoc, "- chpldoc is not built")
 
     # Exit clean if no errors.
     if not reduce(operator.and_, results):
@@ -55,13 +55,16 @@ def check_man_page(bin_name, additional_args=None):
     help_cmd = [bin_name]
     if additional_args is not None:
         help_cmd.extend(additional_args)
-    help_cmd.append('--help')
+    help_cmd.append("--help")
     helptxt, help_exit = _run_cmd(help_cmd)
 
     if help_exit != 0:
-        _error('failed to get help text with:',
-               ' '.join(help_cmd).replace(chpl_home, '$CHPL_HOME'),
-               'exited with non-zero status code', help_exit)
+        _error(
+            "failed to get help text with:",
+            " ".join(help_cmd).replace(chpl_home, "$CHPL_HOME"),
+            "exited with non-zero status code",
+            help_exit,
+        )
         return False
 
     # Get the man page text
@@ -82,15 +85,17 @@ def check_man_page(bin_name, additional_args=None):
     for hline in [l.strip() for l in helptxt.splitlines() if l.strip()]:
 
         # Line is section
-        if hline[-1] == ':':
-            section = hline.strip(':')
+        if hline[-1] == ":":
+            section = hline.strip(":")
             helpsections[section] = []
             currentsection = section
         # Line is flag
-        elif hline[0] == '-':
+        elif hline[0] == "-":
             if currentsection is None:
                 numerrors += 1
-                _error(sl, 'not in a {0} man page section'.format(short_bin_name))
+                _error(
+                    sl, "not in a {0} man page section".format(short_bin_name)
+                )
                 notFound.append(hline)
                 continue
 
@@ -105,15 +110,19 @@ def check_man_page(bin_name, additional_args=None):
     for mline in [l.strip() for l in manpage if len(l.strip()) > 2]:
 
         # Line is flag
-        if (mline[0:5] == "**\\--" or mline[4:5] == "," or mline[0:3] == "**-") and mline[-2:] == '**' and currentsection:
+        if (
+            (mline[0:5] == "**\\--" or mline[4:5] == "," or mline[0:3] == "**-")
+            and mline[-2:] == "**"
+            and currentsection
+        ):
 
             mflags = _get_flags(mline)
 
             if mflags:
                 mansections[section].append(mflags)
         # Line is section
-        elif mline[0] == '*' and mline[-1] == '*' and mline[1] != '*':
-            section = mline.strip('*')
+        elif mline[0] == "*" and mline[-1] == "*" and mline[1] != "*":
+            section = mline.strip("*")
             mansections[section] = []
             currentsection = section
 
@@ -130,9 +139,9 @@ def check_man_page(bin_name, additional_args=None):
         numerrors += len(helpdiff) + len(mandiff)
 
         if helpdiff:
-            _error('help output has additional sections: {0}'.format(helpdiff))
+            _error("help output has additional sections: {0}".format(helpdiff))
         if mandiff:
-            _error('man page has additional sections: {0}'.format(mandiff))
+            _error("man page has additional sections: {0}".format(mandiff))
 
         # We require same sections to continue, return early
         return numerrors
@@ -148,13 +157,13 @@ def check_man_page(bin_name, additional_args=None):
             if mflag[0] == "\\" or mflag[4] == "\\":
                 continue
             else:
-                numerrors+=1
+                numerrors += 1
                 _error('man section "{0}" has some misformatted flags:\
                         {1}'.format(section, mflag))
 
-        # Removing '\' from manpage flags of this section to match with compiler's flags      
+        # Removing '\' from manpage flags of this section to match with compiler's flags
         for i in range(len(manflags)):
-            manflags[i] = manflags[i].replace("\\", "")   
+            manflags[i] = manflags[i].replace("\\", "")
 
         if helpflags != manflags:
             helpdiff = list(set(helpflags) - set(manflags))
@@ -175,13 +184,17 @@ def check_man_page(bin_name, additional_args=None):
 
 def _get_chpl_home():
     repo_root = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), '../..'))
-    chpl_home = os.environ.get('CHPL_HOME', repo_root)
+        os.path.join(os.path.dirname(__file__), "../..")
+    )
+    chpl_home = os.environ.get("CHPL_HOME", repo_root)
     return chpl_home
 
+
 def _get_man_page(bin_name):
-    man_file = os.path.join(_get_chpl_home(), 'man', os.path.basename(bin_name) + '.rst')
-    with open(man_file, 'r') as fp:
+    man_file = os.path.join(
+        _get_chpl_home(), "man", os.path.basename(bin_name) + ".rst"
+    )
+    with open(man_file, "r") as fp:
         man_rst = fp.readlines()
     return man_rst
 
@@ -189,30 +202,30 @@ def _get_man_page(bin_name):
 def _get_flags(s):
     """Get the flags in a string."""
 
-    rs = ''
+    rs = ""
     # Handle empty lines
     if not s.strip():
         return rs
 
     # Remove rst formatting of **bold text**
-    ls = s.strip('*')
+    ls = s.strip("*")
 
     # Look for all comma separated flags
-    ls = ls.strip().split(',')
+    ls = ls.strip().split(",")
     for f in ls:
         sf = f.strip()
         try:
-            if sf[0] == '-':
+            if sf[0] == "-":
                 # Add flag to the return string
-                rs += sf.split()[0]+','
-            elif sf[0] == '\\':
-                rs += sf.split()[0]+','
+                rs += sf.split()[0] + ","
+            elif sf[0] == "\\":
+                rs += sf.split()[0] + ","
             else:
                 break
         except IndexError:
             continue
     if rs[2] == ",":
-        rs = rs[0:3] + " " + rs[3:len(rs)]
+        rs = rs[0:3] + " " + rs[3 : len(rs)]
     if rs:
         # Remove any trailing text
         return rs.strip()
@@ -228,18 +241,17 @@ def _run_cmd(cmd):
 
 
 def _msg(level, *args):
-    log_msg = ' '.join([str(arg) for arg in args])
-    print('{level}: {msg}'.format(level=level.upper(), msg=log_msg))
+    log_msg = " ".join([str(arg) for arg in args])
+    print("{level}: {msg}".format(level=level.upper(), msg=log_msg))
 
 
 def _warn(*args):
-    _msg('Warning', *args)
+    _msg("Warning", *args)
 
 
 def _error(*args):
-    _msg('Error', *args)
+    _msg("Error", *args)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
-

--- a/test/mason/MasonBashSubTest
+++ b/test/mason/MasonBashSubTest
@@ -32,7 +32,6 @@ def cd(d: Optional[Path]):
         if d is not None:
             os.chdir(old_dir)
 
-
 def mason() -> Path:
     sub_dir = chpl_home / "util" / "chplenv" / "chpl_bin_subdir.py"
     result = sp.check_output(

--- a/test/mason/MasonBashSubTest
+++ b/test/mason/MasonBashSubTest
@@ -32,6 +32,7 @@ def cd(d: Optional[Path]):
         if d is not None:
             os.chdir(old_dir)
 
+
 def mason() -> Path:
     sub_dir = chpl_home / "util" / "chplenv" / "chpl_bin_subdir.py"
     result = sp.check_output(

--- a/test/runtime/configMatters/launch/slurm/sub_test
+++ b/test/runtime/configMatters/launch/slurm/sub_test
@@ -4,6 +4,7 @@ import os
 import subprocess as sp
 import sys
 
+
 def main():
     print("[Starting subtest]")
     d = os.path.dirname(os.path.abspath(__file__))
@@ -11,8 +12,11 @@ def main():
     if chpl_home is None:
         print("[Error: CHPL_HOME not set]")
         sys.exit(1)
-    
-    bin_subdir=sp.check_output([os.path.join(chpl_home, "util", "chplenv", "chpl_bin_subdir.py")], encoding='utf-8').strip()
+
+    bin_subdir = sp.check_output(
+        [os.path.join(chpl_home, "util", "chplenv", "chpl_bin_subdir.py")],
+        encoding="utf-8",
+    ).strip()
     chpl = os.path.join(chpl_home, "bin", bin_subdir, "chpl")
 
     # force this test to use sbatch
@@ -23,11 +27,13 @@ def main():
     if ret != 0:
         print("[Error compiling hello.chpl]")
         sys.exit(1)
-    
+
     launchcmd = os.path.join(chpl_home, "util", "test", "chpl_launchcmd.py")
     outfile = os.path.join(d, "hello.exec.tmp")
     with open(outfile, "w") as f:
-        ret = sp.call([launchcmd, "./hello", "-nl", "2"], stdout=f, stderr=sp.STDOUT)
+        ret = sp.call(
+            [launchcmd, "./hello", "-nl", "2"], stdout=f, stderr=sp.STDOUT
+        )
     if ret != 0:
         print("[Error running hello.chpl]")
         sys.exit(1)
@@ -38,10 +44,11 @@ def main():
     if ret != 0:
         print("[Error matching good file]")
         sys.exit(1)
-    
+
     print("[Success matching hello.chpl output]")
 
     print("[Finished subtest {}]".format(d))
+
 
 def cleanup(ret):
     def rm(file):
@@ -49,11 +56,12 @@ def cleanup(ret):
             os.unlink(file)
         except:
             pass
-    
+
     rm("hello")
     # only delete good file on success
     if ret == 0:
         rm("hello.exec.tmp")
+
 
 if __name__ == "__main__":
     ret = main()


### PR DESCRIPTION
Extend our `check-python-format` job to cover some additional Python files that don't have a `.py` extension, and format them to comply.

Adds the following files to the check:
- `test/mason/MasonBashSubTest`
- `test/man/checkManPages`
- all `sub_test`s with a Python shebang

[reviewed by @jabraham17 , thanks!]