### PR TITLE
Run large directories first in GA paratest

### DIFF
--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -244,15 +244,7 @@ jobs:
           matrix=$(python3 -c '
           import csv, json, os
           path = os.path.join(os.environ["RUNNER_TEMP"], "testdirs.csv")
-          with open(path, mode="r+", encoding="utf-8", newline="") as file:
-            rows = list(csv.reader(file))
-            # Put directories with more files earlier in the list, to prevent
-            # long tails.
-            rows.sort(
-              key=lambda row: sum(len(files) for _,_, files in os.walk(row[0])),
-              reverse=True)
-            file.seek(0)
-            csv.writer(file).writerows(rows)
+          rows = list(csv.reader(open(path, encoding="utf-8", newline="")))
           include = [
             {"id": str(i),
              "dir": row[0],

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -226,7 +226,7 @@ jobs:
               }
             }
           ' "$RUNNER_TEMP/cleanlog.txt" | sort -u \
-            | xargs -n 1 -I'{}' sh -c 'echo "$(cut -d',' -f1 <<<"{}" | (read p; find $p -type f | wc -l)):{}"' | sort -r | cut -d':' -f2 | tee "$RUNNER_TEMP/testdirs.csv"
+            | xargs -n 1 -I'{}' bash -c 'echo "$(cut -d',' -f1 <<<"{}" | (read p; find $p -type f | wc -l)):{}"' | sort -r | cut -d':' -f2 | tee "$RUNNER_TEMP/testdirs.csv"
 
       - name: create testing matrix
         id: test-directories

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -226,7 +226,7 @@ jobs:
               }
             }
           ' "$RUNNER_TEMP/cleanlog.txt" | sort -u \
-            | xargs -I'{}' bash -c 'echo "$(cut -d',' -f1 <<<"{}" | (read p; find $p -type f | wc -l)):{}"' | sort -r | cut -d':' -f2 | tee "$RUNNER_TEMP/testdirs.csv"
+            | xargs -I'{}' bash -c "echo $(cut -d',' -f1 <<<"{}" | (read -r p; find "$p" -type f | wc -l)):{}" | sort -r | cut -d':' -f2 | tee "$RUNNER_TEMP/testdirs.csv"
 
       - name: create testing matrix
         id: test-directories

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -173,8 +173,6 @@ jobs:
           "$CHPL_HOME/util/start_test" "${requested_tests[@]}" \
             --clean-only --logfile "$RUNNER_TEMP/cleanlog.txt"
 
-          echo "${requested_tests[@]}"
-
           # clean-only walks the suite without running it.
           # This is more reliable than just using `ls` (it resolves skipifs, notests, etc).
           # Store each matrix job as CSV: directory,start_test flags.

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -225,7 +225,8 @@ jobs:
                 }
               }
             }
-          ' "$RUNNER_TEMP/cleanlog.txt" | sort -u > "$RUNNER_TEMP/testdirs.csv"
+          ' "$RUNNER_TEMP/cleanlog.txt" | sort -u \
+            | xargs -n 1 -I'{}' sh -c 'echo "$(cut -d',' -f1 <<<"{}" | (read p; find $p -type f | wc -l)):{}"' | sort -r | cut -d':' -f2 | tee "$RUNNER_TEMP/testdirs.csv"
 
       - name: create testing matrix
         id: test-directories

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -226,7 +226,7 @@ jobs:
               }
             }
           ' "$RUNNER_TEMP/cleanlog.txt" | sort -u \
-            | xargs -I'{}' bash -c "echo $(cut -d',' -f1 <<<"{}" | (read -r p; find "$p" -type f | wc -l)):{}" | sort -r | cut -d':' -f2 | tee "$RUNNER_TEMP/testdirs.csv"
+            | xargs -I'{}' bash -c "echo $(cut -d',' -f1 <<<"{}" | (read -r p; find "$p" -type f -name "*.chpl" | wc -l)):{}" | sort -r | cut -d':' -f2 | tee "$RUNNER_TEMP/testdirs.csv"
 
       - name: create testing matrix
         id: test-directories

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -260,6 +260,7 @@ jobs:
           cat "$RUNNER_TEMP/testdirs.csv"
 
   run-tests:
