### PR TITLE
Fix Vagrant `tryit.sh` post-increment causing exit code 1

### DIFF
--- a/util/devel/test/portability/vagrant/tryit.sh
+++ b/util/devel/test/portability/vagrant/tryit.sh
@@ -93,7 +93,7 @@ do
     vagrant halt 2>&1 | tee -a "$DIR"/log
     cd "$DIR"
 
-    ((i++))
+    ((++i))
   fi
 done
 
@@ -106,7 +106,7 @@ do
   then
     echo "${NAME[$i]}:${RESULT[$i]}"
 
-    ((i++))
+    ((++i))
   fi
 done
 


### PR DESCRIPTION
Replace some post-increments in `util/devel/test/portability/vagrant/tryit.sh` with pre-increments, as the syntax used returns 1 if the value of the expression is 0.

Per https://www.gnu.org/software/bash/manual/html_node/Conditional-Constructs.html, the `((` syntax returns 1 if the value of the expression is 0. As the starting value of `i` is 0, on the first run, its value within the _post_-increment expression is still 0. Take the simple fix of making this a pre-increment instead, so on first run its value is 1.

Follow up to https://github.com/chapel-lang/chapel/pull/29317, which made this harmless non-zero-exiting statement a fatal error.

[trivial, not reviewed]