### PR TITLE
Fetch mason deps as a pre-build step in gasnet paratest

### DIFF
--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -343,5 +343,4 @@ jobs:
       build-steps: |
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
-          all test-venv
-        make -C tools/mason tarball-prep
+          all test-venv mason-deps

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -340,9 +340,8 @@ jobs:
       configuration: linux64-gasnet-everything
       cron-script: util/cron/test-gasnet-everything.bash
       start-test-args: --futures
-      pre-build-steps: |
-        make mason-deps
       build-steps: |
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \
           all test-venv
+        make -C tools/mason tarball-prep

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -340,6 +340,8 @@ jobs:
       configuration: linux64-gasnet-everything
       cron-script: util/cron/test-gasnet-everything.bash
       start-test-args: --futures
+      pre-build-steps: |
+        make mason-deps
       build-steps: |
         num_procs=$(util/buildRelease/chpl-make-cpu_count)
         make -j"$num_procs" DEBUG=0 WARNINGS=1 OPTIMIZE=1 \


### PR DESCRIPTION
Fetch Mason deps ahead of time in the `build-steps` of the linux64-gasnet-everything GA paratest, as they are needed for tests and if we're gonna hit a network failure it's better if it's up front.

[reviewed by @jabraham17 , thanks!]