### PR TITLE
Serialize pushing docs, drop extra queued runs

### DIFF
--- a/.github/workflows/core-ci-checks.yml
+++ b/.github/workflows/core-ci-checks.yml
@@ -301,6 +301,9 @@ jobs:
 
   publish-docs:
     if: ${{ github.repository_owner == 'chapel-lang' && contains(fromJSON('["push","workflow_dispatch","schedule"]'), github.event_name) }}
+    concurrency:
+      group: ${{ github.job }}
+      queue: single
     runs-on: ubuntu-slim
     needs: make_doc
     steps:


### PR DESCRIPTION
Serialize runs of `publish-docs` since they affect an external resource and we want to ensure only the results of the last-triggered run are visible.

Additionally, use `queue: single` so if extra runs are queued up, only the latest actually occurs, since we don't care about intermediate pushes that are seconds/minutes from being overwritten.

[reviewed by @jabraham17 , thanks!]