### PR TITLE
Adjust the max-parallel parameter for GA paratest

### DIFF
--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -4,6 +4,11 @@ name: Extended CI checks
 
 on:
   workflow_call:
+    inputs:
+      is-merge-queue:
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -333,7 +338,7 @@ jobs:
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv chpldoc mason protoc-gen-chpl
-      max-parallel: ${{ github.event_name != 'merge_group' && 20 || 0 }}
+      max-parallel: ${{ !inputs.is-merge-queue && 20 || 0 }}
   paratest-linux64-gasnet-everything:
     name: Chapel paratest on linux64 with gasnet-everything
     uses: ./.github/workflows/ga-paratest.yml
@@ -345,4 +350,4 @@ jobs:
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv
-      max-parallel: ${{ github.event_name != 'merge_group' && 20 || 0 }}
+      max-parallel: ${{ !inputs.is-merge-queue && 20 || 0 }}

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -338,7 +338,6 @@ jobs:
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv chpldoc mason protoc-gen-chpl
-      max-parallel: &GA_PARATEST_MAX_PARALLEL ${{ !inputs.is-merge-queue && 20 || 0 }}
   paratest-linux64-gasnet-everything:
     name: Chapel paratest on linux64 with gasnet-everything
     uses: ./.github/workflows/ga-paratest.yml
@@ -350,4 +349,3 @@ jobs:
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv
-      max-parallel: *GA_PARATEST_MAX_PARALLEL

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -338,7 +338,7 @@ jobs:
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv chpldoc mason protoc-gen-chpl
-      max-parallel: ${{ !inputs.is-merge-queue && 20 || 0 }}
+      max-parallel: &GA_PARATEST_MAX_PARALLEL ${{ !inputs.is-merge-queue && 20 || 0 }}
   paratest-linux64-gasnet-everything:
     name: Chapel paratest on linux64 with gasnet-everything
     uses: ./.github/workflows/ga-paratest.yml
@@ -350,4 +350,4 @@ jobs:
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv
-      max-parallel: ${{ !inputs.is-merge-queue && 20 || 0 }}
+      max-parallel: *GA_PARATEST_MAX_PARALLEL

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -4,11 +4,6 @@ name: Extended CI checks
 
 on:
   workflow_call:
-    inputs:
-      is-merge-queue:
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -333,7 +333,7 @@ jobs:
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv chpldoc mason protoc-gen-chpl
-      max-parallel: 50
+      max-parallel: ${{ github.event_name != 'merge_group' && 20 || 0 }}
   paratest-linux64-gasnet-everything:
     name: Chapel paratest on linux64 with gasnet-everything
     uses: ./.github/workflows/ga-paratest.yml
@@ -345,3 +345,4 @@ jobs:
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv
+      max-parallel: ${{ github.event_name != 'merge_group' && 20 || 0 }}

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -35,7 +35,7 @@ on:
         type: string
         default: ""
       max-parallel:
-        description: Maximum number of test jobs to run concurrently; 0 is unrestricted
+        description: Maximum number of test jobs to run concurrently; 0 is unrestricted. Defaults to 20 for non-merge-queue runs, and 0 for merge queue runs.
         required: false
         type: number
         default: ${{ !github.event.merge_group && 20 || 0 }}

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -35,7 +35,7 @@ on:
         type: string
         default: ""
       max-parallel:
-        description: Maximum number of test jobs to run concurrently
+        description: Maximum number of test jobs to run concurrently; 0 is unrestricted
         required: false
         type: number
         default: 20
@@ -272,7 +272,7 @@ jobs:
         password: ${{ github.token }}
     strategy:
       fail-fast: false
-      max-parallel: ${{ inputs.max-parallel }}
+      max-parallel: ${{ inputs.max-parallel || fromJSON(needs.build.outputs.test-count) }}
       matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
     steps:
       - name: checkout

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -38,7 +38,7 @@ on:
         description: Maximum number of test jobs to run concurrently; 0 is unrestricted
         required: false
         type: number
-        default: 20
+        default: ${{ !github.event.merge_group && 20 || 0 }}
       timeout-minutes:
         description: Maximum number of minutes each job may run
         required: false

--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -53,8 +53,6 @@ jobs:
     needs: should-run-extended-checks
     if: needs.should-run-extended-checks.outputs.run-all == 'true'
     uses: ./.github/workflows/extended-ci-checks.yml
-    with:
-      is-merge-queue: ${{ github.event_name == 'merge_group' }}
 
   # This job exists to have a single check for which failure means merging
   # should be blocked, for GH required status checks purposes.

--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -53,6 +53,8 @@ jobs:
     needs: should-run-extended-checks
     if: needs.should-run-extended-checks.outputs.run-all == 'true'
     uses: ./.github/workflows/extended-ci-checks.yml
+    with:
+      is-merge-queue: ${{ github.event_name == 'merge_group' }}
 
   # This job exists to have a single check for which failure means merging
   # should be blocked, for GH required status checks purposes.


### PR DESCRIPTION
Adjusts the max-parallel parameter for GA paratest

* The default is 20 runners at a time per paratest job, to prevent overwhelming the runners
* Runners can specify 0 as a special value to say run this job with exactly the number of runners you need, ie unrestricted
* All jobs default to the default of 20, except in the merge queue where they run unrestricted

[Reviewed by @arifthpe]