### PR TITLE
Add chpl-tester user to sudo in CI container

### DIFF
--- a/util/packaging/docker/github-ci/Dockerfile
+++ b/util/packaging/docker/github-ci/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3-dev \
     python3-pip \
     python3-venv \
+    sudo \
     time \
     tzdata \
     wget \
@@ -51,7 +52,9 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd --gid 1001 chpl-tester && \
-    useradd --uid 1001 --gid chpl-tester --create-home --shell /bin/bash chpl-tester
+    useradd --uid 1001 --gid chpl-tester --create-home --shell /bin/bash chpl-tester && \
+    echo "chpl-tester ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/chpl-tester && \
+    chmod 0440 /etc/sudoers.d/chpl-tester
 
 
 # Configure locale (taken from primary Chapel Dockerfile)


### PR DESCRIPTION
Adds chpl-tester user to the sudo group for the CI container

Allows a container to run in user-mode and still install extra packages as needed

[Reviewed by @arifthpe]