### PR TITLE
Fix broken `--incremental` compilation under C backend

### DIFF
--- a/runtime/include/chpl-prginfo-program-only-decls.h
+++ b/runtime/include/chpl-prginfo-program-only-decls.h
@@ -82,6 +82,7 @@ extern const c_string chpl_filenameTable[];
 extern const int chpl_filenameTableSize;
 extern void* const chpl_private_broadcast_table[];
 extern const int chpl_private_broadcast_table_len;
+extern void* const chpl_global_serialize_table[];
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I removed `chplcgfns.h` but didn't add a declaration for `chpl_global_serialize_table` to a program-only header which exists to keep `--incremental` compilation from breaking.

Reviewed by @jabraham17. Thanks!