### PR TITLE
Avoid -Werror=stringop failure with some versions of GCC

### DIFF
--- a/compiler/include/vec.h
+++ b/compiler/include/vec.h
@@ -455,7 +455,7 @@ Vec<C,S>::addx() {
     return;
   }
   if (v == e) {
-    if (!(0 <= n && n <= S))
+    if (!(0 <= n && n <= VEC_INITIAL_SIZE))
       CHPL_UNREACHABLE();
     v = (C*)malloc(VEC_INITIAL_SIZE * sizeof(C));
     memcpy((void*)v, &e[0], n * sizeof(C));

--- a/compiler/include/vec.h
+++ b/compiler/include/vec.h
@@ -66,6 +66,15 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define SET_MAX_PROBE           5
 #define SET_INITIAL_INDEX       2
 
+#ifdef __has_builtin
+#if __has_builtin (__builtin_unreachable) && !defined(CHPL_UNREACHABLE)
+  #define CHPL_UNREACHABLE() __builtin_unreachable()
+#endif
+#endif
+#ifndef CHPL_UNREACHABLE
+  #define CHPL_UNREACHABLE() do { } while (0)
+#endif
+
 // Do not define the generic variation of _vec_hasher, requiring us to write
 // a _vec_hasher for potential types.
 //
@@ -446,6 +455,8 @@ Vec<C,S>::addx() {
     return;
   }
   if (v == e) {
+    if (!(0 <= n && n <= S))
+      CHPL_UNREACHABLE();
     v = (C*)malloc(VEC_INITIAL_SIZE * sizeof(C));
     memcpy((void*)v, &e[0], n * sizeof(C));
   } else {


### PR DESCRIPTION
Avoids GCC warning about invalid memcpy calls (and errors in developer builds).

This seems to stem from GCC being unnable to prove that `n` is small and less than the size being allocated. There are likely ways to massage the actual code so that GCC can properly prove `n` is small, but I took the approach of encoding the assertion to the compiler. [I double checked the assembly output](https://godbolt.org/z/qPKnrxd9c) before and after this change, its pretty much the same. GCC does some extra optimization work to avoid a memcpy call with some vector instructions, but clang codegen is more or less identical w/wo this change.

- [x] paratest

[Reviewed by @arifthpe]