### PR TITLE
Add missing table of contents entry for GA docs

### DIFF
--- a/doc/rst/developer/bestPractices/ContributorInfo.rst
+++ b/doc/rst/developer/bestPractices/ContributorInfo.rst
@@ -40,6 +40,7 @@ Overview:
    #. `Submit pull request`_
    #. `Find a reviewer`_
    #. `Work with your reviewers`_
+   #. `Get GitHub Actions tests passing`_
    #. `Before merging`_
    #. `After merging`_
 


### PR DESCRIPTION
Follow up to https://github.com/chapel-lang/chapel/pull/29218.

[trivial, not reviewed]

Testing:
- [x] locally generated docs look right