### PR TITLE
Pin to LLVM 22 in Vagrant Linuxbrew testing

### DIFF
--- a/util/devel/test/portability/provision-scripts/apt-get-and-linuxbrew.sh
+++ b/util/devel/test/portability/provision-scripts/apt-get-and-linuxbrew.sh
@@ -26,7 +26,8 @@ brew install gcc #hide
 
 # install some dependencies in homebrew
 brew install cmake python gmp #unsudo
-brew install llvm #unsudo
+# Pin LLVM 22 since we don't support the latest LLVM yet
+brew install llvm@22 #unsudo
 
 # we could use Homebrew's gcc if that becomes important in the future:
 # # link the homebrew-installed gcc-* to gcc


### PR DESCRIPTION
Pin to LLVM 22 in Vagrant Linuxbrew testing, as LLVM 23 is now the default version and we don't yet support it.

[trivial, not reviewed]