### PR TITLE
Use GitHub recommended repo self-reference syntax for actions

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -19,3 +19,4 @@ paths:
    ignore:
      - 'unexpected key \"queue\" for \"concurrency\" section' # https://github.com/rhysd/actionlint/issues/657
      - 'invalid activity type "destroyed" for "merge_group" Webhook event' # https://github.com/rhysd/actionlint/issues/726
+     - 'reusable workflow call "\$/.+" at "uses" is not following the format' # https://github.com/rhysd/actionlint/issues/711

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -19,7 +19,7 @@ defaults:
 
 jobs:
   arkouda-release-smoke-test:
-    uses: ./.github/workflows/arkouda-smoke-test.yml
+    uses: $/.github/workflows/arkouda-smoke-test.yml
     with:
       arkouda-version: "release"
 
@@ -324,7 +324,7 @@ jobs:
 
   paratest-linux64:
     name: Chapel paratest on linux64
-    uses: ./.github/workflows/ga-paratest.yml
+    uses: $/.github/workflows/ga-paratest.yml
     with:
       configuration: linux64
       cron-script: util/cron/test-linux64.bash
@@ -335,7 +335,7 @@ jobs:
           all test-venv chpldoc mason protoc-gen-chpl
   paratest-linux64-gasnet-everything:
     name: Chapel paratest on linux64 with gasnet-everything
-    uses: ./.github/workflows/ga-paratest.yml
+    uses: $/.github/workflows/ga-paratest.yml
     with:
       configuration: linux64-gasnet-everything
       cron-script: util/cron/test-gasnet-everything.bash

--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -19,7 +19,7 @@ defaults:
 
 jobs:
   arkouda-main-smoke-test:
-    uses: ./.github/workflows/arkouda-smoke-test.yml
+    uses: $/.github/workflows/arkouda-smoke-test.yml
     with:
       arkouda-version: "main"
 
@@ -227,7 +227,7 @@ jobs:
 
   paratest-linux64-c-backend:
     name: Chapel paratest on linux64 with C backend
-    uses: ./.github/workflows/ga-paratest.yml
+    uses: $/.github/workflows/ga-paratest.yml
     with:
       configuration: linux64-c-backend
       cron-script: util/cron/test-c-backend.bash
@@ -237,7 +237,7 @@ jobs:
           all test-venv mason
   paratest-darwin:
     name: Chapel paratest on darwin
-    uses: ./.github/workflows/ga-paratest.yml
+    uses: $/.github/workflows/ga-paratest.yml
     with:
       configuration: darwin
       runner: macos-latest

--- a/.github/workflows/trigger-nightly-checks.yml
+++ b/.github/workflows/trigger-nightly-checks.yml
@@ -17,13 +17,13 @@ defaults:
 
 jobs:
   core-checks:
-    uses: ./.github/workflows/core-ci-checks.yml
+    uses: $/.github/workflows/core-ci-checks.yml
 
   extended-checks:
-    uses: ./.github/workflows/extended-ci-checks.yml
+    uses: $/.github/workflows/extended-ci-checks.yml
 
   full-checks:
-    uses: ./.github/workflows/full-ci-checks.yml
+    uses: $/.github/workflows/full-ci-checks.yml
 
   send-failure-mail:
     if: github.event_name == 'schedule' && (cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure'))

--- a/.github/workflows/trigger-pr-checks.yml
+++ b/.github/workflows/trigger-pr-checks.yml
@@ -31,7 +31,7 @@ defaults:
 jobs:
   core-checks:
     if: ${{ ! (github.event_name == 'merge_group' && github.event.action == 'destroyed') }}
-    uses: ./.github/workflows/core-ci-checks.yml
+    uses: $/.github/workflows/core-ci-checks.yml
 
   should-run-extended-checks:
     if: ${{ ! (github.event_name == 'merge_group' && github.event.action == 'destroyed') }}
@@ -52,7 +52,7 @@ jobs:
   extended-checks:
     needs: should-run-extended-checks
     if: needs.should-run-extended-checks.outputs.run-all == 'true'
-    uses: ./.github/workflows/extended-ci-checks.yml
+    uses: $/.github/workflows/extended-ci-checks.yml
 
   # This job exists to have a single check for which failure means merging
   # should be blocked, for GH required status checks purposes.


### PR DESCRIPTION
Switch references to reused workflows in this repo to use the special `$/` syntax.

GitHub [calls this the "self-repository syntax"](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/) and [recommends using it](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/find-and-customize-actions#adding-an-action-from-the-same-repository). Additionally, [zizmor just started warning about it](https://github.com/zizmorcore/zizmor/pull/2271) at `low` level.

[Actionlint is not yet aware of this syntax](https://github.com/rhysd/actionlint/issues/711), so this PR adds an ignore for the resulting warning from it.

[trivial, not reviewed]