### PR TITLE
Enable sub-jobs for large test dirs in GA paratest

### DIFF
--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -179,8 +179,8 @@ jobs:
           awk -v home="$CHPL_HOME/" '
             BEGIN {
               # these are well-known slow directories that should be split into multiple jobs
-              slow_directories["test/library"] = 1
               slow_directories["test/classes"] = 1
+              slow_directories["test/library"] = 1
               slow_directories["test/types"] = 1
             }
             function relative(path) {

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -179,7 +179,7 @@ jobs:
           awk -v home="$CHPL_HOME/" '
             BEGIN {
               # these are well-known slow directories that should be split into multiple jobs
-              slow_directories["test/functions"] = 1
+              slow_directories["test/library"] = 1
               slow_directories["test/classes"] = 1
               slow_directories["test/types"] = 1
             }

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -179,11 +179,9 @@ jobs:
           awk -v home="$CHPL_HOME/" '
             BEGIN {
               # these are well-known slow directories that should be split into multiple jobs
-              # however, this results in a massive amount of GA runners, so
-              # for now dont actually do that
-              # slow_directories["test/functions"] = 1
-              # slow_directories["test/classes"] = 1
-              # slow_directories["test/types"] = 1
+              slow_directories["test/functions"] = 1
+              slow_directories["test/classes"] = 1
+              slow_directories["test/types"] = 1
             }
             function relative(path) {
               if (index(path, home) == 1) return substr(path, length(home) + 1)


### PR DESCRIPTION
Enable the well-known slow directory split-up feature that was added but commented out in https://github.com/chapel-lang/chapel/pull/29212.

Currently nothing is getting through the merge queue, as linux64-gasnet-everything paratesting on large test dirs is consistently hitting the 90 minute timeout since its introduction in https://github.com/chapel-lang/chapel/pull/29316. Although splitting large dirs will blow up the number of jobs, it may be necessary if we want paratests in MQ without a slower MQ.

<details>
<summary>This job also modifies which directories are split up (from those in the existing, commented-out list), as explained below.</summary>

I enumerated the test directories with the largest number of files, which though not a 1:1 correspondence should be a rough indication of which ones will take the longest to complete:
```
rift in ~/chapel on main λ for f in test/*; do echo $(find $f -type f | wc -l) $f; done | sort -rh
| head -n 10
5452 test/library
5085 test/types
4836 test/classes
3738 test/studies
3443 test/functions
1983 test/arrays
1825 test/visibility
1549 test/users
1243 test/parallel
1180 test/interop
```

Of these, looking at [a recent gasnet-everything run](github.com/chapel-lang/chapel/actions/runs/33115515723/), the longest runtimes (rounded to minutes) were:

1. `classes`, 147m
2. `library`, 121m
3. `types`, 73m
4. `functions`, 56m
5. `studies`, 47m

Given building Chapel pre-paratest takes about 15m, and our merge queue time limit is 90m, 75m is the approximate limit for how long a test dir can take (assuming no contention for runners causes further delays). The top 3 items on this list are over that limit, and the rest are under it with a buffer of 15+m, so IMO we ought to split exactly these 3.

</details>

[reviewed by @jabraham17 , thanks!]