### PR TITLE
Use -exuo pipefail in retrying command blocks

### DIFF
--- a/.github/workflows/arkouda-smoke-test.yml
+++ b/.github/workflows/arkouda-smoke-test.yml
@@ -92,9 +92,13 @@ jobs:
         timeout_seconds: 900
         retry_wait_seconds: 30
         on_retry_command: |
+          set -exuo pipefail
+
           cd arkouda
           git clean -dfx
         command: |
+          set -exuo pipefail
+
           num_procs=$(util/buildRelease/chpl-make-cpu_count)
           cd arkouda
           # Download sources serially first before building, as it is flaky and

--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -311,6 +311,8 @@ jobs:
           timeout_seconds: 60
           retry_wait_seconds: 30
           command: |
+            set -exuo pipefail
+
             echo "extract docs"
             tar -xvf docs.tar.gz
             echo "Publish module docs to web server"

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -76,6 +76,8 @@ jobs:
           timeout_minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
           retry_wait_seconds: 60
           command: |
+            set -exuo pipefail
+
             sudo update-alternatives --remove-all gcc
             sudo update-alternatives --remove-all g++
 
@@ -155,6 +157,8 @@ jobs:
           timeout_minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
           retry_wait_seconds: 60
           command: |
+            set -exuo pipefail
+
             sudo apt install \
               clang \
               libclang-dev \
@@ -189,6 +193,8 @@ jobs:
           timeout_minutes: ${{ fromJSON(env.APT_INSTALL_TIMEOUT_MINS) }}
           retry_wait_seconds: 60
           command: |
+            set -exuo pipefail
+
             wget https://apt.llvm.org/llvm.sh
             chmod +x llvm.sh
 
@@ -317,6 +323,8 @@ jobs:
         timeout_seconds: 900
         retry_wait_seconds: 30
         command: |
+          set -exuo pipefail
+
           tarball="$C2CHAPEL_PYCPARSER_TARBALL_PATH/$(basename "$C2CHAPEL_PYCPARSER_TARBALL_URL")"
           wget --output-document="$tarball" "$C2CHAPEL_PYCPARSER_TARBALL_URL"
     - name: configure pycparser tarball for c2chapel

--- a/.github/workflows/extended-ci-checks.yml
+++ b/.github/workflows/extended-ci-checks.yml
@@ -78,8 +78,9 @@ jobs:
           command: |
             set -exuo pipefail
 
-            sudo update-alternatives --remove-all gcc
-            sudo update-alternatives --remove-all g++
+            # Ignore errors in the case there are no alternatives.
+            sudo update-alternatives --remove-all gcc || true
+            sudo update-alternatives --remove-all g++ || true
 
             sudo add-apt-repository --yes --update ppa:ubuntu-toolchain-r/test
             sudo apt update

--- a/.github/workflows/full-ci-checks.yml
+++ b/.github/workflows/full-ci-checks.yml
@@ -87,6 +87,8 @@ jobs:
           timeout_minutes: 30
           retry_wait_seconds: 60
           command: |
+            set -exuo pipefail
+
             export APPTAINER_IMAGE
             cd "$apptainer_dir"
             ./image-rebuild.sh

--- a/.github/workflows/trigger-nightly-checks.yml
+++ b/.github/workflows/trigger-nightly-checks.yml
@@ -65,6 +65,8 @@ jobs:
           timeout_seconds: 180
           retry_wait_seconds: 300
           command: |
+            set -exuo pipefail
+
             gh api /repos/${{ github.repository }}/commits/${{ github.sha }} | jq '.' > commit.json
             gh api --paginate /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq '.' > jobs_raw.json
             # Combine pages of job results into one array


### PR DESCRIPTION
Manually do `set -exuo pipefail` in each command block of a https://github.com/nick-fields/retry step, since it is not a `run` block and therefore doesn't get it from the `run` defaults.

This bit us in https://github.com/chapel-lang/chapel/actions/runs/31540888925/job/93945205941, where a command failed but did not fail the step.

[reviewed by @jabraham17 , thanks!]