### PR TITLE
Fix champs build with extra make vars

### DIFF
--- a/test/studies/champs/functions.bash
+++ b/test/studies/champs/functions.bash
@@ -88,7 +88,7 @@ function test_compile() {
     echo "[Building $kind in normal mode]"
   fi
 
-  make_vars+=$extra_make
+  make_vars+=" $extra_make"
   echo "[make_vars: $make_vars]"
 
   test_start "make $kind"


### PR DESCRIPTION
Fixes the champs build with extra make vars due to missing space

[Not reviewed - trivial]