### PR TITLE
Increase package building timeout-minutes 90->120

### DIFF
--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -187,7 +187,7 @@ jobs:
         with:
           name: packaging-tarball
       - name: build package ${{ env.DISTRO }} for ${{ env.ARCH }}
-        timeout-minutes: 90
+        timeout-minutes: 120
         run: |
           echo "Building the Chapel Package for: "
 


### PR DESCRIPTION
Increase the timeout of the package build step of `build-linux-packages` from 90 minutes to 120 minutes, since we are seeing relatively frequent timeouts and even good runs often come close to 90 minutes.

[Here](https://github.com/chapel-lang/chapel/actions/runs/33006240912/job/98343572188) is an example of a recent successful run, in which most package build configs exceed 75 minutes. And here are some recent failures due to hitting the timeout; the [first](https://github.com/chapel-lang/chapel/actions/runs/33096812597/job/98608292405) appears to be legitimately stalled, while the [second](https://github.com/chapel-lang/chapel/actions/runs/33085034070/job/98562671868) was close to completion.

[reviewed by @jabraham17 , thanks!]