### PR TITLE
Make Docker Hub secrets non-required

### DIFF
--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -6,9 +6,9 @@ on:
   workflow_call:
     secrets:
       DOCKERHUB_USER:
-        required: true
+        required: false
       DOCKERHUB_PAT:
-        required: true
+        required: false
 
 permissions:
   contents: read


### PR DESCRIPTION
Because some workflows do not need (or have) access to secrets to pass along, such as the merge queue triggered trigger-pr-checks.

Follow up to https://github.com/chapel-lang/chapel/pull/29378.

[trivial fix, not reviewed]