### PR TITLE
Grant actions:write perm to nightly extended checks

### DIFF
--- a/.github/workflows/trigger-nightly-checks.yml
+++ b/.github/workflows/trigger-nightly-checks.yml
@@ -20,6 +20,10 @@ jobs:
     uses: $/.github/workflows/core-ci-checks.yml
 
   extended-checks:
+    permissions:
+      contents: read
+      packages: read
+      actions: write
     uses: $/.github/workflows/extended-ci-checks.yml
 
   full-checks:


### PR DESCRIPTION
Grant the `actions: write` permission to the call of `extended-ci-checks` from `trigger-nightly-checks`, which requires it as of https://github.com/chapel-lang/chapel/pull/29338.

Follow up to https://github.com/chapel-lang/chapel/pull/29338.

[trivial fix, not reviewed]