### PR TITLE
Exclude the failure mail job from reporting itself

### DIFF
--- a/.github/workflows/trigger-nightly-checks.yml
+++ b/.github/workflows/trigger-nightly-checks.yml
@@ -61,7 +61,7 @@ jobs:
 
             message=$(jq -r '.commit.message' commit.json | head -n 1)
             num_jobs=$(jq 'length' jobs_array.json)
-            readarray -t failed_job_ids < <(jq '.[] | select((.status != "completed" and .id != "${{ github.job }}") or (.conclusion != "success" and .conclusion != "skipped")) | .id' jobs_array.json)
+            readarray -t failed_job_ids < <(jq '.[] | select(.id != "${{ github.job }}" and (.status != "completed" or (.conclusion != "success" and .conclusion != "skipped"))) | .id' jobs_array.json)
 
             failed_jobs_text=""
             echo "failed jobs:"

--- a/.github/workflows/trigger-nightly-checks.yml
+++ b/.github/workflows/trigger-nightly-checks.yml
@@ -61,7 +61,7 @@ jobs:
 
             message=$(jq -r '.commit.message' commit.json | head -n 1)
             num_jobs=$(jq 'length' jobs_array.json)
-            readarray -t failed_job_ids < <(jq '.[] | select(.status != "completed" or (.conclusion != "success" and .conclusion != "skipped")) | .id' jobs_array.json)
+            readarray -t failed_job_ids < <(jq '.[] | select((.status != "completed" and .id != "${{ github.job }}") or (.conclusion != "success" and .conclusion != "skipped")) | .id' jobs_array.json)
 
             failed_jobs_text=""
             echo "failed jobs:"


### PR DESCRIPTION
Make the nightly failure mail job not report itself as a failure, due to being unfinished at the time it runs.

We are occasionally seeing successful runs of the nightly failure mail job report itself among the failures ([example](https://github.com/chapel-lang/chapel/actions/runs/33728944183/job/100596944266)). I believe this is because we report jobs that are not `completed` as failed, because we expect it to run after all other jobs should have wrapped up -- of course, it cannot run after itself.

It's strange we don't observe this failure on every single run, but I think it's likely that GitHub does not specify whether an API call to list jobs for a workflow will get the current job (or running jobs in general), and may behave differently from call to call.

[reviewed by @jabraham17 , thanks!]