### PR TITLE
Remove special select behavior for unions

### DIFF
--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1294,8 +1294,7 @@ BlockStmt* buildSelectStmt(Expr* selectCond, BlockStmt* whenstmts) {
   tmp->addFlag(FLAG_MAYBE_TYPE);
   tmp->addFlag(FLAG_EXPR_TEMP);
 
-  block->insertAtTail(new DefExpr(tmp));
-  block->insertAtTail(new CallExpr(PRIM_MOVE, tmp, new CallExpr("_select_test", selectCond)));
+  block->insertAtTail(new DefExpr(tmp, selectCond));
 
   for_alist(stmt, whenstmts->body) {
     CondStmt* when = toCondStmt(stmt);

--- a/compiler/AST/build.cpp
+++ b/compiler/AST/build.cpp
@@ -1294,7 +1294,8 @@ BlockStmt* buildSelectStmt(Expr* selectCond, BlockStmt* whenstmts) {
   tmp->addFlag(FLAG_MAYBE_TYPE);
   tmp->addFlag(FLAG_EXPR_TEMP);
 
-  block->insertAtTail(new DefExpr(tmp, selectCond));
+  block->insertAtTail(new DefExpr(tmp));
+  block->insertAtTail(new CallExpr(PRIM_MOVE, tmp, selectCond));
 
   for_alist(stmt, whenstmts->body) {
     CondStmt* when = toCondStmt(stmt);

--- a/frontend/lib/resolution/Resolver.cpp
+++ b/frontend/lib/resolution/Resolver.cpp
@@ -3933,11 +3933,6 @@ void Resolver::exit(const uast::Conditional* cond) {
 }
 
 bool Resolver::enter(const uast::Select* sel) {
-  // TODO: to match production, we need to specialize the select based on
-  // the type of the Select expression. For a union, a call to getActiveIndex
-  // needs to be inserted (all other cases are left untouched).
-  // Production handles this with _select_test, but we should handle this more
-  // directly with a generated call to getActiveIndex
   sel->expr()->traverse(*this);
   enterScope(sel);
   if (!scopeResolveOnly) return branchSensitivelyTraverse(sel, {});

--- a/modules/internal/ChapelBase.chpl
+++ b/modules/internal/ChapelBase.chpl
@@ -1554,10 +1554,6 @@ module ChapelBase {
   pragma "last resort"
   proc _cond_invalid(x) param do return true;
 
-  inline proc _select_test(param x) param do return x;
-  inline proc _select_test(type x) type do return x;
-  inline proc _select_test(x) do return x;
-
   //
   // isNonnegative(i) == (i>=0), but is a param value if i is unsigned.
   //

--- a/modules/internal/ChapelUnion.chpl
+++ b/modules/internal/ChapelUnion.chpl
@@ -216,9 +216,6 @@ module ChapelUnion {
   }
 
   @chpldoc.nodoc
-  proc _select_test(x: union) do return x.getActiveIndex();
-
-  @chpldoc.nodoc
   operator ==(u1: union, u2: union) {
     if u1.type != u2.type then
       compilerError("Cannot compare unions of type ", u1.type:string, " and ",

--- a/test/types/unions/equality/unionSelect.bad
+++ b/test/types/unions/equality/unionSelect.bad
@@ -1,8 +1,0 @@
-unionSelect.chpl:13: error: unresolved call '==(int(64), u)'
-$CHPL_HOME/modules/internal/ChapelBase.chpl:159: note: this candidate did not match: ==(a: int(8), b: int(8))
-unionSelect.chpl:13: note: because actual argument #1 with type 'int(64)'
-$CHPL_HOME/modules/internal/ChapelBase.chpl:159: note: is passed to formal 'a: int(8)'
-unionSelect.chpl:13: note: other candidates are:
-$CHPL_HOME/modules/internal/ChapelBase.chpl:160: note:   ==(a: int(16), b: int(16))
-$CHPL_HOME/modules/internal/ChapelBase.chpl:161: note:   ==(a: int(32), b: int(32))
-note: and 100 other candidates, use --print-all-candidates to see them

--- a/test/types/unions/equality/unionSelect.future
+++ b/test/types/unions/equality/unionSelect.future
@@ -1,5 +1,0 @@
-unimplemented feature: equality-based select statements for unions
-
-This doesn't work at present because the compiler treats all selects
-on unions as being active field checks, so does "integer == union"
-comparisons.

--- a/test/types/unions/selectPatterns.chpl
+++ b/test/types/unions/selectPatterns.chpl
@@ -38,11 +38,20 @@ proc doFancySelect() throws do
       throw new Error("union is not currently active");
   }
 proc doSuperFancySelect() throws do
-  select u {
+  select u.getActiveIndex() {
     when U.x do writeln("x: ", u.x);
     when U.y do writeln("y: ", u.y);
     when U.z do writeln("z: ", u.z);
     when U.w do writeln("w: ", u.w);
+    otherwise
+      throw new Error("union is not currently active");
+  }
+proc doMatch() throws do
+  union select u {
+    when x do writeln("x: ", x);
+    when y do writeln("y: ", y);
+    when z do writeln("z: ", z);
+    when w do writeln("w: ", w);
     otherwise
       throw new Error("union is not currently active");
   }
@@ -61,6 +70,11 @@ try {
 }
 try {
   doSuperFancySelect();
+} catch e {
+  writeln("caught error: ", e.message());
+}
+try {
+  doMatch();
 } catch e {
   writeln("caught error: ", e.message());
 }
@@ -124,3 +138,13 @@ u.z = "hello";
 doSuperFancySelect();
 u.w = 20;
 doSuperFancySelect();
+
+writeln("test match");
+u.x = 10;
+doMatch();
+u.y = 3.14;
+doMatch();
+u.z = "hello";
+doMatch();
+u.w = 20;
+doMatch();

--- a/test/types/unions/selectPatterns.good
+++ b/test/types/unions/selectPatterns.good
@@ -2,6 +2,7 @@
 caught error: union is not currently active
 caught error: union is not currently active
 caught error: union is not currently active
+caught error: union is not currently active
 test getActiveIndex
 0
 1
@@ -28,6 +29,11 @@ y: 3.14
 z: hello
 w: 20
 test super fancy select
+x: 10
+y: 3.14
+z: hello
+w: 20
+test match
 x: 10
 y: 3.14
 z: hello

--- a/test/types/unions/union-copy-init3.chpl
+++ b/test/types/unions/union-copy-init3.chpl
@@ -4,11 +4,11 @@ union U {
 }
 proc U.init=(other: U) {
   writeln("In my init=");
-  select other {
-    when U.x do
-      this.x = other.x;
-    when U.y do
-      this.y = other.y;
+  union select other {
+    when x do
+      this.x = x;
+    when y do
+      this.y = y;
   }
 }
 

--- a/test/types/unions/union-copy-init3b.chpl
+++ b/test/types/unions/union-copy-init3b.chpl
@@ -4,11 +4,11 @@ union U {
 }
 proc U.init=(other: U) {
   writeln("In my init=");
-  select other {
-    when U.x do
-      this.x = other.x;
-    when U.y do
-      this.y = other.y;
+  union select other {
+    when x do
+      this.x = x;
+    when y do
+      this.y = y;
     otherwise
       halt("Unexpected result");
   }

--- a/test/types/unions/union-copy-init3c.chpl
+++ b/test/types/unions/union-copy-init3c.chpl
@@ -4,11 +4,11 @@ union U {
 }
 proc U.init=(other: U) {
   writeln("In my init=");
-  select other {
-    when U.x do
-      this.x = other.x;
-    when U.y do
-      this.y = other.y;
+  union select other {
+    when x do
+      this.x = x;
+    when y do
+      this.y = y;
     otherwise
       this.x = 999;
   }

--- a/test/types/unions/union-copy-init3d.chpl
+++ b/test/types/unions/union-copy-init3d.chpl
@@ -4,11 +4,11 @@ union U {
 }
 proc U.init=(other: U) {
   writeln("In my init=");
-  select other {
-    when U.x do
-      this.x = other.x;
-    when U.y do
-      this.y = other.y;
+  union select other {
+    when x do
+      this.x = x;
+    when y do
+      this.y = y;
     otherwise
       this.y = 999;
   }

--- a/test/types/unions/union-copy-init3e.chpl
+++ b/test/types/unions/union-copy-init3e.chpl
@@ -4,9 +4,10 @@ union U {
 
   proc init=(other: U) {
     writeln("In my init=");
-    select other {
-      when U.y do
-        this.y = 3*other.y;
+    union select other {
+      when y do
+        this.y = 3*y;
+      otherwise ;
     }
   }
 }


### PR DESCRIPTION
Removes the special select behavior for unions in favor of a proper pattern matching syntax (see https://github.com/chapel-lang/chapel/pull/29354)

- [x] paratest