+    if: ${{ !always() }}
     name: Test ${{ matrix.dir }} (${{ inputs.configuration }})
     needs: build
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -182,7 +182,6 @@ jobs:
               slow_directories["test/classes"] = 1
               slow_directories["test/library"] = 1
               slow_directories["test/types"] = 1
-              slow_directories["test/functions"] = 1
             }
             function relative(path) {
               if (index(path, home) == 1) return substr(path, length(home) + 1)

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -244,7 +244,15 @@ jobs:
           matrix=$(python3 -c '
           import csv, json, os
           path = os.path.join(os.environ["RUNNER_TEMP"], "testdirs.csv")
-          rows = list(csv.reader(open(path, encoding="utf-8", newline="")))
+          with open(path, mode="r+", encoding="utf-8", newline="") as file:
+            rows = list(csv.reader(file))
+            # Put directories with more files earlier in the list, to prevent
+            # long tails.
+            rows.sort(
+              key=lambda row: sum(len(files) for _,_, files in os.walk(row[0])),
+              reverse=True)
+            file.seek(0)
+            csv.writer(file).writerows(rows)
           include = [
             {"id": str(i),
              "dir": row[0],

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -182,6 +182,7 @@ jobs:
               slow_directories["test/classes"] = 1
               slow_directories["test/library"] = 1
               slow_directories["test/types"] = 1
+              slow_directories["test/functions"] = 1
             }
             function relative(path) {
               if (index(path, home) == 1) return substr(path, length(home) + 1)

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -173,6 +173,8 @@ jobs:
           "$CHPL_HOME/util/start_test" "${requested_tests[@]}" \
             --clean-only --logfile "$RUNNER_TEMP/cleanlog.txt"
 
+          echo "${requested_tests[@]}"
+
           # clean-only walks the suite without running it.
           # This is more reliable than just using `ls` (it resolves skipifs, notests, etc).
           # Store each matrix job as CSV: directory,start_test flags.

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -226,7 +226,7 @@ jobs:
               }
             }
           ' "$RUNNER_TEMP/cleanlog.txt" | sort -u \
-            | xargs -n 1 -I'{}' bash -c 'echo "$(cut -d',' -f1 <<<"{}" | (read p; find $p -type f | wc -l)):{}"' | sort -r | cut -d':' -f2 | tee "$RUNNER_TEMP/testdirs.csv"
+            | xargs -I'{}' bash -c 'echo "$(cut -d',' -f1 <<<"{}" | (read p; find $p -type f | wc -l)):{}"' | sort -r | cut -d':' -f2 | tee "$RUNNER_TEMP/testdirs.csv"
 
       - name: create testing matrix
         id: test-directories

--- a/.github/workflows/ga-paratest.yml
+++ b/.github/workflows/ga-paratest.yml
@@ -259,7 +259,6 @@ jobs:
           cat "$RUNNER_TEMP/testdirs.csv"
 
   run-tests:
-    if: ${{ !always() }}
     name: Test ${{ matrix.dir }} (${{ inputs.configuration }})
     needs: build
     runs-on: ${{ inputs.runner }}


### PR DESCRIPTION
Sort the list of test directories for GA paratesting by the number of `.chpl` files in the directory (descending) before spawning test jobs, so jobs that will probably take longer to run get started earlier.

This relies on the fast that GA spawns matrix jobs in the order items are listed in the matrix.

This should make it so we can't get unlucky with the (lexicographical) ordering of test directories causing relatively long-running dirs to get started late, which would lead to long tails in the overall paratest run.

[reviewed by @jabraham17 , thanks!]