### PR TITLE
Rename "Full" checks to "Nightly", and stop running per-PR

### DIFF
--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -7,13 +7,6 @@ on:
       timezone: "America/Vancouver"
   workflow_dispatch:
 
-# Run serially per type of triggering event.
-# Primarily intended to limit (avoid) concurrent runs for multiple PR merges in
-# a row.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}
-  queue: max
-
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/trigger-full-checks.yml
+++ b/.github/workflows/trigger-full-checks.yml
@@ -1,9 +1,7 @@
-# Kick off the full suite of checks post-merge and nightly.
+# Kick off the full suite of checks nightly.
 name: Run full checks
 
 on:
-  push:
-    branches: [ main ]
   schedule:
     - cron: "30 0 * * *"
       timezone: "America/Vancouver"

--- a/.github/workflows/trigger-nightly-checks.yml
+++ b/.github/workflows/trigger-nightly-checks.yml
@@ -1,5 +1,5 @@
 # Kick off the full suite of checks nightly.
-name: Run full checks
+name: Run nightly checks
 
 on:
   schedule:


### PR DESCRIPTION
Change the Full checks tier to only run nightly and on demand, removing the per-push to `main` trigger, and accordingly change its name to Nightly.

This is because we're hitting concurrent runner limits in GA pretty hard, and would rather have those resources available for robust pre-merge checks long term.

[reviewed by @jabraham17 , thanks!]