### PR TITLE
Remove the horizontal line from the nightly failure email

### DIFF
--- a/.github/workflows/trigger-nightly-checks.yml
+++ b/.github/workflows/trigger-nightly-checks.yml
@@ -72,8 +72,6 @@ jobs:
 
           $failed_jobs_text
 
-          ___
-
           Ran $num_jobs total jobs at commit ${{ github.sha }} "$message".
 
           GitHub Actions run info:

--- a/.github/workflows/trigger-nightly-checks.yml
+++ b/.github/workflows/trigger-nightly-checks.yml
@@ -74,7 +74,7 @@ jobs:
 
           Ran $num_jobs total jobs at commit ${{ github.sha }} "$message".
 
-          GitHub Actions run info:
+          ##### GitHub Actions run info:
           - SHA: [${{ github.sha }}](https://github.com/chapel-lang/chapel/commit/${{ github.sha }})
           - Run ID: [${{ github.run_id }}](https://github.com/chapel-lang/chapel/actions/runs/${{ github.run_id }})
           - Run attempt: ${{ github.run_attempt }}


### PR DESCRIPTION
Remove the horizontal line from our nightly failure mail, which is causing Discourse to cut it off.

To visually separate it a bit, make the "GitHub Actions run info" line into a 5th-level header.

Follow up to https://github.com/chapel-lang/chapel/pull/29323.

[reviewed by @jabraham17 , thanks!]