### PR TITLE
Serialize runs of the commit emailer workflow

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -6,6 +6,12 @@ on:
       types:
         - closed
 
+# Serialize runs of this workflow to ensure emails are sent in the same order
+# as merges are done.
+concurrency:
+  group: ${{ github.workflow }}
+  queue: max
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Serialize runs of the emailer workflow, to guarantee emails get sent in the order merges happen on GitHub.

This also has the side effect of spacing out commit emails a bit (the job takes ~3-5 minutes to run), which in my opinion can't be a bad thing for making sure we don't get rate limited with several back-to-back merges.

[reviewed by @jabraham17 , thanks!]