### PR TITLE
Suppress memory leaks for new test

### DIFF
--- a/test/arrays/return/infoVarFromTuple2.suppressif
+++ b/test/arrays/return/infoVarFromTuple2.suppressif
@@ -1,0 +1,2 @@
+# an explicit tuple type with arrays leaks
+EXECOPTS <= --memLeaks


### PR DESCRIPTION
Suppresses the memory leaks for a new test, which are caused by https://github.com/chapel-lang/chapel/issues/29394

[Not reviewed - trivial]