### PR TITLE
dlopen: Use runtime build markers to check if it is a dynamic library or not

### DIFF
--- a/modules/internal/ChapelDynamicLoading.chpl
+++ b/modules/internal/ChapelDynamicLoading.chpl
@@ -31,9 +31,8 @@ module ChapelDynamicLoading {
   }
 
   private proc isRuntimeCompiledAsDynamicLibrary {
-    // TODO: Need to adjust the runtime build to inject a macro value or
-    // compile in a separate source file just into the '.so/.dylib'.
-    return true;
+    extern const chpl_rt_is_dynamic_library: c_int;
+    return chpl_rt_is_dynamic_library != 0;
   }
 
   param chpl_defaultProcBufferSize = 512;


### PR DESCRIPTION
This PR improves checks when dynamic loading. It uses the built-in runtime build marker to detect if it has been compiled as a dynamic library, and emits an error if that is not the case.

Reviewed by @benharsh. Thanks!