### PR TITLE
Stop printing unnecessary context info in email workflow

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -19,12 +19,6 @@ jobs:
     if:  github.event.pull_request.merged == true && github.repository == 'chapel-lang/chapel'
     runs-on: ubuntu-slim
     steps:
-      - name: print git events
-        run:  cat "$GITHUB_EVENT_PATH"
-      - name: print GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
      # This workflow step will parse github env. The parsed env will be used in the email body.
       - name: get commits payload
         id: build-payload


### PR DESCRIPTION
Stop printing `$GITHUB_EVENT_PATH` and the `github` context in the `email` workflow, as it is unnecessary and not a good security practice.

[GitHub docs advise caution when using or printing the `github` context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#example-printing-context-information-to-the-log), as it contains at minimum the sensitive `github.token`. While the token is masked, it seems unnecessary to do something that comes this close to printing the token. This workflow gets extra scrutiny due to its `pull_request_target` trigger.

[reviewed by @jabraham17 , thanks!]