### PR TITLE
Fix trying to print Vagrant configs that didn't run

### DIFF
--- a/util/devel/test/portability/vagrant/tryit.sh
+++ b/util/devel/test/portability/vagrant/tryit.sh
@@ -104,6 +104,15 @@ for name in current/*
 do
   if [ -f $name/Vagrantfile ]
   then
+    # skip if this isn't a desired VM to run on
+    if [ "$VM_NAME" != "all" ]
+    then
+      if [ "$name" != "current/$VM_NAME" ]
+      then
+        continue
+      fi
+    fi
+
     echo "${NAME[$i]}:${RESULT[$i]}"
 
     ((++i))


### PR DESCRIPTION
Copy the logic to skip VMs (other than the user-specified one) to the result-printing code in `util/devel/test/portability/vagrant/tryit.sh`.

This bug has been around for a long time, but became an error with the addition of `set -u` in https://github.com/chapel-lang/chapel/pull/29317.

[trivial fix, not reviewed]