### PR TITLE
Enable publish-docs to run from nightly trigger

### DIFF
--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -289,7 +289,7 @@ jobs:
         ./util/buildRelease/check-release-files.bash
 
   publish-docs:
-    if: github.event_name == 'push' && github.repository == 'chapel-lang/chapel'
+    if: ${{ github.repository_owner == 'chapel-lang' && contains(fromJSON('["push","workflow_dispatch","schedule"]'), github.event_name) }}
     runs-on: ubuntu-slim
     needs: make_doc
     steps:


### PR DESCRIPTION
Change the condition of `publish-docs` to match our CI container pushing jobs, primarily to make it so this job will go off on nightly runs.

Previously this job was not getting run, since it was never triggered on a `push` event but its condition would only let it run on `push` events.

[reviewed by @jabraham17 , thanks!]