### PR TITLE
Pin GA jobs installing brew LLVM to 22

### DIFF
--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -441,7 +441,7 @@ jobs:
         timeout-minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
         run: |
           if [[ "$OS" == "macos"* ]] ; then
-            brew install llvm
+            brew install llvm@22
           else
             sudo apt install \
               clang \

--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -244,4 +244,4 @@ jobs:
       use-container: false
       cron-script: util/cron/test-darwin.bash
       pre-build-steps: |
-        brew install llvm
+        brew install llvm@22


### PR DESCRIPTION
Pin to `llvm@22` in jobs that `brew install llvm`, as the default version of LLVM in Homebrew is now 23.

[reviewed by @jabraham17 , thanks!]