### PR TITLE
Pass Docker Hub login secrets to Docker workflow

### DIFF
--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -4,6 +4,11 @@ name: Extended CI checks
 
 on:
   workflow_call:
+    secrets:
+      DOCKERHUB_USER:
+        required: true
+      DOCKERHUB_PAT:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/trigger-nightly-checks.yml
+++ b/.github/workflows/trigger-nightly-checks.yml
@@ -25,6 +25,9 @@ jobs:
       packages: read
       actions: write
     uses: $/.github/workflows/extended-ci-checks.yml
+    secrets:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}
 
   full-checks:
     permissions:


### PR DESCRIPTION
Pass the Docker Hub login credential secrets to `extended-ci-checks`, so it can use them to log in.

Follow up to https://github.com/chapel-lang/chapel/pull/29232.

[trivial fix, not reviewed]