### PR TITLE
Adjust OFI_OOB to also look for mpich

### DIFF
--- a/util/chplenv/chpl_comm_ofi_oob.py
+++ b/util/chplenv/chpl_comm_ofi_oob.py
@@ -68,7 +68,7 @@ def _find_mpi():
 
         return (name, cflags, ldflags)
 
-    mpi_names = ("ompi", "mpi")
+    mpi_names = ("ompi", "mpi", "mpich")
     for name in mpi_names:
         if third_party_utils.pkgconfig_system_has_package(name):
             cflags = third_party_utils.pkgconfig_get_system_compile_args(name)


### PR DESCRIPTION
Adjusts some of the auto-detection logic for CHPL_COMM_OFI_OOB to also look for installs of mpich

[Not reviewed - trivial]