### PR TITLE
Add missing newlines between list items in failure mail

### DIFF
--- a/.github/workflows/trigger-nightly-checks.yml
+++ b/.github/workflows/trigger-nightly-checks.yml
@@ -62,7 +62,8 @@ jobs:
           for id in "${failed_job_ids[@]}"; do
             gh api "/repos/chapel-lang/chapel/actions/jobs/$id" | jq '.' | tee "job_$id.json"
             sleep 0.25
-            failed_jobs_text+=$(jq -r '{html_url, name, first_bad_step: ([.steps[] | select(.conclusion != "success")] | first).name} | "- [\(.name)](\(.html_url)), step: \"\(.first_bad_step)\""' "job_$id.json")
+            failed_jobs_text+="$(jq -r '{html_url, name, first_bad_step: ([.steps[] | select(.conclusion != "success")] | first).name} | "- [\(.name)](\(.html_url)), step: \"\(.first_bad_step)\""' "job_$id.json")
+          "
           done
 
           [[ $num_jobs -eq 1 ]] && plural="" || plural="s"


### PR DESCRIPTION
The intended newlines were always missing, but before https://github.com/chapel-lang/chapel/pull/29323 when the email was written in HTML instead of Markdown it didn't affect the visible result.

Follow up to https://github.com/chapel-lang/chapel/pull/29323.

[trivial, not reviewed]